### PR TITLE
Improve readability of absent() documentation

### DIFF
--- a/content/docs/querying/functions.md
+++ b/content/docs/querying/functions.md
@@ -18,12 +18,12 @@ their absolute value.
 
 ## `absent()`
 
-`absent(v instant-vector)` returns an empty vector if the vector passed to it has any
-elements and a 1-element vector with the value 1 if the vector passed to it has
-no elements.
+`absent(v instant-vector)` returns an empty vector if the vector passed to it
+has any elements and a 1-element vector with the value 1 if the vector passed to
+it has no elements.
 
-In the second case, `absent()` tries to be smart about deriving labels of
-the 1-element output vector from the input vector:
+This is useful for alerting on when no time series exist for a given metric name
+and label combination.
 
 ```
 absent(nonexistent{job="myjob"})
@@ -36,8 +36,8 @@ absent(sum(nonexistent{job="myjob"}))
 # => {}
 ```
 
-This is useful for alerting on when no time series
-exist for a given metric name and label combination.
+In the second example, `absent()` tries to be smart about deriving labels of the
+1-element output vector from the input vector.
 
 ## `ceil()`
 


### PR DESCRIPTION
This is just swapping two paragraphs and moves the explanation of the
example after the example itself.

@brian-brazil just had to read it 2 times until I got what "the second case" was referring to".