### PR TITLE
Add missing "s" to {metric_,}relabel_config

### DIFF
--- a/content/blog/2015-06-01-advanced-service-discovery.md
+++ b/content/blog/2015-06-01-advanced-service-discovery.md
@@ -35,7 +35,7 @@ labels set by an earlier stage:
 1. Global labels, which are assigned to every target scraped by the Prometheus instance.
 2. The `job` label, which is configured as a default value for each scrape configuration.
 3. Labels that are set per target group within a scrape configuration.
-4. Advanced label manipulation via [_relabeling_](/docs/operating/configuration/#target-relabeling-relabel_config).
+4. Advanced label manipulation via [_relabeling_](/docs/operating/configuration/#relabel_configs).
 
 Each stage overwrites any colliding labels from the earlier stages. Eventually, we have a flat
 set of labels that describe a single target. Those labels are then attached to every time series that
@@ -76,7 +76,7 @@ scrape_configs:
       job: 'job2'
 ```
 
-Through a mechanism named [_relabeling_](http://prometheus.io/docs/operating/configuration/#target-relabeling-relabel_config),
+Through a mechanism named [_relabeling_](http://prometheus.io/docs/operating/configuration/#relabel_configs),
 any label can be removed, created, or modified on a per-target level. This
 enables fine-grained labeling that can also take into account metadata coming
 from the service discovery. Relabeling is the last stage of label assignment
@@ -124,7 +124,7 @@ This rule transforms a target with the label set:
 You could then also remove the source labels in an additional relabeling step.
 
 You can read more about relabeling and how you can use it to filter targets in the
-[configuration documentation](/docs/operating/configuration#target-relabeling-relabel_config).
+[configuration documentation](/docs/operating/configuration#relabel_configs).
 
 Over the next sections, we will see how you can leverage relabeling when using service discovery.
 
@@ -219,7 +219,7 @@ has the `production` or `canary` Consul tag, a respective `group` label is assig
 Each target's `instance` label is set to the node name provided by Consul.
 
 A full documentation of all configuration parameters for service discovery via Consul
-can be found on the [Prometheus website](/docs/operating/configuration#target-relabeling-relabel_config).
+can be found on the [Prometheus website](/docs/operating/configuration#relabel_configs).
 
 
 ## Custom service discovery

--- a/content/docs/operating/configuration.md
+++ b/content/docs/operating/configuration.md
@@ -241,7 +241,7 @@ A DNS-SD configuration allows specifying a set of DNS record names which
 are periodically queried to discover a list of targets (host-port pairs). The
 DNS servers to be contacted are read from `/etc/resolv.conf`.
 
-During the [relabeling phase](#target-relabeling-relabel_config), the meta
+During the [relabeling phase](#relabel_configs), the meta
 label `__meta_dns_name` is available on each target and is set to the SRV
 record name that produced the discovered target.
 
@@ -301,7 +301,7 @@ services:
 Note that the IP number and port used to scrape the targets is assembled as
 `<__meta_consul_address>:<__meta_consul_service_port>`. However, in some
 Consul setups, the relevant address is in `__meta_consul_service_address`.
-In those cases, you can use the [relabel](#target-relabeling-relabel_config)
+In those cases, you can use the [relabel](#relabel_configs)
 feature to replace the special `__address__` label.
 
 ### `<kubernetes_sd_config>`
@@ -530,7 +530,7 @@ As a fallback, the file contents are also re-read periodically at the specified
 refresh interval.
 
 Each target has a meta label `__meta_filepath` during the
-[relabeling phase](#target-relabeling-relabel_config). Its value is set to the
+[relabeling phase](#relabel_configs). Its value is set to the
 filepath from which the target was extracted.
 
 ```
@@ -546,7 +546,7 @@ Where `<filename_pattern>` may be a path ending in `.json`, `.yml` or `.yaml`. T
 may contain a single `*` that matches any character sequence, e.g. `my/path/tg_*.json`.
 
 
-### `<relabel_config>`
+### `<relabel_configs>`
 
 Relabeling is a powerful tool to dynamically rewrite the label set of a target before
 it gets scraped. Multiple relabeling steps can be configured per scrape configuration.
@@ -615,7 +615,7 @@ the `replace`, `keep`, `drop` and `labelmap` actions. The regex is fully anchore
    to label names given by `replacement` with match group references
   (`${1}`, `${2}`, ...) in `replacement` substituted by their value.
 
-### `<metric_relabel_config>`
+### `<metric_relabel_configs>`
 
 Metric relabeling is applied to samples as the last step before ingestion. It
 has the same configuration format and actions as target relabeling. Metric


### PR DESCRIPTION
Also fix references to anchors, which were already broken.