### PR TITLE
Fix for overlapping text in feature item headings.

### DIFF
--- a/content/css/docs.css
+++ b/content/css/docs.css
@@ -115,6 +115,8 @@ body {
   font-weight: 300;
   font-size: 25px;
   white-space: nowrap;
+  overflow: hidden;
+  text-overflow: ellipsis;
 }
 
 .feature-item .fa {


### PR DESCRIPTION
Only happens in certain window sizes.