### PR TITLE
Remove 'Hierarchical federation' from roadmap (it's now implemented)

### DIFF
--- a/content/docs/introduction/roadmap.md
+++ b/content/docs/introduction/roadmap.md
@@ -11,18 +11,6 @@ features and current work, see the issue trackers for the various repositories,
 for example, the [Prometheus
 server](https://github.com/prometheus/prometheus/issues).
 
-### Hierarchical federation
-
-Hierarchical federation will allow higher-level Prometheus servers to collect
-aggregated time series data from subordinated servers. This will enable more
-scalable monitoring topologies. For example, a setup might consist of
-per-datacenter Prometheus servers that collect data in high detail, and a set
-of global Prometheus servers which collect and store only aggregated data from
-those local servers. This allows you to have an aggregate global view and
-detailed local views.
-
-GitHub issue: [#9](https://github.com/prometheus/prometheus/issues/9)
-
 ### Support for more types of service discovery
 
 Currently Prometheus supports configuring static HTTP targets, as well as


### PR DESCRIPTION
Since prometheus/prometheus#9 was closed.

Related: unsure if the "[Architecture](http://prometheus.io/docs/introduction/comparison/#architecture)" section under "Comparison to alternatives" also needs an update.