### PR TITLE
Added Docker Hub exporter to list of third-party exporters

### DIFF
--- a/content/docs/instrumenting/exporters.md
+++ b/content/docs/instrumenting/exporters.md
@@ -48,6 +48,7 @@ hosted outside of the Prometheus GitHub organization.
    * [Ceph exporter](https://github.com/digitalocean/ceph_exporter)
    * [CouchDB exporter](https://github.com/gesellix/couchdb-exporter)
    * [Django exporter](https://github.com/korfuri/django-prometheus)
+   * [Docker Hub exporter](https://github.com/infinityworksltd/docker-hub-exporter)
    * [Google's mtail log data extractor](https://github.com/google/mtail)
    * [Grok exporter](https://github.com/fstab/grok_exporter)
    * [Heka dashboard exporter](https://github.com/docker-infra/heka_exporter)


### PR DESCRIPTION
Adding details of a simple Docker Hub exporter for tracking statistics about pulls/stars etc