### PR TITLE
Prom org url for Docker Hub incorrect

### DIFF
--- a/content/docs/introduction/install.md
+++ b/content/docs/introduction/install.md
@@ -31,7 +31,7 @@ other) repositories.
 ## Using Docker
 
 All Prometheus services are available as Docker images under the
-[prom](https://registry.hub.docker.com/repos/prom/) organization.
+[prom](https://hub.docker.com/u/prom/) organization.
 
 Running Prometheus on Docker is as simple as
  `docker run -p 9090:9090 prom/prometheus`. This starts Prometheus with


### PR DESCRIPTION
@juliusv @brian-brazil  

Minor update. Outdated url in the Using Docker Section

https://registry.hub.docker.com/repos/prom/ no longer works

https://hub.docker.com/u/prom/ seems to work as expected.