### PR TITLE
Next release

### DIFF
--- a/content/docs/introduction/getting_started.md
+++ b/content/docs/introduction/getting_started.md
@@ -150,10 +150,7 @@ for three services with different latency distributions.
 
 Ensure you have the [Go compiler installed](https://golang.org/doc/install) and
 have a [working Go build environment](https://golang.org/doc/code.html) (with
-correct `GOPATH`) set up. For some of the dependencies that `go get` will
-fetch, you will also need to have the
-[Mercurial](https://www.mercurial-scm.org/) revision control system (`hg`
-command) installed.
+correct `GOPATH`) set up.
 
 Download the Go client library for Prometheus and run three of these example
 processes:

--- a/content/docs/operating/configuration.md
+++ b/content/docs/operating/configuration.md
@@ -317,7 +317,6 @@ The following meta labels are available on targets during relabeling:
 
 * `__meta_kubernetes_role`: the role of the target: one of `master`, `node` or
 `service`
-* `__meta_kubernetes_node`: the name of the node from the Kubernetes API
 * `__meta_kubernetes_node_label_<labelname>`: each node label from the
 Kubernetes API
 * `__meta_kubernetes_service_namespace`: the namespace of the service
@@ -326,6 +325,9 @@ Kubernetes API
 Kubernetes API
 * `__meta_kubernetes_service_annotation_<annotationname>`: each service
 annotation from the Kubernetes API
+
+In addition, the `instance` label for node metrics will be set to the node name
+as retrieved from the API server.
 
 See below for the configuration options for Kubernetes discovery:
 

--- a/content/docs/operating/configuration.md
+++ b/content/docs/operating/configuration.md
@@ -307,16 +307,16 @@ likely in future releases.
 
 Kubernetes SD configurations allow retrieving scrape targets from
 [Kubernetes'](http://kubernetes.io/) REST API. By default, this discovers
-masters, nodes, and appropriately annotated services so that metrics from both
+API servers, nodes, and appropriately annotated services so that metrics from both
 cluster components and deployed applications can be scraped. This will create
-multiple target groups: one for all masters with each master as a target, one
+multiple target groups: one for all API servers with each API server as a target, one
 for all nodes with each node as a target, and one for each service containing
 each service endpoint as a target.
 
 The following meta labels are available on targets during relabeling:
 
-* `__meta_kubernetes_role`: the role of the target: one of `master`, `node` or
-`service`
+* `__meta_kubernetes_role`: the role of the target: one of `apiserver`, `node`
+or `service`
 * `__meta_kubernetes_node_label_<labelname>`: each node label from the
 Kubernetes API
 * `__meta_kubernetes_service_namespace`: the namespace of the service
@@ -334,9 +334,9 @@ See below for the configuration options for Kubernetes discovery:
 ```
 # The information to access the Kubernetes API.
 
-# The master addresses. In a cluster this will normally be
-# `https://kubernetes.default.svc`. Supports multiple HA masters.
-masters:
+# The API server addresses. In a cluster this will normally be
+# `https://kubernetes.default.svc`. Supports multiple HA API servers.
+api_servers:
   - [<host>]
 
 # Run in cluster. This will use the automounted CA certificate and bearer
@@ -347,14 +347,21 @@ masters:
 # port of 10255 (default).
 [ kubelet_port: <int> ]
 
-# File to read the bearer token from to authenticate to the API server. If
-# running in a pod, then it is best to use a service account and set in_cluster
-# to true.
-[ bearer_token_file: <filename> ]
+# Optional authentication information used to authenticate to the API server.
+# Note that `basic_auth`, `bearer_token` and `bearer_token_file` options are
+# mutually exclusive.
 
-# Username and password for basic authentication to the API server.
-[ username: <string> ]
-[ password: <string> ]
+# Optional HTTP basic authentication information.
+basic_auth:
+  [ username: <string> ]
+  [ password: <string> ]
+
+# Optional bearer token authentication information.
+[ bearer_token: <string> ]
+
+# Optional bearer token file authentication information. If running in a pod,
+# then it is best to use a service account and set in_cluster to true.
+[ bearer_token_file: <filename> ]
 
 # TLS configuration. If running in a pod, then it is best to use a service
 # account and set in_cluster to true.

--- a/content/docs/querying/basics.md
+++ b/content/docs/querying/basics.md
@@ -85,7 +85,7 @@ For example, this selects all `http_requests_total` time series for `staging`,
     http_requests_total{environment=~"staging|testing|development",method!="GET"}
 
 Label matchers that match empty label values also select all time series that do
-not have the specific label set at all. Regex-matches are not anchored.
+not have the specific label set at all. Regex-matches are fully anchored.
 
 Vector selectors must either specify a name or at least one label matcher
 that does not match the empty string. The following expression is illegal:

--- a/content/docs/querying/functions.md
+++ b/content/docs/querying/functions.md
@@ -51,6 +51,16 @@ For each input time series, `changes(v range-vector)` returns the number of
 times its value has changed within the provided time range as an instant
 vector.
 
+## `clamp_max()`
+
+`clamp_max(v instant-vector, max scalar)` clamps the sample values of all
+elements in `v` to have an upper limit of `max`.
+
+## `clamp_min()`
+
+`clamp_min(v instant-vector, min scalar)` clamps the sample values of all
+elements in `v` to have a lower limit of `min`.
+
 ## `count_scalar()`
 
 `count_scalar(v instant-vector)` returns the number of elements in a time series

--- a/content/docs/querying/operators.md
+++ b/content/docs/querying/operators.md
@@ -53,11 +53,9 @@ and vector/vector value pairs. By default they filter. Their behaviour can be
 modified by providing `bool` after the operator, which will return `0` or `1`
 for the value rather than filtering.
 
-**Between two scalars**, these operators result in another scalar that is
-either `0` (`false`) or `1` (`true`), depending on the comparison result.
-The `bool` modifier has no effect on this comparison, however it's
-recommended to always provide it due to [upcoming changes](https://github.com/prometheus/prometheus/issues/482).
-
+**Between two scalars**, the `bool` modifier must be provided and these
+operators result in another scalar that is either `0` (`false`) or `1`
+(`true`), depending on the comparison result.
 
 **Between an instant vector and a scalar**, these operators are applied to the
 value of every data sample in the vector, and vector elements between which the


### PR DESCRIPTION

The most notable change is regarding alerting, where notes about pre-0.17 behavior are in place.

As we cut the 0.17.0 release candidate, it makes sense to have this on the website.