### PR TITLE
Remove title case in exporter and clientlib guidelines.

### DIFF
--- a/content/docs/instrumenting/clientlib_guidelines.md
+++ b/content/docs/instrumenting/clientlib_guidelines.md
@@ -1,9 +1,9 @@
 ---
-title: Client Library Guidelines
+title: Client library guidelines
 sort_rank: 2
 ---
 
-# Client Library Guidelines
+# Client library guidelines
 
 This document covers what functionality and API Prometheus client libraries
 should offer, with the aim of consistency across libraries, making the easy use
@@ -295,7 +295,7 @@ except when a custom Collector is proxying from other
 instrumentation/monitoring systems. Generated/dynamic metric names are a sign
 that you should be using labels instead.
 
-### Metric description/help
+### Metric description and help
 
 Gauge/Counter/Summary/Histogram MUST require metric descriptions/help to be
 provided.
@@ -347,7 +347,7 @@ Client libraries are ENCOURAGED to offer ways that make it easy for users to
 unit-test their use of the instrumentation code. For example, the
 `CollectorRegistry.get_sample_value` in Python.
 
-## Packaging and Dependencies
+## Packaging and dependencies
 
 Ideally, a client library can be included in any application to add some
 instrumentation, without having to worry about it breaking the application.
@@ -362,7 +362,7 @@ separated from the bridges/exposition of metrics in a given format. For
 example, the Java simpleclient `simpleclient` module has no dependencies, and
 the `simpleclient_servlet` has the HTTP bits.
 
-## Performance Considerations
+## Performance considerations
 
 As client libraries must be thread-safe, some form of concurrency control is
 required and consideration must be given to performance on multi-core machines

--- a/content/docs/instrumenting/exporter_guidelines.md
+++ b/content/docs/instrumenting/exporter_guidelines.md
@@ -1,9 +1,9 @@
 ---
-title: Exporter Guidelines
+title: Exporter guidelines
 sort_rank: 5
 ---
 
-# Exporter Guidelines
+# Exporter guidelines
 
 When directly instrumenting your own code, the general rules of how to
 instrument code with a Prometheus client library can be followed quite
@@ -17,7 +17,7 @@ direct instrumentation.
 If you are writing an exporter and are unclear on anything here, contact us on
 IRC (#prometheus on Freenode) or the [mailing list](/community).
 
-## Maintainability and Purity
+## Maintainability and purity
 
 The main decision you need to make when writing an exporter is how much work
 you’re willing to put in to get perfect metrics out of it.
@@ -247,7 +247,7 @@ instrumentation system that has a way to decrement it (e.g. Dropwizard metrics)
 that’s not a counter - it’s a gauge. `UNTYPED` is probably the best type to use
 there, as `GAUGE` would be misleading if it were being used as a counter.
 
-### Help Strings
+### Help strings
 
 When you’re transforming metrics it’s useful for users to be able to track back
 to what the original was, and what rules were in play that caused that


### PR DESCRIPTION
We have opted for not using title case in headers in Prometheus docs.