### PR TITLE
Installation: mention Puppet module

### DIFF
--- a/content/docs/introduction/install.md
+++ b/content/docs/introduction/install.md
@@ -93,6 +93,10 @@ Chef:
 
 * [rayrod2030/chef-prometheus](https://github.com/rayrod2030/chef-prometheus)
 
+Puppet:
+
+* [puppet/prometheus](https://forge.puppet.com/puppet/prometheus)
+
 SaltStack:
 
 * [bechtoldt/saltstack-prometheus-formula](https://github.com/bechtoldt/saltstack-prometheus-formula)


### PR DESCRIPTION
The puppet prometheus module works fine with the current version of prometheus.