### PR TITLE
Improve alerting exmaple based on severity

### DIFF
--- a/content/docs/alerting/rules.md
+++ b/content/docs/alerting/rules.md
@@ -74,7 +74,7 @@ Examples:
     ALERT InstanceDown
       IF up == 0
       FOR 5m
-      LABELS { severity = "page" }
+      LABELS { severity = "critical" }
       ANNOTATIONS {
         summary = "Instance {{ $labels.instance }} down",
         description = "{{ $labels.instance }} of job {{ $labels.job }} has been down for more than 5 minutes.",


### PR DESCRIPTION
It should be alertmanager's responsibility how to route alerts and which
receiver to use. Alerts should only provide all necessary information,
but not describe the receiver of an alert. As this might not be true in
all cases, it can quickly create confusion.

@fabxc @juliusv 
