### PR TITLE
Add GitHub star button to header.

### DIFF
--- a/layouts/header.html
+++ b/layouts/header.html
@@ -72,6 +72,9 @@
             <li><a href="/community/">Community</a></li>
             <li><a href="/blog/">Blog</a></li>
             <li><a href="https://github.com/prometheus"><i class="fa fa-github"></i> Github</a></li>
+            <li>
+              <iframe src="https://ghbtns.com/github-btn.html?user=prometheus&repo=prometheus&type=star&count=true" class="github-stars" frameborder="0" scrolling="0"></iframe>
+            </li>
           </ul>
         </div>
       </div>

--- a/static/docs.css
+++ b/static/docs.css
@@ -19,6 +19,12 @@ body {
   margin-right: 3px;
 }
 
+.navbar .github-stars {
+  margin: 15px 0 0 15px;
+  width: 100px;
+  height: 20px;
+}
+
 .jumbotron {
   background-color: #e6522c;
   background-image: url("/assets/jumbotron-background.png");


### PR DESCRIPTION
This would look like this:

![stars](https://cloud.githubusercontent.com/assets/538008/14087175/f13c5f90-f528-11e5-8940-3e29531a7546.png)

The button doesn't immediately increment the stars (that's not possible unfortunately), but takes the user to the GitHub page, where they can click the button. The question is whether we still want to keep the other (explicit) link to GitHub then. I would say yes, because it is not obvious to the user that the star button also would just take them to GitHub.