### PR TITLE
Replaces deprecated `scrape_configs` in examples

### DIFF
--- a/content/docs/introduction/getting_started.md
+++ b/content/docs/introduction/getting_started.md
@@ -51,7 +51,7 @@ scrape_configs:
     # Override the global default and scrape targets from this job every 5 seconds.
     scrape_interval: 5s
 
-    target_groups:
+    static_configs:
       - targets: ['localhost:9090']
 ```
 
@@ -191,7 +191,7 @@ scrape_configs:
     # Override the global default and scrape targets from this job every 5 seconds.
     scrape_interval: 5s
 
-    target_groups:
+    static_configs:
       - targets: ['localhost:8080', 'localhost:8081']
         labels:
           group: 'production'
@@ -252,7 +252,7 @@ scrape_configs:
     # Override the global default and scrape targets from this job every 5 seconds.
     scrape_interval: 5s
 
-    target_groups:
+    static_configs:
       - targets: ['localhost:9090']
 
   - job_name:       'example-random'
@@ -260,7 +260,7 @@ scrape_configs:
     # Override the global default and scrape targets from this job every 5 seconds.
     scrape_interval: 5s
 
-    target_groups:
+    static_configs:
       - targets: ['localhost:8080', 'localhost:8081']
         labels:
           group: 'production'


### PR DESCRIPTION
According to https://prometheus.io/docs/operating/configuration/ the `target_groups` field was replaced by `static_configs`.