### PR TITLE
Include Python pushgateway in Pushing docs

### DIFF
--- a/content/docs/instrumenting/pushing.md
+++ b/content/docs/instrumenting/pushing.md
@@ -13,14 +13,16 @@ time series from these components to an intermediary job which Prometheus can
 scrape. Combined with Prometheus's simple text-based exposition format, this
 makes it easy to instrument even shell scripts without a client library.
 
-For more information on using the Pushgateway and use from a Unix shell, see the project's
+ * For more information on using the Pushgateway and use from a Unix shell, see the project's
 [README.md](https://github.com/prometheus/pushgateway/blob/master/README.md).
 
-For use from Java see the
+ * For use from Java see the
 [PushGateway](http://prometheus.github.io/client_java/io/prometheus/client/exporter/PushGateway.html)
 class.
 
-For use from Go see the [Push](http://godoc.org/github.com/prometheus/client_golang/prometheus#Push) and [PushAdd](http://godoc.org/github.com/prometheus/client_golang/prometheus#PushAdd) functions.
+ * For use from Go see the [Push](http://godoc.org/github.com/prometheus/client_golang/prometheus#Push) and [PushAdd](http://godoc.org/github.com/prometheus/client_golang/prometheus#PushAdd) functions.
+
+ * For use from Python see [Exporting to a Pushgateway](https://github.com/prometheus/client_python#exporting-to-a-pushgateway).
 
 ## Java batch job example
 


### PR DESCRIPTION
Currently only shell, Java and Go are listed. Python supports pushgateways as well but requires users to go to the client library page to discover about it.