### PR TITLE
Change vector.im -> riot.im on Community page

### DIFF
--- a/content/community.html
+++ b/content/community.html
@@ -11,7 +11,7 @@ title: Community
     <p>
       <strong>IRC:</strong>
       <a href="https://webchat.freenode.net/?channels=#prometheus"><code>#prometheus</code></a> on <a href="http://freenode.net/">irc.freenode.net</a>
-      (for the easiest start, <a href="https://vector.im/beta/#/room/#freenode_#prometheus:matrix.org">join via Vector</a>)
+      (for the easiest start, <a href="https://riot.im/app/#/room/#freenode_#prometheus:matrix.org">join via Riot</a>)
     </p>
     <p>
       <strong>Mailing list:</strong>


### PR DESCRIPTION
Vector is Riot now, see:

https://techcrunch.com/2016/09/19/riot-wants-to-be-like-slack-but-with-the-flexibility-of-an-underlying-open-source-platform/