### PR TITLE
Bring SoundCloud mentions up to date with reality.

### DIFF
--- a/content/community.html
+++ b/content/community.html
@@ -4,9 +4,8 @@ title: Community
 <div class="col-md-8 col-md-offset-2 doc-content">
   <h1>Community</h1>
   <p>
-    Prometheus is developed in the open and has a growing community outside of
-    SoundCloud. Here are some of the channels we use to communicate and
-    contribute:
+    Prometheus is developed in the open. Here are some of the channels we use
+    to communicate and contribute:
   </p>
   <p>
     <strong>Mailing list:</strong>

--- a/content/docs/introduction/overview.md
+++ b/content/docs/introduction/overview.md
@@ -8,9 +8,11 @@ sort_rank: 1
 ## What is Prometheus?
 
 [Prometheus](https://github.com/prometheus) is an open-source systems
-monitoring and alerting toolkit built at [SoundCloud](http://soundcloud.com).
-Since its inception in 2012, it has become the standard for instrumenting new
-services at SoundCloud and is seeing growing external usage and contributions.
+monitoring and alerting toolkit originally built at
+[SoundCloud](http://soundcloud.com). Since its inception in 2012, many
+companies and organizations have adopted Prometheus, and the project has a very
+active developer and user community. It is now a standalone open source project
+and maintained independently of any company.
 
 For a more elaborate overview, see the resources linked from the
 [media](/docs/introduction/media/) section.

--- a/layouts/container_footer.html
+++ b/layouts/container_footer.html
@@ -4,7 +4,4 @@
   <p class="pull-left">
     &copy; Prometheus Authors 2015
   </p>
-  <p class="pull-right">
-    Brought to you by <a href="http://soundcloud.com/" class="sc-logo" title="Go to SoundCloud.com"><img src="/assets/sc_sbs_grey_96x12.png"></a>
-  </p>
 </footer>


### PR DESCRIPTION
Prometheus is an independent project and some of the current SoundCloud
mentions serve more to confuse/make people insecure about using
Prometheus than they help. This adjusts the language and mentions a bit.