### PR TITLE
Sanitize and uniquify in-page anchors properly.

### DIFF
--- a/content/docs/concepts/metric_types.md
+++ b/content/docs/concepts/metric_types.md
@@ -63,7 +63,7 @@ during a scrape:
   * the **count** of events that have been observed, exposed as `<basename>_count` (identical to `<basename>_bucket{le="+Inf"}` above)
 
 Use the [`histogram_quantile()`
-function](/docs/querying/functions/#histogram_quantile()) to calculate
+function](/docs/querying/functions/#histogram_quantile) to calculate
 quantiles from histograms or even aggregations of histograms. A
 histogram is also suitable to calculate an [Apdex
 score](http://en.wikipedia.org/wiki/Apdex). See [histograms and

--- a/content/docs/introduction/comparison.md
+++ b/content/docs/introduction/comparison.md
@@ -74,7 +74,7 @@ geared towards slightly different use cases.
 ### Scope
 
 The same scope differences as in the case of
-[Graphite](/docs/introduction/comparison/#prometheus-vs.-graphite) apply here.
+[Graphite](/docs/introduction/comparison/#prometheus-vs-graphite) apply here.
 
 ### Data model / storage
 
@@ -139,7 +139,7 @@ node outages due to data replication.
 ### Scope
 
 The same scope differences as in the case of
-[Graphite](/docs/introduction/comparison/#prometheus-vs.-graphite) apply here.
+[Graphite](/docs/introduction/comparison/#prometheus-vs-graphite) apply here.
 
 ### Data model
 

--- a/content/docs/practices/histograms.md
+++ b/content/docs/practices/histograms.md
@@ -91,7 +91,7 @@ calculate streaming φ-quantiles on the client side and expose them directly,
 while histograms expose bucketed observation counts and the calculation of
 quantiles from the buckets of a histogram happens on the server side using the
 [`histogram_quantile()`
-function](/docs/querying/functions/#histogram_quantile()).
+function](/docs/querying/functions/#histogram_quantile).
 
 The two approaches have a number of different implications:
 
@@ -102,8 +102,8 @@ The two approaches have a number of different implications:
 | Server performance | The server has to calculate quantiles. You can use [recording rules](/docs/querying/rules/#recording-rules) should the ad-hoc calculation take too long (e.g. in a large dashboard). | Low server-side cost.
 | Number of time series (in addition to the `_sum` and `_count` series) | One time series per configured bucket. | One time series per configured quantile.
 | Quantile error (see below for details) | Error is limited in the dimension of observed values by the width of the relevant bucket. | Error is limited in the dimension of φ by a configurable value.
-| Specification of φ-quantile and sliding time-window | Ad-hoc with [Prometheus expressions](/docs/querying/functions/#histogram_quantile()). | Preconfigured by the client.
-| Aggregation | Ad-hoc with [Prometheus expressions](/docs/querying/functions/#histogram_quantile()). | In general [not aggregatable](http://latencytipoftheday.blogspot.de/2014/06/latencytipoftheday-you-cant-average.html).
+| Specification of φ-quantile and sliding time-window | Ad-hoc with [Prometheus expressions](/docs/querying/functions/#histogram_quantile). | Preconfigured by the client.
+| Aggregation | Ad-hoc with [Prometheus expressions](/docs/querying/functions/#histogram_quantile). | In general [not aggregatable](http://latencytipoftheday.blogspot.de/2014/06/latencytipoftheday-you-cant-average.html).
 
 Note the importance of the last item in the table. Let us return to
 the SLA of serving 95% of requests within 300ms. This time, you do not
@@ -124,7 +124,7 @@ quantiles yields statistically nonsensical values.
 
 Using histograms, the aggregation is perfectly possible with the
 [`histogram_quantile()`
-function](/docs/querying/functions/#histogram_quantile()).
+function](/docs/querying/functions/#histogram_quantile).
 
     histogram_quantile(0.95, sum(rate(http_request_duration_seconds_bucket[5m])) by (le)) // GOOD.
 

--- a/content/docs/visualization/consoles.md
+++ b/content/docs/visualization/consoles.md
@@ -29,7 +29,7 @@ The example consoles have 5 parts:
 1. A table on the right
 
 The navigation bar is for links to other systems, such as other Prometheis
-<sup>[1](/docs/introduction/faq/#what-is-the-plural-of-prometheus?)</sup>,
+<sup>[1](/docs/introduction/faq/#what-is-the-plural-of-prometheus)</sup>,
 documentation, and whatever else makes sense to you. The menu is for navigation
 inside the same Prometheus server, which is very useful to be able to quickly
 open a console in another tab to correlate information. Both are configured in


### PR DESCRIPTION
Things like question marks or parentheses don't play nicely in URLs in
many contexts. Replace all special characters with dashes, and also
ensure that anchors are unique within a page if there are headers with
identical texts.