### PR TITLE
Add Tarantool to the list of exporters

### DIFF
--- a/content/docs/instrumenting/clientlibs.md
+++ b/content/docs/instrumenting/clientlibs.md
@@ -27,6 +27,7 @@ Unofficial third-party client libraries:
 * [Erlang](https://github.com/deadtrickster/prometheus.erl)
 * [Haskell](https://github.com/fimad/prometheus-haskell)
 * [Lua](https://github.com/knyar/nginx-lua-prometheus) for Nginx
+* [Lua](https://github.com/tarantool/prometheus) for Tarantool
 * [.NET / C#](https://github.com/andrasm/prometheus-net)
 * [Node.js](https://github.com/siimon/prom-client)
 * [PHP](https://github.com/Jimdo/prometheus_client_php)

--- a/content/docs/instrumenting/exporters.md
+++ b/content/docs/instrumenting/exporters.md
@@ -37,6 +37,7 @@ wide variety of JVM-based applications, for example [Kafka](http://kafka.apache.
    * [Redis exporter](https://github.com/oliver006/redis_exporter)
    * [RethinkDB exporter](https://github.com/oliver006/rethinkdb_exporter)
    * [SQL query result set metrics exporter](https://github.com/chop-dbhi/prometheus-sql)
+   * [Tarantool metric library](https://github.com/tarantool/prometheus)
 
 ### Hardware related
    * [apcupsd exporter](https://github.com/mdlayher/apcupsd_exporter)


### PR DESCRIPTION
Tarantool is a fast in-memory database and an application
server for Lua apps.

Homepage: https://tarantool.org