### PR TITLE
Kubernetes SD: Remove references to `in_cluster`

### DIFF
--- a/content/docs/operating/configuration.md
+++ b/content/docs/operating/configuration.md
@@ -610,12 +610,10 @@ basic_auth:
 # Optional bearer token authentication information.
 [ bearer_token: <string> ]
 
-# Optional bearer token file authentication information. If running in a pod,
-# then it is best to use a service account and set in_cluster to true.
+# Optional bearer token file authentication information.
 [ bearer_token_file: <filename> ]
 
-# TLS configuration. If running in a pod, then it is best to use a service
-# account and set in_cluster to true.
+# TLS configuration.
 tls_config:
   [ <tls_config> ]
 ```


### PR DESCRIPTION
`in_cluster` doesn't exist anymore, and the comment for the
`api_server` config option already explains how in-cluster auth works.

@fabxc @brancz Same story as https://github.com/prometheus/prometheus/pull/2235