### PR TITLE
Note the required ordering of lines with timestamps

### DIFF
--- a/content/docs/instrumenting/exposition_formats.md
+++ b/content/docs/instrumenting/exposition_formats.md
@@ -83,7 +83,8 @@ syntax (EBNF):
 `value` is a float, and timestamp an `int64` (milliseconds since epoch, i.e. 1970-01-01 00:00:00 UTC, excluding leap seconds), represented as required by the [Go strconv package](http://golang.org/pkg/strconv/) (see functions `ParseInt` and `ParseFloat`). In particular, `Nan`, `+Inf`, and `-Inf` are valid values.
 
 All lines for a given metric must be provided as one uninterrupted group, with
-the optional `HELP` and `TYPE` lines first.
+the optional `HELP` and `TYPE` lines first.   If the timestamp is provided,
+the lines must be ordered with the earliest lines first.
 
 The `histogram` and `summary` types are difficult to represent in the text
 format. The following conventions apply:


### PR DESCRIPTION
When attempting to feed Prometheus timestamped metrics, the timestamps
were not adhered to when the lines were unordered.  This should be
documented to avoid this mistake.