### PR TITLE
Fix logo and docs menu alignment.

### DIFF
--- a/content/css/docs.css
+++ b/content/css/docs.css
@@ -20,7 +20,6 @@ body {
   display: inline;
   margin-top: -5px;
   margin-right: 3px;
-  margin-left: 12px;
 }
 
 .navbar-toggle {
@@ -214,7 +213,7 @@ footer {
 
 .side-nav {
   margin-top: 20px;
-  padding: 5px 20px 20px 20px;
+  padding: 5px 20px 20px 0;
 }
 
 .side-nav .fa {


### PR DESCRIPTION
Instead of moving the logo to the right to align it with the docs
side-nav, remove the extraneous left-padding on the side-nav. Then the
logo is aligned with the text on all pages again.