### PR TITLE
Fix `label_replace` documentation

### DIFF
--- a/content/docs/querying/functions.md
+++ b/content/docs/querying/functions.md
@@ -248,8 +248,7 @@ src_label string, regex string)`  matches the regular expression `regex` against
 the label `src_label`.  If it matches, then the timeseries is returned with the
 label `dst_label` replaced by the expansion of `replacement`. `$1` is replaced
 with the first matching subgroup, `$2` with the second etc. If the regular
-expression doesn't match then the timeseries is not returned.
-
+expression doesn't match then the timeseries is returned unchanged.
 
 This example will return a vector with each time series having a `foo`
 label with the value `a` added to it:


### PR DESCRIPTION
With the fix in place, the documentation is in line with the intention
expressed by tests,
e.g. https://github.com/prometheus/prometheus/blob/master/promql/testdata/functions.test#L173-L176
and
https://github.com/prometheus/prometheus/blob/master/promql/testdata/functions.test#L195-L199
.
@brian-brazil , master of labels.
@brapse for your information.