### PR TITLE
Require that metrics be grouped together for text format.

### DIFF
--- a/content/docs/instrumenting/exposition_formats.md
+++ b/content/docs/instrumenting/exposition_formats.md
@@ -72,7 +72,7 @@ metric name, and the second is either `counter`, `gauge`, `histogram`,
 one `TYPE` line may exist for the same metric name. The `TYPE` line for a
 metric name has to appear before the first sample is reported for that metric
 name. If there is no `TYPE` line for a metric name, the type is set to
-`untyped`.  Remaining lines describe samples, one per line, with the following
+`untyped`. Remaining lines describe samples, one per line, with the following
 syntax (EBNF):
 
     metric_name [
@@ -81,6 +81,9 @@ syntax (EBNF):
 
 `metric_name` and `label_name` have the usual Prometheus expression language restrictions. `label_value` can be any sequence of UTF-8 characters, but the backslash, the double-quote, and the line-feed characters have to be escaped as `\\`, `\"`, and `\n`, respectively.
 `value` is a float, and timestamp an `int64` (milliseconds since epoch, i.e. 1970-01-01 00:00:00 UTC, excluding leap seconds), represented as required by the [Go strconv package](http://golang.org/pkg/strconv/) (see functions `ParseInt` and `ParseFloat`). In particular, `Nan`, `+Inf`, and `-Inf` are valid values.
+
+All lines for a given metric should be provided as one uninterrupted group, with
+the optional `HELP` and `TYPE` lines first.
 
 The `histogram` and `summary` types are difficult to represent in the text
 format. The following conventions apply:


### PR DESCRIPTION
While it'd be nice for TYPE to be first,
that's not what the examples do so we leave the ordering
of HELP/TYPE unspecified.

@beorn7 @fabxc 