### PR TITLE
Add rsyslog_exporter to exporter list

### DIFF
--- a/content/docs/instrumenting/exporters.md
+++ b/content/docs/instrumenting/exporters.md
@@ -51,6 +51,7 @@ hosted outside of the Prometheus GitHub organization.
    * [Redis exporter](https://github.com/oliver006/redis_exporter)
    * [RethinkDB exporter](https://github.com/oliver006/rethinkdb_exporter)
    * [scollector exporter](https://github.com/tgulacsi/prometheus_scollector)
+   * [Rsyslog exporter](https://github.com/digitalocean/rsyslog_exporter)
 
 ## Directly instrumentated software
 

--- a/content/docs/instrumenting/exporters.md
+++ b/content/docs/instrumenting/exporters.md
@@ -50,8 +50,8 @@ hosted outside of the Prometheus GitHub organization.
    * [RabbitMQ exporter](https://github.com/kbudde/rabbitmq_exporter)
    * [Redis exporter](https://github.com/oliver006/redis_exporter)
    * [RethinkDB exporter](https://github.com/oliver006/rethinkdb_exporter)
-   * [scollector exporter](https://github.com/tgulacsi/prometheus_scollector)
    * [Rsyslog exporter](https://github.com/digitalocean/rsyslog_exporter)
+   * [scollector exporter](https://github.com/tgulacsi/prometheus_scollector)
 
 ## Directly instrumentated software
 


### PR DESCRIPTION
Adding a link to rsyslog_exporter  to the third party exporters list.