### PR TITLE
Upgrade to Nanoc 4

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -1,6 +1,6 @@
 source 'https://rubygems.org'
 
-gem 'nanoc'
+gem 'nanoc', '~> 4.0'
 gem 'adsf'
 gem 'kramdown'
 gem 'guard-nanoc'

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -8,7 +8,7 @@ GEM
       timers (~> 4.0.0)
     coderay (1.1.0)
     colored (1.2)
-    cri (2.6.1)
+    cri (2.7.0)
       colored (~> 1.2)
     em-websocket (0.5.1)
       eventmachine (>= 0.12.9)
@@ -40,7 +40,7 @@ GEM
     method_source (0.8.2)
     mini_portile (0.6.0)
     multi_json (1.11.2)
-    nanoc (3.7.3)
+    nanoc (4.0.0)
       cri (~> 2.3)
     nokogiri (1.6.3.1)
       mini_portile (= 0.6.0)
@@ -74,10 +74,13 @@ DEPENDENCIES
   guard-livereload
   guard-nanoc
   kramdown
-  nanoc
+  nanoc (~> 4.0)
   nokogiri
   pygments.rb
   rb-fchange
   rb-fsevent
   rb-inotify
   redcarpet
+
+BUNDLED WITH
+   1.10.6

--- a/Rules
+++ b/Rules
@@ -1,45 +1,21 @@
 #!/usr/bin/env ruby
 
-# A few helpful tips about the Rules file:
-#
-# * The string given to #compile and #route are matching patterns for
-#   identifiers--not for paths. Therefore, you can’t match on extension.
-#
-# * The order of rules is important: for each item, only the first matching
-#   rule is applied.
-#
-# * Item identifiers start and end with a slash (e.g. “/about/” for the file
-#   “content/about.html”). To select all children, grandchildren, … of an
-#   item, use the pattern “/about/*/”; “/about/*” will also select the parent,
-#   because “*” matches zero or more characters.
-
-compile '/assets/*' do
-end
-
-route '/assets/*' do
-  # /assets/foo.html/ → /foo.html
-  item.identifier[0..-2]
-end
-
-route '/README/' do
-    '/README.md'
-end
+passthrough '/static/**/*'
+passthrough '/README.md'
 
 # RSS Feed
-compile '/blog/feed/' do
+compile '/blog/feed.*' do
     filter :erb
 end
 
-route '/blog/feed/' do
-    '/blog/feed.xml'
+route '/blog/feed.*' do
+  '/blog/feed.xml'
 end
 
-compile '*' do
+compile '/**/*' do
   filter :erb
 
-  if item[:title] == 'README.md'
-    # Don't filter; this should propagate verbatim to the output GitHub repository.
-  elsif item[:extension] == 'md'
+  if item[:extension] == 'md'
     #filter :kramdown
     filter :redcarpet, options: {filter_html: true, autolink: true, no_intraemphasis: true, fenced_code_blocks: true, gh_blockcode: true, tables: true}, renderer_options: {with_toc_data: true}
     filter :add_anchors
@@ -47,46 +23,42 @@ compile '*' do
     filter :admonition
     filter :colorize_syntax, :default_colorizer => :pygmentsrb
     if item[:kind] == 'article'
-      layout 'blog'
+      layout '/blog.*'
     else
-      layout 'docs'
+      layout '/docs.*'
     end
-  elsif item[:extension] == 'css'
-    # don’t filter stylesheets
   elsif item.binary?
     # don’t filter binary items
   elsif item[:layout]
     layout item[:layout]
   else
-    layout 'default'
+    layout '/default.*'
   end
 end
 
-route '/blog/' do
+route '/blog{/index,}.*' do
   '/blog/index.html'
 end
 
 # Transform /blog/<YYYY>-<MM>-<DD>-<post title> to
 # /blog/<YYYY>/<MM>/<DD>/<post title>.
-route '/blog/*' do
+route '/blog/**/*' do
   y, m, d, slug = /([0-9]+)\-([0-9]+)\-([0-9]+)\-([^\/]+)/.match(item.identifier).captures
 
   "/blog/#{y}/#{m}/#{d}/#{slug}/index.html"
 end
 
-route '*' do
-  if item[:extension] == 'css'
-    # Write item with identifier /foo/ to /foo.css
-    item.identifier.chop + '.css'
-  elsif item.binary?
-    # Write item with identifier /foo/ to /foo.ext
-    item.identifier.chop + '.' + item[:extension]
+route '/**/*' do
+  if item.binary?
+    # Write item with identifier /foo.dat to /foo.dat
+    item.identifier.to_s
+  elsif item.identifier =~ '/**/index.*'
+    # Write item with identifier /foo/index.md to /foo/index.html
+    item.identifier.without_ext + '.html'
   else
-    # Write item with identifier /foo/ to /foo/index.html
-    item.identifier + 'index.html'
+    # Write item with identifier /foo/bar.md to /foo/bar/index.html
+    item.identifier.without_ext + '/index.html'
   end
 end
 
-#passthrough '/assets/*'
-
-layout '*', :erb
+layout '/**/*', :erb

--- a/content/blog/index.html
+++ b/content/blog/index.html
@@ -12,4 +12,4 @@ title: Blog
     </div>
   <% end %>
 </div>
-<%= render 'blog_sidebar' %>
+<%= render '/blog_sidebar.*' %>

--- a/content/index.html
+++ b/content/index.html
@@ -1,5 +1,5 @@
 ---
-layout: jumbotron
+layout: /jumbotron.*
 ---
 <div class="main">
   <div class="row">

--- a/layouts/blog.html
+++ b/layouts/blog.html
@@ -1,4 +1,4 @@
-<% render 'default' do %>
+<% render '/default.*' do %>
   <div class="col-md-9 blog doc-content">
     <h1><%= item[:title] %></h1>
     <aside>Posted at: <%= get_pretty_date(item) %> by <%= item[:author_name]%></aside>
@@ -10,7 +10,7 @@
     <script type="text/javascript">
         /* * * CONFIGURATION VARIABLES * * */
         var disqus_shortname = 'prometheus-blog';
-     
+
         /* * * DON'T EDIT BELOW THIS LINE * * */
         (function() {
             var dsq = document.createElement('script'); dsq.type = 'text/javascript'; dsq.async = true;
@@ -21,5 +21,5 @@
     <noscript>Please enable JavaScript to view the <a href="https://disqus.com/?ref_noscript" rel="nofollow">comments powered by Disqus.</a></noscript>
   </div>
 
-  <%= render 'blog_sidebar' %>
+  <%= render '/blog_sidebar.*' %>
 <% end %>

--- a/layouts/default.html
+++ b/layouts/default.html
@@ -1,7 +1,7 @@
-<%= render 'header' %>
+<%= render '/header.*' %>
 
 <div class="container">
   <%= yield %>
 </div>
 
-<%= render 'footer' %>
+<%= render '/footer.*' %>

--- a/layouts/docs.html
+++ b/layouts/docs.html
@@ -1,10 +1,10 @@
-<%= render 'header' %>
+<%= render '/header.*' %>
 
 <div class="container">
   <div class="row">
     <div class="col-md-3 side-nav-col">
       <ul class="nav navbar-nav side-nav">
-        <% @items['/docs/'].children.sort_by { |i| i[:sort_rank] || 0 }.each do |i| %>
+        <% @items.find_all('/docs/*').sort_by { |i| i[:sort_rank] || 0 }.each do |i| %>
           <%= toc(i, @item) %>
         <% end %>
       </ul>
@@ -15,7 +15,7 @@
     </div>
 
   </div>
-  <%= render 'container_footer' %>
+  <%= render '/container_footer.*' %>
 </div>
 
-<%= render 'footer' %>
+<%= render '/footer.*' %>

--- a/layouts/jumbotron.html
+++ b/layouts/jumbotron.html
@@ -1,4 +1,4 @@
-<%= render 'header' %>
+<%= render '/header.*' %>
 
 <div class="jumbotron">
   <div class="container">
@@ -10,7 +10,7 @@
 
 <div class="container">
   <%= yield %>
-  <%= render 'container_footer' %>
+  <%= render '/container_footer.*' %>
 </div>
 
-<%= render 'footer' %>
+<%= render '/footer.*' %>

--- a/lib/default.rb
+++ b/lib/default.rb
@@ -3,8 +3,8 @@
 
 include Nanoc::Helpers::LinkTo
 include Nanoc::Helpers::Rendering
-include Nanoc3::Helpers::Blogging
-include Nanoc3::Helpers::Tagging
+include Nanoc::Helpers::Blogging
+include Nanoc::Helpers::Tagging
 
 module BlogHelper
   def get_pretty_date(post)
@@ -18,7 +18,7 @@ module BlogHelper
       "<div class='read-more'><a href='#{post.path}'>Continue reading &rsaquo;</a></div>"
     end
     return content
-  end  
+  end
 end
 
 include BlogHelper

--- a/nanoc.yaml
+++ b/nanoc.yaml
@@ -62,8 +62,10 @@ data_sources:
     # UTF-8 (which they should be!), change this.
     encoding: utf-8
   -
-    type: static
-    items_root: /assets/
+    type: filesystem
+    items_root: /static
+    content_dir: static
+    layouts_dir: null
 
 # Configuration for the “check” command, which run unit tests on the site.
 checks:


### PR DESCRIPTION
This PR upgrades the Prometheus site to Nanoc 4. It also makes use of the new identifiers with extensions, as well as globs.

**Note:** Ruby 2.2+ or JRuby 9000+ is required to use Nanoc 4.

Also see the [Nanoc 4 upgrade guide](http://nanoc.ws/doc/nanoc-4-upgrade-guide/).
