### PR TITLE
Rename "X guidelines" docs to "Writing X"

### DIFF
--- a/content/docs/instrumenting/clientlibs.md
+++ b/content/docs/instrumenting/clientlibs.md
@@ -35,7 +35,7 @@ dependencies, you may also implement one of the supported [exposition
 formats](/docs/instrumenting/exposition_formats/) yourself to expose metrics.
 
 When implementing a new Prometheus client library, please follow the
-[Prometheus Client Library Guidelines](/docs/instrumenting/clientlib_guidelines).
+[guidelines on writing client libraries](/docs/instrumenting/writing_clientlibs).
 Note that this document is still a work in progress. Please also consider
 consulting the [development mailing list](https://groups.google.com/forum/#!forum/prometheus-developers).
 We are happy to give advice on how to make your library as useful and

--- a/content/docs/instrumenting/exporters.md
+++ b/content/docs/instrumenting/exporters.md
@@ -76,7 +76,7 @@ hosted outside of the Prometheus GitHub organization.
    * [Varnish exporter](https://github.com/jonnenauha/prometheus_varnish_exporter)
 
 When implementing a new Prometheus exporter, please follow the
-[Prometheus Exporter Guidelines](/docs/instrumenting/exporter_guidelines)
+[guidelines on writing exporters](/docs/instrumenting/writing_exporters)
 Please also consider consulting the [development mailing
 list](https://groups.google.com/forum/#!forum/prometheus-developers).  We are
 happy to give advice on how to make your exporter as useful and consistent as

--- a/content/docs/instrumenting/writing_clientlibs.md
+++ b/content/docs/instrumenting/writing_clientlibs.md
@@ -1,9 +1,9 @@
 ---
-title: Client library guidelines
+title: Writing client libraries
 sort_rank: 2
 ---
 
-# Client library guidelines
+# Writing client libraries
 
 This document covers what functionality and API Prometheus client libraries
 should offer, with the aim of consistency across libraries, making the easy use

--- a/content/docs/instrumenting/writing_exporters.md
+++ b/content/docs/instrumenting/writing_exporters.md
@@ -1,9 +1,9 @@
 ---
-title: Exporter guidelines
+title: Writing exporters
 sort_rank: 5
 ---
 
-# Exporter guidelines
+# Writing exporters
 
 When directly instrumenting your own code, the general rules of how to
 instrument code with a Prometheus client library can be followed quite


### PR DESCRIPTION
The meanings of "Client library guidelines" and "Exporter guidelines" are not
immediately clear. For example, it could mean the usage of client
libraries or exporters. I think "Writing client libraries" and "Writing
exporters" makes this clearer.

Alternative to "Writing": "Building"?