### PR TITLE
docs/content/index.html: Fix YouTube link

### DIFF
--- a/content/index.html
+++ b/content/index.html
@@ -13,7 +13,7 @@ layout: jumbotron
 </div>
 
 <div class="newsbar">
-  CloudNativeCon 2017 videos are out!&nbsp;&nbsp;—&nbsp;&nbsp;<a href="https://www.youtube.com/watch?list=PLqm7NmbgjUExeDZU8xb2nxz-ysnjuC2Mz&v=x2Lp8nktLjE">Watch the Prometheus track here</a>
+  CloudNativeCon 2017 videos are out!&nbsp;&nbsp;—&nbsp;&nbsp;<a href="https://www.youtube.com/watch?v=uV_sh7_lVw8&list=PLqm7NmbgjUExeDZU8xb2nxz-ysnjuC2Mz&index=1">Watch the Prometheus track here</a>
 </div>
 
 <div class="container">


### PR DESCRIPTION
As per IRC:

09:55:00 < gouthamve> bbrazil: jrv: The link for the Prometheus track on the website (https://prometheus.io/) leads to a 404.
09:57:31 < gouthamve> Prometheus track videos from CloudNativeCon
