### PR TITLE
Add Varnish exporter to 3rd party section

### DIFF
--- a/content/docs/instrumenting/exporters.md
+++ b/content/docs/instrumenting/exporters.md
@@ -69,6 +69,7 @@ hosted outside of the Prometheus GitHub organization.
    * [SMTP/Maildir MDA blackbox prober](https://github.com/cherti/mailexporter)
    * [Speedtest.net exporter](https://github.com/RichiH/speedtest_exporter)
    * [SQL query result set metrics exporter](https://github.com/chop-dbhi/prometheus-sql)
+   * [Varnish exporter](https://github.com/jonnenauha/prometheus_varnish_exporter)
 
 When implementing a new Prometheus exporter, please follow the
 [Prometheus Exporter Guidelines](https://docs.google.com/document/d/1JapuiRbp-XoyECgl2lPdxITrhm5IyCUq9iA_h6jp3OY/edit).


### PR DESCRIPTION
Created this over the weekend. Might be useful as Varnish is quite common part of web infra. I have tested it to work and to actually be useful with our company production instances.

P.S. Yey for Varnish turning 10 years ;) Maybe this is my way of celebrating
http://info.varnish-software.com/varnish-cache-10-years 