### PR TITLE
bearer_token, bearer_token_file for Marathon SD

### DIFF
--- a/content/docs/operating/configuration.md
+++ b/content/docs/operating/configuration.md
@@ -662,6 +662,12 @@ See below for the configuration options for Marathon discovery:
 servers:
   - <string>
 
+# Optional bearer token authentication information.
+  [ bearer_token: <string> ]
+
+# Optional bearer token file authentication information.
+  [ bearer_token_file: <filename>
+
 # Polling interval
 [ refresh_interval: <duration> | default = 30s ]
 ```

--- a/content/docs/operating/configuration.md
+++ b/content/docs/operating/configuration.md
@@ -663,9 +663,11 @@ servers:
   - <string>
 
 # Optional bearer token authentication information.
+# It is mutually exclusive with `bearer_token_file`.
 [ bearer_token: <string> ]
 
 # Optional bearer token file authentication information.
+# It is mutually exclusive with `bearer_token`.
 [ bearer_token_file: <filename>
 
 # Polling interval

--- a/content/docs/operating/configuration.md
+++ b/content/docs/operating/configuration.md
@@ -668,7 +668,7 @@ servers:
 
 # Optional bearer token file authentication information.
 # It is mutually exclusive with `bearer_token`.
-[ bearer_token_file: <filename>
+[ bearer_token_file: <filename> ]
 
 # Polling interval
 [ refresh_interval: <duration> | default = 30s ]

--- a/content/docs/operating/configuration.md
+++ b/content/docs/operating/configuration.md
@@ -663,10 +663,10 @@ servers:
   - <string>
 
 # Optional bearer token authentication information.
-  [ bearer_token: <string> ]
+[ bearer_token: <string> ]
 
 # Optional bearer token file authentication information.
-  [ bearer_token_file: <filename>
+[ bearer_token_file: <filename>
 
 # Polling interval
 [ refresh_interval: <duration> | default = 30s ]


### PR DESCRIPTION
Reflect the possibility to include bearer_token or bearer_token_file for Marathon SD