### PR TITLE
Clarify requirements for histograms and summaries text exposition format

### DIFF
--- a/content/docs/instrumenting/exposition_formats.md
+++ b/content/docs/instrumenting/exposition_formats.md
@@ -109,6 +109,7 @@ format. The following conventions apply:
 * Each bucket count of a histogram named `x` is given as a separate sample line with the name `x_bucket` and a label `{le="y"}` (where `y` is the upper bound of the bucket).
 * A histogram _must_ have a bucket with `{le="+Inf"}`. Its value _must_ be identical to the value of `x_count`.
 * The buckets of a histogram and the quantiles of a summary must appear in increasing numerical order of their label values (for the `le` or the `quantile` label, respectively).
+* Histogram and summary metrics _must_ have a comment defining their type (`# TYPE` line before the samples of a given metric).
 
 See also the example below.
 


### PR DESCRIPTION
It seems that [text_parse.go](https://github.com/prometheus/common/blob/master/expfmt/text_parse.go) *requires* histograms and summaries to have type declaration, even though `HELP` and `TYPE` lines are described as optional in the document.