### PR TITLE
Add documentation for Marathon SD

### DIFF
--- a/content/docs/operating/configuration.md
+++ b/content/docs/operating/configuration.md
@@ -337,6 +337,42 @@ server: <host>
 [ retry_interval: <duration> | default = 1s ]
 ```
 
+### Marathon SD configurations `<marathon_sd_configs>`
+
+CAUTION: Marathon SD is in beta: breaking changes to configuration are still
+likely in future releases.
+
+Marathon SD configurations allow retrieving scrape targets using the
+[Marathon](https://mesosphere.github.io/marathon/) REST API. Prometheus
+will periodically check the REST endpoint for currently running tasks and
+create a target group for every app that has at least one healthy task.
+
+The following meta labels are available on targets during relabeling:
+
+* `__meta_marathon_app`: the name of the app (with slashes replaced by dashes)
+* `__meta_marathon_image`: the name of the Docker image used (if available)
+* `__meta_marathon_task`: the ID of the Mesos task
+* `__meta_marathon_app_label_<labelname>`: any Marathon labels attached to the app
+
+See below for the configuration options for Marathon discovery:
+
+```
+# List of URLs to be used to contact Marathon servers.
+# You need to provide at least one server URL, but should provide URLs for
+# all masters you have running.
+servers:
+  - <string>
+
+# Polling interval
+[ refresh_interval: <duration> | default = 30s ]
+```
+
+By default every app listed in Marathon will be scraped by Prometheus. If not all
+of your services provide Prometheus metrics, you can use a Marathon label and
+Prometheus relabeling to control which instances will actually be scraped. Also
+by default all apps will show up as a single job in Prometheus (the one specified
+in the configuration file), which can also be changed using relabeling.
+
 ### Zookeeper Serverset SD configurations `<serverset_sd_config>`
 
 Serverset SD configurations allow retrieving scrape targets from [Serversets]


### PR DESCRIPTION
I have added a small paragraph about the Marathon SD configuration. It documents the available configuration options and the meta labels. Currently I have two points that I am not sure about:

* Should I also add a "caution very new" label like for Kubernetes?
* Should I add an example for the relabeling configuration (filtering services which do not support prometheus, etc)?

Regarding the examples: This might be helpful for other parts of the configuration as well. I find the current style of documentation for the configuration file a bit hard to understand.