### PR TITLE
Add Prometheus-Talk @ MRMCD 2016

### DIFF
--- a/content/docs/introduction/media.md
+++ b/content/docs/introduction/media.md
@@ -37,6 +37,7 @@ with Prometheus.
 * [Prometheus workshop](https://vimeo.com/131581353) – Jamie Wilkinson at Monitorama PDX 2015 ([slides](https://docs.google.com/presentation/d/1X1rKozAUuF2MVc1YXElFWq9wkcWv3Axdldl8LOH9Vik/edit)).
 * [Monitoring Hadoop with Prometheus](https://www.youtube.com/watch?v=qs2sqOLNGtw) – Brian Brazil at the Hadoop User Group Ireland ([slides](http://www.slideshare.net/brianbrazil/monitoring-hadoop-with-prometheus-hadoop-user-group-ireland-december-2015)).
 * In German: [Monitoring mit Prometheus](https://media.ccc.de/v/eh16-43-monitoring_mit_prometheus#video&t=2804) – Michael Stapelberg at [Easterhegg 2016](https://eh16.easterhegg.eu/).
+* In German: [Prometheus in der Praxis](https://media.ccc.de/v/MRMCD16-7754-prometheus_in_der_praxis) – Jonas Große Sundrup at [MRMCD 2016](https://2016.mrmcd.net/en/)
 
 ## Presentation slides
 


### PR DESCRIPTION
@juliusv 

Adds the "Prometheus in practice"-Talk on MRMCD 2016 to the list of talks in the media-section of the introduction.