### PR TITLE
Fix rule_checker example

### DIFF
--- a/content/docs/querying/rules.md
+++ b/content/docs/querying/rules.md
@@ -21,7 +21,7 @@ a Prometheus server, install and run Prometheus's `rule_checker` tool:
 go get -u github.com/prometheus/prometheus
 
 go install github.com/prometheus/prometheus/tools/rule_checker
-rule_checker -ruleFile=/path/to/example.rules
+rule_checker /path/to/example.rules
 ```
 
 When the file is syntactically valid, the checker prints a textual


### PR DESCRIPTION
-ruleFile doesn’t exist, and the existing -rule-file flag is deprecated in https://github.com/prometheus/prometheus/commit/c4e762adbf6ee7f8fd24af8dc584a64d14974a7e