### PR TITLE
Fix typos.

### DIFF
--- a/content/blog/2015-06-01-advanced-service-discovery.md
+++ b/content/blog/2015-06-01-advanced-service-discovery.md
@@ -90,7 +90,7 @@ Relabeling works as follows:
 - A regular expression is matched against the resulting string.
 - A new value based on those matches is assigned to another label.
 
-Mutiple relabeling rules can be defined for each scrape configuration. A simple one
+Multiple relabeling rules can be defined for each scrape configuration. A simple one
 that squashes two labels into one, looks as follows:
 
 ```

--- a/content/blog/2016-03-03-custom-alertmanager-templates.md
+++ b/content/blog/2016-03-03-custom-alertmanager-templates.md
@@ -20,7 +20,7 @@ ones.
 In this blog post, we will walk through a simple customization of Slack
 notifications.
 
-We use this simple Alertmanager configuartion that sends all alerts to Slack:
+We use this simple Alertmanager configuration that sends all alerts to Slack:
 
 ```yaml
 global:

--- a/content/blog/2016-09-07-interview-with-shuttlecloud.md
+++ b/content/blog/2016-09-07-interview-with-shuttlecloud.md
@@ -5,7 +5,7 @@ kind: article
 author_name: Brian Brazil
 ---
 
-*Continuing our series of interviews with users of Prometheus, ShuttleCloud talks about how they began using Promethus. Ignacio from ShuttleCloud also explained how [Prometheus Is Good for Your Small Startup](https://www.youtube.com/watch?v=gMHa4Yh8avk) at PromCon 2016.*
+*Continuing our series of interviews with users of Prometheus, ShuttleCloud talks about how they began using Prometheus. Ignacio from ShuttleCloud also explained how [Prometheus Is Good for Your Small Startup](https://www.youtube.com/watch?v=gMHa4Yh8avk) at PromCon 2016.*
 
 ## What does ShuttleCloud do?
 

--- a/content/docs/alerting/clients.md
+++ b/content/docs/alerting/clients.md
@@ -12,7 +12,7 @@ recommended to configure alerting rules in Prometheus based on time series
 data rather than implementing a direct client.__
 
 The Alertmanager listens for alerts on an API endpoint at `/api/v1/alerts`.
-Clients are expected to continously re-send alerts as long as they are still
+Clients are expected to continuously re-send alerts as long as they are still
 active (usually on the order of 30 seconds to 3 minutes).
 Clients can push a list of alerts to that endpoint via a POST request of
 the following format:

--- a/content/docs/alerting/configuration.md
+++ b/content/docs/alerting/configuration.md
@@ -105,7 +105,7 @@ It then traverses the child nodes. If `continue` is set to false, it stops
 after the first matching child. If `continue` is true on a matching node, the
 alert will continue matching against subsequent siblings.
 If an alert does not match any children of a node (no matching child nodes, or
-none exist), the alert is handled based on the configuration paramters of the
+none exist), the alert is handled based on the configuration parameters of the
 current node.
 
 

--- a/content/docs/instrumenting/writing_exporters.md
+++ b/content/docs/instrumenting/writing_exporters.md
@@ -127,7 +127,7 @@ prefix on to these if they follow the [matching
 semantics](https://docs.google.com/document/d/1Q0MXWdwp1mdXCzNRak6bW5LLVylVRXhdi7_21Sg15xQ/edit).
 E.g. Prometheus has `scrape_duration_seconds` for how long a scrape took, it’s
 good practice to have e.g. `jmx_scrape_duration_seconds` saying how long the
-JMX collector took to do it’s thing. For process stats where you have access to
+JMX collector took to do its thing. For process stats where you have access to
 the pid, both Go and Python offer collectors that’ll handle this for you (see
 the [haproxy exporter](https://github.com/prometheus/haproxy_exporter) for an
 example).
@@ -172,7 +172,7 @@ it’s easier to use them that way.
 The rule of thumb is that one metric should make sense when summed or averaged.
 There is one other case that comes up with exporters, and that’s where the data
 is fundamentally tabular and doing otherwise would require users to do regexes
-on metric names to be useable. Consider the voltage sensors on your
+on metric names to be usable. Consider the voltage sensors on your
 motherboard, while doing math across them is meaningless, it makes sense to
 have them in one metric rather than having one metric per sensor. All values
 within a metrics should (almost) always have the same unit (consider if fan
@@ -452,7 +452,7 @@ A user may have many exporters and Prometheus components on the same machine,
 so to make that easier each has a unique port number.
 
 [https://github.com/prometheus/prometheus/wiki/Default-port-allocations](https://github.com/prometheus/prometheus/wiki/Default-port-allocations)
-is where we track them, this is publically editable.
+is where we track them, this is publicly editable.
 
 Feel free to grab the next free port number when developing your exporter,
 preferably before publicly announcing it. If you’re not ready to release yet,

--- a/content/docs/introduction/faq.md
+++ b/content/docs/introduction/faq.md
@@ -121,7 +121,7 @@ Currently, the following external systems are supported:
 
 ### Can I create dashboards?
 
-Yes, we recomend [Grafana](/docs/visualization/grafana/) for production usage. [PromDash](/docs/visualization/promdash/) and [Console templates](/docs/visualization/consoles/) also exist.
+Yes, we recommend [Grafana](/docs/visualization/grafana/) for production usage. [PromDash](/docs/visualization/promdash/) and [Console templates](/docs/visualization/consoles/) also exist.
 
 ### Can I change the timezone? Why is everything in UTC?
 

--- a/content/docs/introduction/roadmap.md
+++ b/content/docs/introduction/roadmap.md
@@ -36,7 +36,7 @@ GitHub issue: [#398](https://github.com/prometheus/prometheus/issues/398)
 ### Server-side metric metadata support
 
 At this time, metric types and other metadata are only used in the
-client libaries and in the exposition format, but not persisted or
+client libraries and in the exposition format, but not persisted or
 utilized in the Prometheus server. We plan on making use of this
 metadata in the future. For example, we could suggest automatic rates
 over counters, warn users if they take the rate of a gauge, or display

--- a/content/docs/practices/rules.md
+++ b/content/docs/practices/rules.md
@@ -33,7 +33,7 @@ doing division, separate the metrics using `_per_` and call the operation
 
 When aggregating up ratios, aggregate up the numerator and denominator
 separately and then divide. Do not take the average of a ratio or average of an
-average as that is not statstically valid.
+average as that is not statistically valid.
 
 When aggregating up the `_count` and `_sum` of a Summary and dividing to
 calculate average observation size, treating it as a ratio would be unwieldy.

--- a/content/docs/querying/operators.md
+++ b/content/docs/querying/operators.md
@@ -248,4 +248,4 @@ highest to lowest.
 
 Operators on the same precedence level are left-associative. For example,
 `2 * 3 % 2` is equivalent to `(2 * 3) % 2`. However `^` is right associative,
-so `2 * 3 ^ 2` is equivilent to `2 * (3 ^ 2)`.
+so `2 * 3 ^ 2` is equivalent to `2 * (3 ^ 2)`.


### PR DESCRIPTION
Also a couple of non-typos: its vs it's and publically vs publicly.

I'm not attached to publically vs publicly though the latter seems more common.