### PR TITLE
Move prometheus-clj to client libraries

### DIFF
--- a/content/docs/instrumenting/clientlibs.md
+++ b/content/docs/instrumenting/clientlibs.md
@@ -22,6 +22,7 @@ Unofficial third-party client libraries:
 
 * [Bash](https://github.com/aecolley/client_bash)
 * [C++](https://github.com/jupp0r/prometheus-cpp)
+* [Clojure](https://github.com/soundcloud/prometheus-clj)
 * [Common Lisp](https://github.com/deadtrickster/prometheus.cl)
 * [Elixir](https://github.com/deadtrickster/prometheus.ex)
 * [Erlang](https://github.com/deadtrickster/prometheus.erl)

--- a/content/docs/instrumenting/exporters.md
+++ b/content/docs/instrumenting/exporters.md
@@ -134,7 +134,6 @@ make use of one of the normal Prometheus client libraries under the hood. As
 for all independently maintained software, we cannot vet all of them for best
 practices.
 
-   * Clojure: [prometheus-clj](https://github.com/soundcloud/prometheus-clj)
    * Go: [go-metrics instrumentation library](https://github.com/armon/go-metrics)
    * Go: [gokit](https://github.com/peterbourgon/gokit)
    * Java/JVM: [Hystrix metrics publisher](https://github.com/soundcloud/prometheus-hystrix)


### PR DESCRIPTION
@brian-brazil While a wrapper, it's still a client library and not an exporter, no?