### PR TITLE
Remove misleading hints about multiple evaluation_interval

### DIFF
--- a/content/docs/introduction/getting_started.md
+++ b/content/docs/introduction/getting_started.md
@@ -37,8 +37,7 @@ Prometheus configuration as a file named `prometheus.yml`:
 ```
 global:
   scrape_interval:     15s # By default, scrape targets every 15 seconds.
-  evaluation_interval: 15s # By default, scrape targets every 15 seconds.
-  # scrape_timeout is set to the global default (10s).
+  evaluation_interval: 15s # Evaluate rules every 15 seconds.
 
   # Attach these labels to any time series or alerts when communicating with
   # external systems (federation, remote storage, Alertmanager).

--- a/content/docs/operating/configuration.md
+++ b/content/docs/operating/configuration.md
@@ -54,7 +54,7 @@ global:
   # How long until a scrape request times out.
   [ scrape_timeout: <duration> | default = 10s ]
 
-  # How frequently to evaluate rules by default.
+  # How frequently to evaluate rules.
   [ evaluation_interval: <duration> | default = 1m ]
 
   # The labels to add to any time series or alerts when communicating with


### PR DESCRIPTION
There is only one global evaluation_interval at this time, so a "by
default" is misleading as it can't be overwritten anywhere.

@brian-brazil 