### PR TITLE
Adjust docs to existing standards.

### DIFF
--- a/content/docs/concepts/metric_types.md
+++ b/content/docs/concepts/metric_types.md
@@ -3,7 +3,7 @@ title: Metric types
 sort_rank: 2
 ---
 
-# Metric Types
+# Metric types
 
 The Prometheus client libraries offer three core metric types:
 

--- a/content/docs/instrumenting/pushing.md
+++ b/content/docs/instrumenting/pushing.md
@@ -22,7 +22,7 @@ class.
 
 For use from Go see the [Push](http://godoc.org/github.com/prometheus/client_golang/prometheus#Push) and [PushAdd](http://godoc.org/github.com/prometheus/client_golang/prometheus#PushAdd) functions.
 
-## Java Batch Job Example
+## Java batch job example
 
 This example illustrates how to instrument a batch job and alert on it not having succeeded recently.
 

--- a/content/docs/introduction/comparison.md
+++ b/content/docs/introduction/comparison.md
@@ -66,7 +66,7 @@ also works well for many short-lived, frequently changing sets of time series.
 ## Prometheus vs. InfluxDB
 
 [InfluxDB](http://influxdb.com/) is a very promising new open-source time
-series database. It didn't exist when Prometheus development began, so we were
+series database. It did not exist when Prometheus development began, so we were
 unable to consider it as an alternative at the time. Still, there are
 significant differences between Prometheus and InfluxDB, and both systems are
 geared towards slightly different use cases.
@@ -112,7 +112,7 @@ Still, InfluxDB is better geared towards the following use cases:
         instance ID
 
 There are other storage features, such as downsampling, which InfluxDB supports
-and Prometheus doesn't yet.
+and Prometheus does not yet.
 
 ### Architecture
 

--- a/content/docs/introduction/getting_started.md
+++ b/content/docs/introduction/getting_started.md
@@ -116,7 +116,7 @@ FAQs](http://golang.org/doc/faq#Why_no_multi_CPU).
 
 ## Using the expression browser
 
-Let's try looking at some data that Prometheus has collected about itself. To
+Let us try looking at some data that Prometheus has collected about itself. To
 use Prometheus's built-in expression browser, navigate to
 http://localhost:9090/graph and choose the "Tabular" view within the "Graph"
 tab.
@@ -167,7 +167,7 @@ Experiment with the graph range parameters and other settings.
 
 ## Starting up some sample targets
 
-Let's make this more interesting and start some example targets for Prometheus
+Let us make this more interesting and start some example targets for Prometheus
 to scrape.
 
 The Go client library includes an example which exports fictional RPC latencies
@@ -193,12 +193,12 @@ http://localhost:8081/metrics, and http://localhost:8082/metrics.
 
 ## Configuring Prometheus to monitor the sample targets
 
-Now we'll configure Prometheus to scrape these new targets. Let's group all
+Now we will configure Prometheus to scrape these new targets. Let's group all
 three endpoints into one job called `example-random`. However, imagine that the
 first two endpoints are production targets, while the third one represents a
 canary instance. To model this in Prometheus, we can add several groups of
 endpoints to a single job, adding extra labels to each group of targets. In
-this example, we'll add the `group="production"` label to the first group of
+this example, we will add the `group="production"` label to the first group of
 targets, while adding `group="canary"` to the second.
 
 To achieve this, add the following job definition to your `prometheus.conf` and

--- a/content/docs/introduction/overview.md
+++ b/content/docs/introduction/overview.md
@@ -69,7 +69,7 @@ Prometheus is designed for reliability, to be the system you go to
 during an outage to allow you to quickly diagnose problems. Each Prometheus
 server is standalone, not depending on network storage or other remote services.
 You can rely on it when other parts of your infrastructure are broken, and
-you don't have to set up complex infrastructure to use it.
+you do not have to set up complex infrastructure to use it.
 
 ## When does it not fit?
 

--- a/content/docs/operating/configuration.md
+++ b/content/docs/operating/configuration.md
@@ -64,7 +64,7 @@ job {
   # provided here needs to resolve to a DNS SRV record containing a set of
   # IP:PORT pairs.
   sd_name: "telemetry.server.prod.api.srv.my-domain.org"
-  # The SRV records don't have information about the endpoint to scrape, so it
+  # The SRV records do not have information about the endpoint to scrape, so it
   # needs to be configured separately when discovering targets dynamically.
   metrics_path: "/metrics"
 }

--- a/content/docs/practices/alerting.md
+++ b/content/docs/practices/alerting.md
@@ -31,7 +31,7 @@ no need to page.
 For error rates, page on user-visible errors. If there are errors further down
 the stack that will cause such a failure, there is no need to page on them
 separately. However, if some failures are not user-visible, but are otherwise
-severe enough to require human involvment (for example, you're losing a lot of
+severe enough to require human involvment (for example, you are losing a lot of
 money), add pages to be sent on those.
 
 You may need alerts for different types of request if they have different

--- a/content/docs/practices/consoles.md
+++ b/content/docs/practices/consoles.md
@@ -24,7 +24,7 @@ service.
 We have found the following guidelines very effective:
 
 * Have no more than 5 graphs on a console.
-* Have no more than 5 plots (lines) on each graph. You can get away with more if it's a stacked/area graph.
+* Have no more than 5 plots (lines) on each graph. You can get away with more if it is a stacked/area graph.
 * When using the provided console template examples, avoid more than 20-30 entries in the right-hand-side table.
 
 If you find yourself exceeding these, it could make sense to demote the visibility of
@@ -34,6 +34,6 @@ it to the right-hand-side table, or even remove data completely if it is rarely
 useful - you can always look at it in the [expression browser](/docs/visualization/browser/)!
 
 Finally, it is difficult for a set of consoles to serve more than one master.
-What you want to know when oncall (what's broken?) tends to be very different
+What you want to know when oncall (what is broken?) tends to be very different
 from what you want when developing features (how many people hit corner
 case X?). In such cases, two separate sets of consoles can be useful.

--- a/content/docs/querying/basics.md
+++ b/content/docs/querying/basics.md
@@ -15,7 +15,7 @@ browser, or consumed by external systems via the HTTP API.
 This document is meant as a reference. For learning, it might be easier to
 start with a couple of [examples](/docs/querying/examples/).
 
-## Expression Language Data Types
+## Expression language data types
 
 In Prometheus's expression language, an expression or sub-expression can
 evaluate to one of four types:
@@ -32,7 +32,7 @@ vector is the only type that can be directly graphed.
 
 ## Literals
 
-### String Literals
+### String literals
 
 Strings may be specified as literals in single or double quotes.
 
@@ -40,7 +40,7 @@ Example:
 
     "this is a string"
 
-### Float Literals
+### Float literals
 
 Scalar float values can be literally written as numbers of the form
 `[-](digits)[.(digits)]`.
@@ -49,7 +49,7 @@ Scalar float values can be literally written as numbers of the form
 
 ## Time series Selectors
 
-### Instant Vector Selectors
+### Instant vector selectors
 
 Instant vector selectors allow the selection of a set of time series and a
 single sample value for each at a given timestamp (instant): in the simplest

--- a/content/docs/querying/examples.md
+++ b/content/docs/querying/examples.md
@@ -3,7 +3,7 @@ title: Examples
 sort_rank: 4
 ---
 
-# Query Examples
+# Query examples
 
 ## Simple time series selection
 
@@ -34,7 +34,7 @@ To select all HTTP status codes except 4xx ones, you could run:
 
     http_requests_total{status!~"^4..$"}
 
-## Using Functions, Operators, etc.
+## Using functions, operators, etc.
 
 Return the per-second rate for all time series with the `http_requests_total`
 metric name, as measured over the last 5 minutes:

--- a/content/docs/querying/functions.md
+++ b/content/docs/querying/functions.md
@@ -105,7 +105,7 @@ the sample values should be rounded. This multiple may also be a fraction.
 ## `scalar()`
 
 Given a single-element input vector, `scalar(v instant-vector)` returns the
-sample value of that single element as a scalar. If the input vector doesn't
+sample value of that single element as a scalar. If the input vector does not
 have exactly one element, `scalar` will return `NaN`.
 
 ## `sort()`
@@ -120,7 +120,7 @@ Same as `sort`, but sorts in descending order.
 ## `time()`
 
 `time()` returns the number of seconds since January 1, 1970 UTC. Note that
-this doesn't actually return the current time, but the time at which the
+this does not actually return the current time, but the time at which the
 expression is to be evaluated.
 
 ## `<aggregation>_over_time()`: Aggregating values over time:

--- a/content/docs/querying/rules.md
+++ b/content/docs/querying/rules.md
@@ -14,7 +14,7 @@ configuration](https://github.com/prometheus/prometheus/blob/master/config/confi
 
 ## Syntax-checking rules
 To quickly check whether a rule file is syntactically correct without starting
-a Prometheus server, install and run Prometheus' `rule_checker` tool:
+a Prometheus server, install and run Prometheus's `rule_checker` tool:
 
 ```bash
 # If $GOPATH/github.com/prometheus/prometheus already exists, update it first:
@@ -129,7 +129,7 @@ not get further updates.
 Prometheus's alerting rules are good at figuring what is broken *right now*,
 but they are not a fully-fledged notification solution. Another layer is needed
 to add summarization, notification rate limiting, silencing and alert
-dependencies on top of the simple alert definitions. In Prometheus' ecosystem,
+dependencies on top of the simple alert definitions. In Prometheus's ecosystem,
 the [Alert Manager](https://github.com/prometheus/alertmanager) takes on this
 role. Thus, Prometheus may be configured to periodically send information about
 alert states to an Alert Manager instance, which then takes care of dispatching

--- a/content/docs/visualization/browser.md
+++ b/content/docs/visualization/browser.md
@@ -5,6 +5,8 @@ sort_rank: 1
 
 # Expression browser
 
-The expression browser is available at `/graph` on the Prometheus server, allowing you to enter any expression and see its result either in a table or graphed over time.
+The expression browser is available at `/graph` on the Prometheus server, allowing you
+to enter any expression and see its result either in a table or graphed over time.
 
-This is primarily useful for ad-hoc queries and debugging. For consoles, use [PromDash](/docs/visualization/promdash/) or [Console templates](/docs/visualization/consoles/).
+This is primarily useful for ad-hoc queries and debugging. For consoles, use
+[PromDash](/docs/visualization/promdash/) or [Console templates](/docs/visualization/consoles/).


### PR DESCRIPTION
- "Prometheus'" to "Prometheus's"
- contractions removed
- no title case in headings