### PR TITLE
file_sd_config: Correct refresh_interval to 5m

### DIFF
--- a/content/docs/operating/configuration.md
+++ b/content/docs/operating/configuration.md
@@ -419,7 +419,7 @@ files:
   [ - <filename_pattern> ... ]
 
 # Refresh interval to re-read the files.
-[ refresh_interval: <duration> | default = 30s ]
+[ refresh_interval: <duration> | default = 5m ]
 ```
 
 Where `<filename_pattern>` may be a path ending in `.json`, `.yml` or `.yaml`. The last path segment


### PR DESCRIPTION
The actual default is 5 minutes:
https://github.com/prometheus/prometheus/blob/ee9abf4535d2a28feb14473716e9118b4e12741b/config/config.go#L106

This was changed in prometheus/prometheus@139f27bf8.

/cc @fabxc 