### PR TITLE
Add a link to nginx-lua-prometheus

### DIFF
--- a/content/docs/instrumenting/clientlibs.md
+++ b/content/docs/instrumenting/clientlibs.md
@@ -22,8 +22,9 @@ Unofficial third-party client libraries:
 
 * [Bash](https://github.com/aecolley/client_bash)
 * [Haskell](https://github.com/fimad/prometheus-haskell)
-* [Node.js](https://github.com/siimon/prom-client)
+* [Lua](https://github.com/knyar/nginx-lua-prometheus) for Nginx
 * [.NET / C#](https://github.com/andrasm/prometheus-net)
+* [Node.js](https://github.com/siimon/prom-client)
 
 When Prometheus scrapes your instance's HTTP endpoint, the client library
 sends the current state of all tracked metrics to the server.

--- a/content/docs/instrumenting/exporters.md
+++ b/content/docs/instrumenting/exporters.md
@@ -57,6 +57,7 @@ hosted outside of the Prometheus GitHub organization.
    * [MongoDB exporter](https://github.com/dcu/mongodb_exporter)
    * [Munin exporter](https://github.com/pvdh/munin_exporter)
    * [New Relic exporter](https://github.com/jfindley/newrelic_exporter)
+   * [Nginx metric library](https://github.com/knyar/nginx-lua-prometheus)
    * [NSQ exporter](https://github.com/lovoo/nsq_exporter)
    * [OpenWeatherMap exporter](https://github.com/RichiH/openweathermap_exporter)
    * [PgBouncer exporter](http://git.cbaines.net/prometheus-pgbouncer-exporter/about)


### PR DESCRIPTION
While nginx-lua-prometheus is not an exporter, it feels like this section is the best fit for it.