### PR TITLE
Community: Add section to discourage 1:1 support queries

### DIFF
--- a/content/community.html
+++ b/content/community.html
@@ -27,6 +27,14 @@ title: Community
     <p>
       <strong>Issue tracker:</strong> We use the GitHub issue tracker for the various <a href="http://github.com/prometheus">Prometheus repositories</a>
     </p>
+    <p>
+      <em>Please do not ask individual project members for
+      support. Use the channels above instead, where the whole
+      community can help you and benefit from the solutions
+      provided. If community support is insufficient for your
+      situation, please refer to the Commercial Support section
+      below.</em>
+    </p>
 
     <h1>Contributing</h1>
     <p>


### PR DESCRIPTION
I find myself quite often in the situation where I have to tell people
what I'm adding here. Even if not all will read it, it is then easy to
point people to it.

@brian-brazil @fabxc @juliusv Does this make sense?