### PR TITLE
add linkerd to directly-instrumented list

### DIFF
--- a/content/docs/instrumenting/exporters.md
+++ b/content/docs/instrumenting/exporters.md
@@ -98,6 +98,7 @@ separate exporters are needed:
    * [Etcd](https://github.com/coreos/etcd)
    * [Kubernetes-Mesos](https://github.com/mesosphere/kubernetes-mesos)
    * [Kubernetes](https://github.com/GoogleCloudPlatform/kubernetes)
+   * [linkerd](https://github.com/BuoyantIO/linkerd)
    * [RobustIRC](http://robustirc.net/)
    * [SkyDNS](https://github.com/skynetservices/skydns)
    * [Weave Flux](http://weaveworks.github.io/flux/)

--- a/content/docs/instrumenting/exporters.md
+++ b/content/docs/instrumenting/exporters.md
@@ -98,7 +98,7 @@ separate exporters are needed:
    * [Etcd](https://github.com/coreos/etcd)
    * [Kubernetes-Mesos](https://github.com/mesosphere/kubernetes-mesos)
    * [Kubernetes](https://github.com/GoogleCloudPlatform/kubernetes)
-   * [linkerd](https://github.com/BuoyantIO/linkerd)
+   * [Linkerd](https://github.com/BuoyantIO/linkerd)
    * [RobustIRC](http://robustirc.net/)
    * [SkyDNS](https://github.com/skynetservices/skydns)
    * [Weave Flux](http://weaveworks.github.io/flux/)


### PR DESCRIPTION
linker exports Prometheus metrics directly, currently on `:9990/admin/metrics/prometheus`. (See e.g. https://github.com/BuoyantIO/linkerd/blob/master/admin/src/main/scala/io/buoyant/admin/PrometheusStatsHandler.scala and https://github.com/BuoyantIO/linkerd/issues/396 for making this configurable.)
