### PR TITLE
Point to better Jenkins exporter

### DIFF
--- a/content/docs/instrumenting/exporters.md
+++ b/content/docs/instrumenting/exporters.md
@@ -53,7 +53,7 @@ hosted outside of the Prometheus GitHub organization.
    * [Heka dashboard exporter](https://github.com/docker-infra/heka_exporter)
    * [Heka exporter](https://github.com/imgix/heka_exporter)
    * [IoT Edison exporter](https://github.com/roman-vynar/edison_exporter)
-   * [Jenkins exporter](https://github.com/RobustPerception/python_examples/tree/master/jenkins_exporter)
+   * [Jenkins exporter](https://github.com/lovoo/jenkins_exporter)
    * [knxd exporter](https://github.com/RichiH/knxd_exporter)
    * [Meteor JS web framework exporter](https://atmospherejs.com/sevki/prometheus-exporter)
    * [Minecraft exporter module](https://github.com/Baughn/PrometheusIntegration)


### PR DESCRIPTION
The RP jenkins exporter is meant mainly as a simple example of an exporter. The Lovoo version builds on this.