### PR TITLE
Point out README.md build section from tutorial.

### DIFF
--- a/content/docs/introduction/getting_started.md
+++ b/content/docs/introduction/getting_started.md
@@ -29,6 +29,10 @@ cd prometheus
 make build
 ```
 
+If you encounter problems building Prometheus, see [the more detailed build
+instructions](https://github.com/prometheus/prometheus#use-make) in the
+README.md.
+
 ## Configuring Prometheus to monitor itself
 
 Prometheus collects metrics from monitored targets by scraping metrics HTTP


### PR DESCRIPTION
This should help clarify cases like missing Mercurial installation, etc.