### PR TITLE
Simplify "Getting Started" tutorial

### DIFF
--- a/content/docs/introduction/getting_started.md
+++ b/content/docs/introduction/getting_started.md
@@ -34,23 +34,13 @@ useful in practice, it is a good starting example. Save the following basic
 Prometheus configuration as a file named `prometheus.yml`:
 
 ```
-global:
-  scrape_interval:     15s # By default, scrape targets every 15 seconds.
-
-  # Attach these labels to any time series or alerts when communicating with
-  # external systems (federation, remote storage, Alertmanager).
-  external_labels:
-    monitor: 'codelab-monitor'
-
 # A scrape configuration containing exactly one endpoint to scrape:
 # Here it's Prometheus itself.
 scrape_configs:
   # The job name is added as a label `job=<job_name>` to any timeseries scraped from this config.
   - job_name: 'prometheus'
-
-    # Override the global default and scrape targets from this job every 5 seconds.
+    # Scrape targets from this job every 5 seconds.
     scrape_interval: 5s
-
     static_configs:
       - targets: ['localhost:9090']
 ```
@@ -65,10 +55,11 @@ To start Prometheus with your newly created configuration file, change to your
 Prometheus build directory and run:
 
 ```language-bash
-# Start Prometheus.
-# By default, Prometheus stores its database in ./data (flag -storage.local.path).
-./prometheus -config.file=prometheus.yml
+./prometheus
 ```
+
+By default, Prometheus stores its database in `./data` (`-storage.local.path` flag)
+and loads its configuration from `prometheus.yml` (`-config.file` flag).
 
 Prometheus should start up and it should show a status page about itself at
 http://localhost:9090. Give it a couple of seconds to collect data about itself
@@ -76,14 +67,6 @@ from its own HTTP metrics endpoint.
 
 You can also verify that Prometheus is serving metrics about itself by
 navigating to its metrics endpoint: http://localhost:9090/metrics
-
-The number of OS threads executed by Prometheus is controlled by the
-`GOMAXPROCS` environment variable. As of Go 1.5 the default value is
-the number of cores available.
-
-Blindly setting `GOMAXPROCS` to a high value can be
-counterproductive. See the relevant [Go
-FAQs](http://golang.org/doc/faq#Why_no_multi_CPU).
 
 Note that Prometheus by default uses around 3GB in memory. If you have a
 smaller machine, you can tune Prometheus to use less memory.  For details,
@@ -186,16 +169,13 @@ section in your `prometheus.yml` and restart your Prometheus instance:
 
 ```
 scrape_configs:
-  - job_name:       'example-random'
-
-    # Override the global default and scrape targets from this job every 5 seconds.
+  - job_name: 'example-random'
+    # Scrape targets from this job every 5 seconds.
     scrape_interval: 5s
-
     static_configs:
       - targets: ['localhost:8080', 'localhost:8081']
         labels:
           group: 'production'
-
       - targets: ['localhost:8082']
         labels:
           group: 'canary'
@@ -235,36 +215,23 @@ global configuration section in your `prometheus.yml`. The config should now
 look like this:
 
 ```
-global:
-  scrape_interval:     15s # By default, scrape targets every 15 seconds.
-  evaluation_interval: 15s # Evaluate rules every 15 seconds.
-
-  # Attach these extra labels to all timeseries collected by this Prometheus instance.
-  external_labels:
-    monitor: 'codelab-monitor'
-
 rule_files:
   - 'prometheus.rules'
 
 scrape_configs:
   - job_name: 'prometheus'
-
-    # Override the global default and scrape targets from this job every 5 seconds.
+    # Scrape targets from this job every 5 seconds.
     scrape_interval: 5s
-
     static_configs:
       - targets: ['localhost:9090']
 
-  - job_name:       'example-random'
-
-    # Override the global default and scrape targets from this job every 5 seconds.
+  - job_name: 'example-random'
+    # Scrape targets from this job every 5 seconds.
     scrape_interval: 5s
-
     static_configs:
       - targets: ['localhost:8080', 'localhost:8081']
         labels:
           group: 'production'
-
       - targets: ['localhost:8082']
         labels:
           group: 'canary'


### PR DESCRIPTION
This gets rid of a few config options and flags that just clutter the
tutorial for beginners and add little value when getting started.