### PR TITLE
Change default storage.local.path mentions

### DIFF
--- a/content/docs/introduction/getting_started.md
+++ b/content/docs/introduction/getting_started.md
@@ -81,7 +81,7 @@ Prometheus build directory and run:
 
 ```language-bash
 # Start Prometheus.
-# By default, Prometheus stores its database in /tmp/metrics (flag -storage.local.path).
+# By default, Prometheus stores its database in ./data (flag -storage.local.path).
 ./prometheus -config.file=prometheus.yml
 ```
 

--- a/content/docs/operating/storage.md
+++ b/content/docs/operating/storage.md
@@ -45,7 +45,7 @@ index via the following flags:
 
 Prometheus stores its on-disk time series data under the directory
 specified by the flag `storage.local.path`. The default path is
-`/tmp/metrics`, which is good to try something out quickly but most
+`./data`, which is good to try something out quickly but most
 likely not what you want for actual operations. The flag
 `storage.local.retention` allows you to configure the retention time
 for samples. Adjust it to your needs and your available disk space.


### PR DESCRIPTION
Or maybe:

```
By default, Prometheus stores its database in a `data` folder in the current path. (flag -storage.local.path).
```

```
The default path is a `data` folder in the current path, which is good to try something out quickly but most likely not what you want for actual operations.
```

@juliusv 