### PR TITLE
Add reference to PHP client library

### DIFF
--- a/content/docs/instrumenting/clientlibs.md
+++ b/content/docs/instrumenting/clientlibs.md
@@ -27,7 +27,7 @@ Unofficial third-party client libraries:
 * [Lua](https://github.com/knyar/nginx-lua-prometheus) for Nginx
 * [.NET / C#](https://github.com/andrasm/prometheus-net)
 * [Node.js](https://github.com/siimon/prom-client)
-* [PHP] (https://github.com/Jimdo/prometheus_client_php)
+* [PHP](https://github.com/Jimdo/prometheus_client_php)
 
 When Prometheus scrapes your instance's HTTP endpoint, the client library
 sends the current state of all tracked metrics to the server.

--- a/content/docs/instrumenting/clientlibs.md
+++ b/content/docs/instrumenting/clientlibs.md
@@ -27,6 +27,7 @@ Unofficial third-party client libraries:
 * [Lua](https://github.com/knyar/nginx-lua-prometheus) for Nginx
 * [.NET / C#](https://github.com/andrasm/prometheus-net)
 * [Node.js](https://github.com/siimon/prom-client)
+* [PHP] (https://github.com/Jimdo/prometheus_client_php)
 
 When Prometheus scrapes your instance's HTTP endpoint, the client library
 sends the current state of all tracked metrics to the server.


### PR DESCRIPTION
This adds a link to our PHP client [library](https://github.com/Jimdo/prometheus_client_php).