### PR TITLE
Remove third-party blackbox exporter

### DIFF
--- a/content/docs/instrumenting/exporters.md
+++ b/content/docs/instrumenting/exporters.md
@@ -48,7 +48,6 @@ hosted outside of the Prometheus GitHub organization.
    * [Google's mtail log data extractor](https://github.com/google/mtail)
    * [Heka dashboard exporter](https://github.com/docker-infra/heka_exporter)
    * [Heka exporter](https://github.com/imgix/heka_exporter)
-   * [HTTP(s)/TCP/ICMP blackbox prober](https://github.com/discordianfish/blackbox_prober)
    * [IoT Edison exporter](https://github.com/roman-vynar/edison_exporter)
    * [Jenkins exporter](https://github.com/RobustPerception/python_examples/tree/master/jenkins_exporter)
    * [knxd exporter](https://github.com/RichiH/knxd_exporter)


### PR DESCRIPTION
Repository says it is deprecated and links to the official blackbox exporter.