### PR TITLE
slack_configs typo

### DIFF
--- a/content/docs/alerting/configuration.md
+++ b/content/docs/alerting/configuration.md
@@ -205,7 +205,7 @@ email_configs:
   [ - <email_config>, ... ]
 pagerduty_configs:
   [ - <pagerduty_config>, ... ]
-slack_config:
+slack_configs:
   [ - <slack_config>, ... ]
 opsgenie_configs:
   [ - <opsgenie_config>, ... ]


### PR DESCRIPTION
slack_config is now slack_configs according to the code

https://github.com/prometheus/alertmanager/blob/c61c01736107bba4f05d30a4e66a9e7b007b8f5d/config/config.go#L389