### PR TITLE
Simplify title of "Exporters and third-party integrations"

### DIFF
--- a/content/docs/instrumenting/exporters.md
+++ b/content/docs/instrumenting/exporters.md
@@ -1,9 +1,9 @@
 ---
-title: Exporters and third-party integrations
+title: Exporters and integrations
 sort_rank: 4
 ---
 
-# Exporters and third-party integrations
+# Exporters and integrations
 
 There are a number of libraries and servers which help in exporting existing
 metrics from third-party systems as Prometheus metrics. This is useful for


### PR DESCRIPTION
"Exporters and integrations" is easier to read in the menu, doesn't wrap
lines, and hopefully means the same thing to people.