### PR TITLE
Move by clauses on aggregators to all be in front.

### DIFF
--- a/content/docs/introduction/getting_started.md
+++ b/content/docs/introduction/getting_started.md
@@ -249,7 +249,7 @@ preserving the `job` and `service` dimensions) as measured over a window of 5
 minutes. We could write this as:
 
 ```
-avg(rate(rpc_durations_microseconds_count[5m])) by (job, service)
+avg by (job, service)(rate(rpc_durations_microseconds_count[5m]))
 ```
 
 Try graphing this expression.
@@ -259,7 +259,7 @@ called `job_service:rpc_durations_microseconds_count:avg_rate5m`, create a file
 with the following recording rule and save it as `prometheus.rules`:
 
 ```
-job_service:rpc_durations_microseconds_count:avg_rate5m = avg(rate(rpc_durations_microseconds_count[5m])) by (job, service)
+job_service:rpc_durations_microseconds_count:avg_rate5m = avg by (job, service)(rate(rpc_durations_microseconds_count[5m]))
 ```
 
 To make Prometheus pick up this new rule, add a `rule_files` statement to the

--- a/content/docs/querying/examples.md
+++ b/content/docs/querying/examples.md
@@ -46,7 +46,7 @@ Assuming that the `http_requests_total` time series all have the labels `job`
 want to sum over the rate of all instances, so we get fewer output time series,
 but still preserve the `job` dimension:
 
-    sum(rate(http_requests_total[5m])) by (job)
+    sum by (job)(rate(http_requests_total[5m]))
 
 If we have two different metrics with the same dimensional labels, we can apply
 binary operators to them and elements on both sides with the same label set
@@ -58,9 +58,9 @@ scheduler exposing these metrics about the instances it runs):
 
 The same expression, but summed by application, could be written like this:
 
-    sum(
+    sum by (app, proc)(
       instance_memory_limit_bytes - instance_memory_usage_bytes
-    ) by (app, proc) / 1024 / 1024
+    ) / 1024 / 1024
 
 If the same fictional cluster scheduler exposed CPU usage metrics like the
 following for every instance:
@@ -74,9 +74,9 @@ following for every instance:
 ...we could get the top 3 CPU users grouped by application (`app`) and process
 type (`proctype`) like this:
 
-    topk(3, sum(rate(instance_cpu_time_ns[5m])) by (app, proc))
+    topk(3, sum by (app, proc)(rate(instance_cpu_time_ns[5m])))
 
 Assuming this metric contains one time series per running instance, you could
 count the number of running instances per application like this:
 
-    count(instance_cpu_time_ns) by (app)
+    count by (app)(instance_cpu_time_ns)

--- a/content/docs/querying/operators.md
+++ b/content/docs/querying/operators.md
@@ -103,7 +103,7 @@ If the metric `http_requests_total` had time series that fan out by
 `application`, `instance`, and `group` labels, we could calculate the total
 number of seen HTTP requests per application and group over all instances via:
 
-    sum(http_requests_total) by (application, group)
+    sum by (application, group)(http_requests_total)
 
 If we are just interested in the total of HTTP requests we've seen in **all**
 applications, we could simply write:

--- a/content/docs/querying/rules.md
+++ b/content/docs/querying/rules.md
@@ -46,7 +46,7 @@ file:
 Some examples:
 
     // Saving the per-job HTTP in-progress request count as a new set of time series:
-    job:http_inprogress_requests:sum = sum(http_inprogress_requests) by (job)
+    job:http_inprogress_requests:sum = sum by (job)(http_inprogress_requests)
 
     // Drop or rewrite labels in the result time series:
     new_time series{label_to_change="new_value",label_to_drop=""} = old_time series

--- a/content/docs/visualization/consoles.md
+++ b/content/docs/visualization/consoles.md
@@ -63,14 +63,14 @@ table. The main content has a queries-per-second graph.
 <tr>
   <td>CPU</td>
   <td>{{ template "prom_query_drilldown" (args
-      "avg by(job)(rate(process_cpu_seconds_total{job='myjob'}[5m]))"
+      "avg by (job)(rate(process_cpu_seconds_total{job='myjob'}[5m]))"
       "s/s" "humanizeNoSmallPrefix") }}
   </td>
 </tr>
 <tr>
   <td>Memory</td>
   <td>{{ template "prom_query_drilldown" (args
-       "avg by(job)(process_resident_memory_bytes{job='myjob'})"
+       "avg by (job)(process_resident_memory_bytes{job='myjob'})"
        "B" "humanize1024") }}
   </td>
 </tr>


### PR DESCRIPTION
With by clauses on binary operators imminent,
mixing the two forms would be confusing. It's
also easier to understand when expressions are deep.

@jrv @fabx