### PR TITLE
Use a protocol-relative URL to load Google Fonts

### DIFF
--- a/layouts/header.html
+++ b/layouts/header.html
@@ -37,7 +37,7 @@
 
     <!-- Custom Fonts -->
     <link href="/assets/font-awesome-4.2.0/css/font-awesome.min.css" rel="stylesheet" type="text/css">
-    <link rel="stylesheet" type="text/css" href="http://fonts.googleapis.com/css?family=Open+Sans">
+    <link rel="stylesheet" type="text/css" href="//fonts.googleapis.com/css?family=Open+Sans">
 
     <!-- HTML5 shim and Respond.js for IE8 support of HTML5 elements and media queries -->
     <!--[if lt IE 9]>


### PR DESCRIPTION
When viewing the documentation site over HTTPS, the CSS is not loaded from Google Fonts due to explicitly requesting it via HTTP. Switch it to a protocol-relative URL so the fonts are loaded correctly.

![screen shot 2015-01-26 at 5 16 42 pm](https://cloud.githubusercontent.com/assets/220451/5902971/297b8ebc-a57f-11e4-9b28-86f63cd653a7.png)
