### PR TITLE
Fix download page problems

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -13,3 +13,7 @@ gem 'rb-inotify', :require => false
 gem 'rb-fsevent', :require => false
 gem 'rb-fchange', :require => false
 gem 'nanoc-cachebuster'
+
+group :test do
+  gem 'rspec'
+end

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -10,6 +10,7 @@ GEM
     colored (1.2)
     cri (2.6.1)
       colored (~> 1.2)
+    diff-lcs (1.2.5)
     em-websocket (0.5.1)
       eventmachine (>= 0.12.9)
       http_parser.rb (~> 0.6.0)
@@ -61,6 +62,19 @@ GEM
     rb-inotify (0.9.5)
       ffi (>= 0.5.0)
     redcarpet (3.2.0)
+    rspec (3.5.0)
+      rspec-core (~> 3.5.0)
+      rspec-expectations (~> 3.5.0)
+      rspec-mocks (~> 3.5.0)
+    rspec-core (3.5.4)
+      rspec-support (~> 3.5.0)
+    rspec-expectations (3.5.0)
+      diff-lcs (>= 1.2.0, < 2.0)
+      rspec-support (~> 3.5.0)
+    rspec-mocks (3.5.0)
+      diff-lcs (>= 1.2.0, < 2.0)
+      rspec-support (~> 3.5.0)
+    rspec-support (3.5.0)
     slop (3.6.0)
     thor (0.19.1)
     timers (4.0.1)
@@ -84,3 +98,7 @@ DEPENDENCIES
   rb-fsevent
   rb-inotify
   redcarpet
+  rspec
+
+BUNDLED WITH
+   1.11.2

--- a/lib/helpers/download.rb
+++ b/lib/helpers/download.rb
@@ -100,18 +100,22 @@ module Downloads
       'Binary'
     end
 
-    # TODO(ts): validate
     def os
-      name.split('.')[3].split('-').first
+      base_name.split('.').last.split('-').first
     end
 
-    # TODO(ts): validate
     def arch
-      name.split('.')[3].split('-').last
+      base_name.split('.').last.split('-').last
     end
 
     def size
       @data['size']
+    end
+
+    private
+
+    def base_name
+      name.chomp('.tar.gz').chomp('.zip')
     end
   end
 

--- a/specs/download_spec.rb
+++ b/specs/download_spec.rb
@@ -1,0 +1,30 @@
+require 'rspec'
+require 'helpers/download'
+
+describe Downloads::Asset do
+  let(:asset) do
+    Downloads::Asset.new({
+      'name' => ' prometheus-1.2.0.freebsd-armv5.tar.gz',
+    })
+  end
+
+  let(:beta) do
+    Downloads::Asset.new({
+      'name' => 'alertmanager-0.5.0-beta.0.darwin-amd64.tar.gz',
+    })
+  end
+
+  describe '#os' do
+    it 'extracts the operating system name' do
+      expect(asset.os).to eql('freebsd')
+      expect(beta.os).to eql('darwin')
+    end
+  end
+
+  describe '#arch' do
+    it 'extracts the architecture' do
+      expect(asset.arch).to eql('armv5')
+      expect(beta.arch).to eql('amd64')
+    end
+  end
+end

--- a/static/docs.js
+++ b/static/docs.js
@@ -48,7 +48,7 @@ $(document).ready(function() {
 
   selectDownloads();
 
-  $('.download-selection a').on('click', function() {
+  $('.download-selection a').on('click', function(event) {
     event.preventDefault();
 
     $(this).parents('.btn-group').find('button .caption').text($(this).text());


### PR DESCRIPTION
The download page currently doesn't parse correctly pre-release assets containing dots. A recent javascript (dependency?) also broke the dropdown.

@juliusv @beorn7 