### PR TITLE
Fix Apdex score example in Histograms page.

### DIFF
--- a/content/docs/practices/histograms.md
+++ b/content/docs/practices/histograms.md
@@ -76,8 +76,8 @@ following expression yields the Apdex score for each job over the last
     (
       sum(rate(http_request_duration_seconds_bucket{le="0.3"}[5m])) by (job)
     +
-      sum(rate(http_request_duration_seconds_bucket{le="1.2"}[5m])) by (job)
-    ) / 2 / sum(rate(http_request_duration_seconds_count[5m])) by (job)
+      sum(rate(http_request_duration_seconds_bucket{le="1.2"}[5m])) by (job) / 2
+    ) / sum(rate(http_request_duration_seconds_count[5m])) by (job)
 
 ## Quantiles
 


### PR DESCRIPTION
I noticed the mistake comparing it to the formula in Wikipedia: https://en.wikipedia.org/wiki/Apdex