### PR TITLE
Revert #166 and add explanation why the formula is in fact correct.

### DIFF
--- a/content/docs/practices/histograms.md
+++ b/content/docs/practices/histograms.md
@@ -79,6 +79,10 @@ following expression yields the Apdex score for each job over the last
       sum(rate(http_request_duration_seconds_bucket{le="1.2"}[5m])) by (job)
     ) / 2 / sum(rate(http_request_duration_seconds_count[5m])) by (job)
 
+Note that we divide the sum of both buckets. The reason is that the histogram
+buckets are cumulative. The `le="0.3"` bucket is also contained in the `le="1.2"`
+bucket; dividing it by 2 corrects for that.
+
 ## Quantiles
 
 You can use both summaries and histograms to calculate so-called φ-quantiles,

--- a/content/docs/practices/histograms.md
+++ b/content/docs/practices/histograms.md
@@ -76,8 +76,8 @@ following expression yields the Apdex score for each job over the last
     (
       sum(rate(http_request_duration_seconds_bucket{le="0.3"}[5m])) by (job)
     +
-      sum(rate(http_request_duration_seconds_bucket{le="1.2"}[5m])) by (job) / 2
-    ) / sum(rate(http_request_duration_seconds_count[5m])) by (job)
+      sum(rate(http_request_duration_seconds_bucket{le="1.2"}[5m])) by (job)
+    ) / 2 / sum(rate(http_request_duration_seconds_count[5m])) by (job)
 
 ## Quantiles
 


### PR DESCRIPTION
Reverts prometheus/docs#166

This is frequently confused so it should be explained, but the original formula is correct. The reason is that the histogram buckets are cumulative; the le="0.3" bucket is also contained in the le="1.2" bucket; dividing by 2 corrects for that.

Add an explanation.