### PR TITLE
Better explain file_sd's expected format

### DIFF
--- a/content/docs/operating/configuration.md
+++ b/content/docs/operating/configuration.md
@@ -428,6 +428,20 @@ The JSON version of a target group has the following format:
 }
 ```
 
+Also, the files must contain an array of target groups, not a standalone one. Here is
+an example of a simple file:
+
+```
+[
+  {
+    "targets": ["10.0.0.1:9090", "10.0.0.2:9090"],
+    "labels": {
+      "generated_from": "unicorn magic"
+    }
+  }
+]
+```
+
 As a fallback, the file contents are also re-read periodically at the specified
 refresh interval.
 


### PR DESCRIPTION
Indicate in the docs that the files need to contain an array of target groups, not a standalone one. This was only discoverable by looking at the output of prometheus saying the file was bad.

I know the docs indicate "zero or more" which implies it is an array, but that detail is extremely easy to miss.