### PR TITLE
Add custom exporter

### DIFF
--- a/content/docs/instrumenting/exporters.md
+++ b/content/docs/instrumenting/exporters.md
@@ -108,6 +108,7 @@ wide variety of JVM-based applications, for example [Kafka](http://kafka.apache.
    * [BIND exporter](https://github.com/digitalocean/bind_exporter)
    * [Blackbox exporter](https://github.com/prometheus/blackbox_exporter) (**official**)
    * [BOSH exporter](https://github.com/cloudfoundry-community/bosh_exporter)
+   * [Custom exporter](https://github.com/orange-cloudfoundry/custom_exporter)
    * [Dovecot exporter](https://github.com/kumina/dovecot_exporter)
    * [Jenkins exporter](https://github.com/lovoo/jenkins_exporter)
    * [Kemp LoadBalancer exporter](https://github.com/giantswarm/prometheus-kemp-exporter)


### PR DESCRIPTION
Hi @brian-brazil 

We have created a custom exporter to run some dedicated commands in different collectors and expose them in dedicated metrics. Indeed, this exporter allow to have some metrics that are not available in dedicated exporter (mysql_exporter, redis_exporter, ...) and too specific to be included in them.
 
### Concept:
  * This exporter works with a dedicated config file that contains all needed metrics.
  * Each dedicated metrics will use a collector to access to data and a custom commands list that will be run into this collector.
  * The final command must expose a ready to be parsed result set to extract metric value and tags value. 
  * A mapping config allows to specify the tags included. Otherwise, only last data on each row or record will be extracted.
  * A collector is defined by its name and include the type (bash, mysql ...) and credentials (data source name, user, password, uri ...). 
  * The dedicated metrics are exposed with a prefix "custom" and the name of this metric's extract from the config file.

At now, this collector is to be released (We will add more collectors in the future) : 
  * bash
  * redis
  * mysql (not tested in acceptance staging)

### Project resources : 
  * Github: https://github.com/orange-cloudfoundry/custom_exporter
  * Release Bosh for CloudFoundry: https://github.com/orange-cloudfoundry/custom_exporter-boshrelease
  * Port binding : 9213 (https://github.com/prometheus/prometheus/wiki/Default-port-allocations)
 
Cheers,

Axel Fauvel, Arthur Halet & Nicolas Juhel

PS : message send on [prometheus-developers](https://groups.google.com/forum/?fromgroups#!topic/prometheus-developers/jX-HGWdOt_w)
CC : @axelfauvel @ArthurHlt