### PR TITLE
Add missing underscore to webhook_config variable

### DIFF
--- a/content/docs/alerting/configuration.md
+++ b/content/docs/alerting/configuration.md
@@ -357,7 +357,7 @@ api_key: <string>
 ```
 
 
-## Webhook receiver `<webhook config>`
+## Webhook receiver `<webhook_config>`
 
 The webhook receiver allows configuring a generic receiver. 
 


### PR DESCRIPTION
The webhook_config variable was missing an underscore in the documentation. 