### PR TITLE
Correcting bucket for 95th percentile

### DIFF
--- a/content/docs/practices/histograms.md
+++ b/content/docs/practices/histograms.md
@@ -154,7 +154,7 @@ sharp spike at 220ms. In the Prometheus histogram metric as configured
 above, almost all observations, and therefore also the 95th percentile,
 will fall into the bucket labeled `{le="0.3"}`, i.e. the bucket from
 200ms to 300ms. The histogram implementation guarantees that the true
-95th percentile is somewhere between 100ms and 200ms. To return a
+95th percentile is somewhere between 200ms and 300ms. To return a
 single value (rather than an interval), it applies linear
 interpolation, which yields 295ms in this case. The calculated
 quantile gives you the impression that you are close to breaking the


### PR DESCRIPTION
Please correct me if I am wrong but with most requests at 220ms, the true histogram should return 200-300ms bucket for 95th percentile.

cc @juliusv 