### PR TITLE
Copy template docs over from the wiki.

### DIFF
--- a/Rules
+++ b/Rules
@@ -24,7 +24,7 @@ end
 compile '*' do
   if item[:extension] == 'md'
     #filter :kramdown
-    filter :redcarpet, options: {hard_wrap: true, filter_html: true, autolink: true, no_intraemphasis: true, fenced_code_blocks: true, gh_blockcode: true}, renderer_options: {with_toc_data: true}
+    filter :redcarpet, options: {filter_html: true, autolink: true, no_intraemphasis: true, fenced_code_blocks: true, gh_blockcode: true, tables: true}, renderer_options: {with_toc_data: true}
     filter :add_anchors
     filter :bootstrappify
     filter :admonition

--- a/content/docs/instrumenting/exporters.md
+++ b/content/docs/instrumenting/exporters.md
@@ -1,6 +1,6 @@
 ---
 title: Exporters for third-party systems
-sort_rank: 4
+sort_rank: 3
 ---
 
 # Exporters for third-party systems
@@ -11,7 +11,7 @@ cases where it is not feasible to instrument a given system with Prometheus
 metrics directly (for example, HAProxy or Linux system stats). The
 following is a list of existing third-party exporters:
 
-   * [node/system metrics exporter](https://github.com/prometheus/node_exporter)
+   * [Node/system metrics exporter](https://github.com/prometheus/node_exporter)
    * [HAProxy exporter](https://github.com/prometheus/haproxy_exporter)
    * [AWS CloudWatch exporter](https://github.com/prometheus/cloudwatch_exporter)
    * [StatsD bridge](https://github.com/prometheus/statsd_bridge)

--- a/content/docs/instrumenting/exposition_formats.md
+++ b/content/docs/instrumenting/exposition_formats.md
@@ -1,6 +1,6 @@
 ---
 title: Exposition formats
-sort_rank: 2
+sort_rank: 4
 ---
 
 # Exposition formats
@@ -16,3 +16,6 @@ client does not support the former.
 For details on each format and the content negotiation options, see the
 [Client Data Exposition Format](https://docs.google.com/document/d/1ZjyKiKxZV83VI9ZKAXRGKaUKK2BIWCT7oiGBKDBpjEY/edit?usp=sharing)
 document.
+
+The majority of users should use the existing [client libraries](../clientlibs)
+that already implement the exposition formats.

--- a/content/docs/instrumenting/pushing.md
+++ b/content/docs/instrumenting/pushing.md
@@ -1,6 +1,6 @@
 ---
 title: Pushing metrics
-sort_rank: 3
+sort_rank: 2
 ---
 
 # Pushing metrics
@@ -15,3 +15,9 @@ makes it easy to instrument even shell scripts without a client library.
 
 For more information on using the push gateway, see the project's
 [README.md](https://github.com/prometheus/pushgateway/blob/master/README.md).
+
+For use from Java see the
+[PushGateway](http://prometheus.github.io/client_java/io/prometheus/client/exporter/PushGateway.html)
+class.
+
+For use from Go see the [Push](http://godoc.org/github.com/prometheus/client_golang/prometheus#Push) and [PushAdd](http://godoc.org/github.com/prometheus/client_golang/prometheus#PushAdd) functions.

--- a/content/docs/visualization/template_examples.md
+++ b/content/docs/visualization/template_examples.md
@@ -1,0 +1,115 @@
+---
+title: Template examples
+sort_rank: 4
+---
+
+# Template examples
+
+Prometheus supports templating in the summary and description fields of
+alerts, as well as in served console pages. Templates have the ability to run
+queries against the local database, iterate over data, use conditionals, format
+data, etc. The Prometheus templating language is based on the
+[Go templating](http://golang.org/pkg/text/template/) system.
+
+## Simple alert field templates
+
+    ALERT InstanceDown
+      IF up == 0
+      FOR 5m
+      WITH {
+        severity="page"
+      }
+      SUMMARY "Instance {{$labels.instance}} down"
+      DESCRIPTION "{{$labels.instance}} of job {{$labels.job}} has been down for more than 5 minutes."
+
+
+Alert field templates will be executed during every rule iteration for each
+alert that fires, so keep any queries and templates lightweight. If you have a
+need for more complicated templates for alerts, it is recommended to link to a
+console instead.
+
+## Simple iteration
+
+This displays a list of instances, and whether they are up:
+
+```
+{{ range query "up" }}
+  {{ .Labels.instance }} {{ .Labels.Value }}
+{{ end }}
+```
+
+The special `.` variable contains the value of the current sample for each loop iteration.
+
+## Display one value
+
+```
+{{ with query "some_metric{instance='someinstance'}" }}
+  {{ . | first | value | humanize }}
+{{ end }}
+```
+
+Go and Go's templating language are both strongly typed, so one must check that
+samples were returned to avoid an execution error. For example this could
+happen if a scrape or rule evaluation has not run yet, or a host was down.
+
+The included `prom_query_drilldown` template handles this, allows for
+formatting of results, and linking to the [expression browser](../browser/).
+
+## Using console URL parameters
+
+```
+{{ with printf "node_memory_MemTotal{job='node',instance='%s'}" .Params.instance | query }}
+  {{ . | first | value | humanize1024}}B
+{{ end }}
+```
+
+If accessed as `console.html?instance=hostname`, `.Params.instance` will evaluate to `hostname`.
+
+## Advanced iteration
+
+```html
+<table>
+{{ range printf "node_network_receive_bytes{job='node',instance='%s',device!='lo'}" .Params.instance | query | sortByLabel "device"}}
+  <tr><th colspan=2>{{ .Labels.device }}</th></tr>
+  <tr>
+    <td>Received</td>
+    <td>{{ with printf "rate(node_network_receive_bytes{job='node',instance='%s',device='%s'}[5m])" .Labels.instance .Labels.device | query }}{{ . | first | value | humanize }}B/s{{end}}</td>
+  </tr>
+  <tr>
+    <td>Transmitted</td>
+    <td>{{ with printf "rate(node_network_transmit_bytes{job='node',instance='%s',device='%s'}[5m])" .Labels.instance .Labels.device | query }}{{ . | first | value | humanize }}B/s{{end}}</td>
+  </tr>{{ end }}
+<table>
+```
+
+Here we iterate over all network devices and display the network traffic for each.
+
+As the `range` action does not specify a variable, `.Params.instance` is not
+available inside the loop as `.` is now the loop variable.
+
+## Defining reusable templates
+
+Prometheus supports defining templates that can be reused. This is particularly
+powerful when combined with 
+[console library](../template_reference/#console-templates) support, allowing
+sharing of templates across consoles.
+
+```
+{{/* Define the template */}}
+{{define "myTemplate"}}
+  do something
+{{end}}
+
+{{/* Use the template */}}
+{{template "myTemplate"}}
+```
+
+Templates are limited to one argument. The `args` function can be used to wrap multiple arguments.
+
+```
+{{define "myMultiArgTemplate"}}
+  First argument: {{.arg0}}
+  Second argument: {{.arg1}}
+{{end}}
+{{template "myMultiArgTemplate" (args 1 2)}}
+```

--- a/content/docs/visualization/template_reference.md
+++ b/content/docs/visualization/template_reference.md
@@ -1,0 +1,110 @@
+---
+title: Template reference
+sort_rank: 6
+---
+
+# Template reference
+Prometheus supports templating in the summary and description fields of
+alerts, as well as in served console pages. Templates have the ability to run
+queries against the local database, iterate over data, use conditionals, format
+data, etc. The Prometheus templating language is based on the
+[Go templating](http://golang.org/pkg/text/template/) system.
+
+## Data Structures
+
+The primary data structure for dealing with time series data is the sample, defined as:
+
+```
+type sample struct {
+        Labels map[string]string
+        Value  float64
+}
+```
+
+The metric name of the sample is encoded in a special `__name__` label in the `Labels` map.
+
+`[]sample` means a list of samples.
+
+`interface{}` in Go is similar to a void pointer in C.
+
+## Functions
+In addition to the [default
+functions](http://golang.org/pkg/text/template/#hdr-Functions) provided by Go
+templating, Prometheus provides functions for easier processing of query
+results in templates.
+
+If functions are used in a pipeline, the pipeline value is passed as the last argument. 
+
+### Queries
+
+| Name          | Arguments     | Returns  | Notes    |
+| ------------- | ------------- | -------- | -------- |
+| query         | query string  | []sample | Queries the databases, does not support returning range vectors.  |
+| first         | []sample      | sample   | Equivalent to `index a 0`  |
+| label         | label, sample | string   | Equivalent to `index sample.Labels label`  |
+| value         | sample        | float64  | Equivalent to `sample.Value`  |
+| sortByLabel   | label, []samples | []sample | Sorts the samples by the given label. Is stable.  |
+
+`first`, `label` and `value` are intended to make query results easily usable in pipelines.
+
+### Numbers
+
+| Name          | Arguments     | Returns |  Notes    |
+| ------------- | --------------| --------| --------- |
+| humanize      | number        | string  | Converts a number to a more readable format, using [metric prefixes](http://en.wikipedia.org/wiki/Metric_prefix). 
+| humanize1024  | number        | string  | Like `humanize`, but uses 1024 as the base rather than 1000. |
+| humanizeDuration | number     | string  | Converts a duration in seconds to a more readable format. |
+
+Humanizing functions are intended to produce reasonable output for consumption
+by humans, and are not guaranteed to return the same results between Prometheus
+versions.
+
+### Strings
+
+| Name          | Arguments     | Returns |    Notes    |
+| ------------- | ------------- | ------- | ----------- |
+| title         | string        | string  | [strings.Title](http://golang.org/pkg/strings/#Title), capitalises first character of each word.|
+| match         | pattern, text | boolean | [regexp.MatchString](http://golang.org/pkg/regexp/#MatchString) Tests for a regexp match. |
+| reReplaceAll  | pattern, replacement, text | string | [Regexp.ReplaceAllString](http://golang.org/pkg/regexp/#Regexp.ReplaceAllString) Regexp substitution. |
+| graphLink  | expr | string | Returns path to graph view in the [expression browser](../browser) for the expression. |
+| tableLink  | expr | string | Returns path to tabular view in the [expression browser](../browser) for the expression. |
+
+### Others
+
+| Name          | Arguments     | Returns |    Notes    |
+| ------------- | ------------- | ------- | ----------- |
+| args          | []interface{} | map[string]interface{} | This converts a list of objects to a map with keys arg0, arg1 etc. This is intended to allow multiple arguments to be passed to templates. |
+| tmpl          | string, []interface{} | nothing  | Like the built-in `template`, but allows non-literals as the template name. Note that the result is assumed to be safe, and will not be auto-escaped. Only available in consoles. |
+| safeHtml      | string        | string  | Marks string as HTML not requiring auto-escaping. |
+
+
+## Template type differences
+
+Each of the types of templates provide different information that can be used to
+parameterize templates, and have a few other differences.
+
+### Alert field templates
+
+`.Value` and `.Labels` contain the alert value and labels. They are also exposed
+as the `$value` and `$labels` variables for convenience.
+
+### Console templates
+
+Consoles are exposed on `/consoles/`, and sourced from the directory pointed to
+by the `-web.console.templates` flag. 
+
+Console templates are rendered with
+[html/template](http://golang.org/pkg/html/template/), which provides
+auto-escaping. To bypass the auto-escaping use the `safe*` functions.,
+
+URL parameters are available as a map in `.Params`. To access multiple URL
+parameters by the same name, `.RawParams` is a map of the list values for each
+parameter. The URL path is available in `.Path`, excluding the `/consoles/`
+prefix.
+
+Consoles also have access to all the templates defined with `{{define
+"templateName"}}...{{end}}` found in `*.lib` files in the directory pointed to
+by the `-web.console.libraries` flag. As this is a shared namespace, take care
+to avoid clashes with other users. Template names beginning with `prom`,
+`_prom`, and `__` are reserved for use by Prometheus, as are the functions
+listed above.

--- a/layouts/jumbotron.html
+++ b/layouts/jumbotron.html
@@ -4,7 +4,7 @@
   <div class="container">
     <h1>Prometheus</h1>
     <p class="subtitle">An open-source service monitoring system and time series database.</p>
-    <p><a class="btn btn-default btn-lg" href="/docs/introduction/overview" role="button">Get Started</a></p>
+    <p><a class="btn btn-default btn-lg" href="/docs/introduction/getting_started" role="button">Get Started</a></p>
   </div>
 </div>
 


### PR DESCRIPTION
Add links to client code for the pushgateway.

Make getting started link on frontpage go to Getting started section.

Put exposition formats at the end of instrumenting, as it's the least relevant
to normal users.