### PR TITLE
Add yet another RabbitMQ Exporter

### DIFF
--- a/content/docs/instrumenting/exporters.md
+++ b/content/docs/instrumenting/exporters.md
@@ -67,6 +67,7 @@ hosted outside of the Prometheus GitHub organization.
    * [PostgreSQL exporter](https://github.com/wrouesnel/postgres_exporter)
    * [PowerDNS exporter](https://github.com/janeczku/powerdns_exporter)
    * [RabbitMQ exporter](https://github.com/kbudde/rabbitmq_exporter)
+   * [RabbitMQ Management Plugin exporter](https://github.com/deadtrickster/prometheus_rabbitmq_exporter)
    * [Rancher exporter](https://github.com/infinityworksltd/prometheus-rancher-exporter)
    * [Redis exporter](https://github.com/oliver006/redis_exporter)
    * [RethinkDB exporter](https://github.com/oliver006/rethinkdb_exporter)


### PR DESCRIPTION
So the differences with listed one (https://github.com/kbudde/rabbitmq_exporter) are:
 - prometheus_rabbitmq_exporter is not standalone daemon but a plugin for RabbitMQ itself. 
 - it also exports Erlang VM stats.

Also I tried to stay compatible with rabbitmq_exporter as much as possible (probably added a couple of labels)

Not sure that 'RabbitMQ Management Plugin exporter' makes said differences clear though :-)

Thank you