### PR TITLE
Add lmsensors exporter to exporters list

### DIFF
--- a/content/docs/instrumenting/exporters.md
+++ b/content/docs/instrumenting/exporters.md
@@ -58,6 +58,7 @@ hosted outside of the Prometheus GitHub organization.
    * [IoT Edison exporter](https://github.com/roman-vynar/edison_exporter)
    * [IPMI exporter](https://github.com/lovoo/ipmi_exporter)
    * [knxd exporter](https://github.com/RichiH/knxd_exporter)
+   * [lmsensors exporter](https://github.com/mdlayher/lmsensors_exporter)
    * [Ubiquiti UniFi exporter](https://github.com/mdlayher/unifi_exporter)
 
 ### Messaging systems


### PR DESCRIPTION
I put this in the hardware section since I guess reading sensor data counts as "hardware"?  Feel free to suggest alternate categories.