### PR TITLE
Move GitHub star button to "Open Source" section.

### DIFF
--- a/content/css/docs.css
+++ b/content/css/docs.css
@@ -23,12 +23,6 @@ body {
   margin-left: 12px;
 }
 
-.navbar .github-stars {
-  margin: 15px 0 0 15px;
-  width: 100px;
-  height: 20px;
-}
-
 .navbar-toggle {
   margin-top: 22px;
 }
@@ -153,7 +147,7 @@ body {
 }
 
 .open-source {
-  margin: 25px 0 25px 0;
+  margin: 25px 0 20px 0;
   font-family: 'Lato', sans-serif;
   font-weight: 300;
   text-align: center;
@@ -168,6 +162,12 @@ body {
   width: 50%;
   margin: auto;
   font-size: 20px;
+}
+
+.open-source .github-stars {
+  margin-top: 20px;
+  width: 160px;
+  height: 30px;
 }
 
 .trusted-by {

--- a/content/index.html
+++ b/content/index.html
@@ -101,6 +101,7 @@ layout: jumbotron
     <div class="col-md-12">
       <h1><i class="fa fa-github"></i> Open Source</h1>
       <p>Prometheus is 100% open source and community-driven. All components are available under the <a href="http://www.apache.org/licenses/LICENSE-2.0">Apache 2 License</a> on <a href="https://github.com/prometheus">GitHub</a>.</p>
+      <iframe src="https://ghbtns.com/github-btn.html?user=prometheus&repo=prometheus&type=star&count=true&size=large" frameborder="0" scrolling="0" class="github-stars"></iframe>
     </div>
   </div>
 

--- a/layouts/header.html
+++ b/layouts/header.html
@@ -70,9 +70,6 @@
             <li><a href="/community/">Community</a></li>
             <li><a href="/blog/">Blog</a></li>
             <li><a href="https://github.com/prometheus"><i class="fa fa-github"></i> Github</a></li>
-            <li>
-              <iframe src="https://ghbtns.com/github-btn.html?user=prometheus&repo=prometheus&type=star&count=true" class="github-stars" frameborder="0" scrolling="0"></iframe>
-            </li>
           </ul>
         </div>
       </div>


### PR DESCRIPTION
As @grobie pointed out, there was some feedback that the "star button looks very needy and falls so much out of the "nice design"". I tend to agree. Also there was no noticeable uptake in GitHub stars since adding the button. Let's move it to the "Open Source" section at the bottom, where it will still give useful information to people (number of stars we already have), but less prominent.