### PR TITLE
Use light color in code blocks

### DIFF
--- a/static/docs.css
+++ b/static/docs.css
@@ -224,8 +224,9 @@ a.sc-logo img {
 
 pre {
   font-family: "Courier New", Monaco, Menlo, Consolas, monospace;
-  background-color: #444;
-  color: #f8f8f2;
+  background-color: #f9f2f4;
+  border: 1px solid #e6522c;
+  color: #333;
 }
 
 code {


### PR DESCRIPTION
The current black code blocks are very dominant. In my personal view
they are too disruptive when scaning a page. This change makes them
similar to inline code examples.

@brian-brazil @fabxc 

![screenshot from 2016-01-20 11-16-05](https://cloud.githubusercontent.com/assets/3432/12455070/2d95e570-bf68-11e5-8a5e-eb28ae5054c3.png)