### PR TITLE
Document time range parameters to /api/v1/series

### DIFF
--- a/content/docs/querying/api.md
+++ b/content/docs/querying/api.md
@@ -198,6 +198,8 @@ URL query parameters:
 
 - `match[]=<series_selector>`: Repeated series selector argument that selects the
   series to return. At least one `match[]` argument must be provided.
+- `start=<rfc3339 | unix_timestamp>`: Start timestamp.
+- `end=<rfc3339 | unix_timestamp>`: End timestamp.
 
 The `data` section of the query result consists of a list of objects that
 contain the label name/value pairs which identify each series.


### PR DESCRIPTION
start and end parameters were added to the series API endpoint in prometheus/prometheus#1625 (see prometheus/prometheus#1542). This updates the online documentation to document this extremely useful feature