### PR TITLE
Correct improper use of 'labels' setting.

### DIFF
--- a/content/docs/introduction/getting_started.md
+++ b/content/docs/introduction/getting_started.md
@@ -243,7 +243,7 @@ global:
   # scrape_timeout is set to the global default (10s).
 
   # Attach these extra labels to all timeseries collected by this Prometheus instance.
-  labels:
+  external_labels:
     monitor: 'codelab-monitor'
 
 rule_files:


### PR DESCRIPTION
The 'labels' setting in the global configuration section has been renamed to 'external_labels' and now has changed semantics. Hence, the fix.