### PR TITLE
Removing FlowDock reference

### DIFF
--- a/content/docs/introduction/faq.md
+++ b/content/docs/introduction/faq.md
@@ -114,7 +114,6 @@ Currently, the following external systems are supported:
 * [HipChat](https://www.hipchat.com/)
 * [Slack](https://slack.com/)
 * [Pushover](https://pushover.net/)
-* [Flowdock](https://www.flowdock.com/)
 
 ### Can I create dashboards?
 


### PR DESCRIPTION
FlowDock integration is not currently supported in .5 version of AM.

See https://github.com/prometheus/alertmanager/issues/236