### PR TITLE
Several minor changes as discussed earlier

### DIFF
--- a/content/community.html
+++ b/content/community.html
@@ -16,7 +16,7 @@ title: Community
     <p>
       <strong>Mailing lists:</strong>
       <ul>
-        <li><a href="https://groups.google.com/forum/#!forum/prometheus-users">prometheus-users</a> – for discussions around Prometheus usage</li>
+        <li><a href="https://groups.google.com/forum/#!forum/prometheus-users">prometheus-users</a> – for discussions around Prometheus usage and community support</li>
         <li><a href="https://groups.google.com/forum/#!forum/prometheus-developers">prometheus-developers</a> – for discussions around Prometheus development</li>
       </ul>
     </p>
@@ -25,7 +25,12 @@ title: Community
       <a href="https://twitter.com/PrometheusIO">@PrometheusIO</a>
     </p>
     <p>
-      <strong>Issue tracker:</strong> We use the GitHub issue tracker for the various <a href="http://github.com/prometheus">Prometheus repositories</a>
+      <strong>Issue tracker:</strong> Use the GitHub issue tracker
+      for the various <a href="http://github.com/prometheus">Prometheus
+      repositories</a> to file bugs and features request.
+      If you need support, please send your questions to the
+      <a href="https://groups.google.com/forum/#!forum/prometheus-users">prometheus-users</a>
+      mailing list rather than filing a GitHub issue.
     </p>
     <p>
       <em>Please do not ask individual project members for

--- a/content/index.html
+++ b/content/index.html
@@ -13,7 +13,7 @@ layout: jumbotron
 </div>
 
 <div class="newsbar">
-  Want to help improve our docs?&nbsp;&nbsp;—&nbsp;&nbsp;<a href="https://groups.google.com/forum/#!topic/prometheus-users/ExE2L7nViVc">We are looking for freelancers!</a>
+  <a href="http://events.linuxfoundation.org/events/cloudnativecon-and-kubecon-europe">CloudNativeCon Europe 2017</a> (March 29–30) with a dedicated <a href="https://cloudnativeeu2017.sched.com/overview/type/Prometheus">Prometheus track</a>.
 </div>
 
 <div class="container">


### PR DESCRIPTION
@grobie told us about the doc-writer hiring being on hold right now, so let's replace it by more relevant news. (I picked CloudNativeCon. Open for suggestions, though. We could also just remove the news bar.)

Following comments by @brian-brazil , I tried to find a nice wording to discourage support requests as GitHub issues.

@juliusv @fabxc you might be interested in this, too.