### PR TITLE
Added GitHub Exporter to documentation

### DIFF
--- a/content/docs/instrumenting/exporters.md
+++ b/content/docs/instrumenting/exporters.md
@@ -49,6 +49,7 @@ hosted outside of the Prometheus GitHub organization.
    * [CouchDB exporter](https://github.com/gesellix/couchdb-exporter)
    * [Django exporter](https://github.com/korfuri/django-prometheus)
    * [Docker Hub exporter](https://github.com/infinityworksltd/docker-hub-exporter)
+   * [GitHub exporter](https://github.com/infinityworksltd/github-exporter)
    * [Google's mtail log data extractor](https://github.com/google/mtail)
    * [Grok exporter](https://github.com/fstab/grok_exporter)
    * [Heka dashboard exporter](https://github.com/docker-infra/heka_exporter)


### PR DESCRIPTION
As per title, similar to the recent Docker Hub Exporter, likely to be extended with more metrics in the coming weeks. Any feedback appreciated, happy to amend if i've strayed from guidelines anywhere.