### PR TITLE
Add apcupsd exporter to exporters list

### DIFF
--- a/content/docs/instrumenting/exporters.md
+++ b/content/docs/instrumenting/exporters.md
@@ -53,6 +53,7 @@ hosted outside of the Prometheus GitHub organization.
    * [SQL query result set metrics exporter](https://github.com/chop-dbhi/prometheus-sql)
 
 ### Hardware related
+   * [apcupsd exporter](https://github.com/mdlayher/apcupsd_exporter)
    * [IoT Edison exporter](https://github.com/roman-vynar/edison_exporter)
    * [IPMI exporter](https://github.com/lovoo/ipmi_exporter)
    * [knxd exporter](https://github.com/RichiH/knxd_exporter)
@@ -75,7 +76,7 @@ hosted outside of the Prometheus GitHub organization.
    * [Passenger exporter](https://github.com/stuartnelson3/passenger_exporter)
    * [Varnish exporter](https://github.com/jonnenauha/prometheus_varnish_exporter)
    * [WebDriver exporter](https://github.com/mattbostock/webdriver_exporter)
-   
+
 ### APIs
    * [Docker Hub exporter](https://github.com/infinityworksltd/docker-hub-exporter)
    * [GitHub exporter](https://github.com/infinityworksltd/github-exporter)
@@ -86,7 +87,7 @@ hosted outside of the Prometheus GitHub organization.
 ### Logging
    * [Google's mtail log data extractor](https://github.com/google/mtail)
    * [Grok exporter](https://github.com/fstab/grok_exporter)
-   
+
 ### Other monitoring systems
    * [Cloud Foundry Firehose exporter](https://github.com/cloudfoundry-community/firehose_exporter)
    * [scollector exporter](https://github.com/tgulacsi/prometheus_scollector)


### PR DESCRIPTION
Adds my exporter for communicating with `apcupsd`, which talks to APC UPSes to pull power information.

My editor also removed a bit of trailing whitespace.