### PR TITLE
exporters.md: Point to non-stale PowerDNS exporter

### DIFF
--- a/content/docs/instrumenting/exporters.md
+++ b/content/docs/instrumenting/exporters.md
@@ -122,7 +122,7 @@ wide variety of JVM-based applications, for example [Kafka](http://kafka.apache.
    * [Kemp LoadBalancer exporter](https://github.com/giantswarm/prometheus-kemp-exporter)
    * [Meteor JS web framework exporter](https://atmospherejs.com/sevki/prometheus-exporter)
    * [Minecraft exporter module](https://github.com/Baughn/PrometheusIntegration)
-   * [PowerDNS exporter](https://github.com/janeczku/powerdns_exporter)
+   * [PowerDNS exporter](https://github.com/ledgr/powerdns_exporter)
    * [Process exporter](https://github.com/ncabatoff/process-exporter)
    * [rTorrent exporter](https://github.com/mdlayher/rtorrent_exporter)
    * [Script exporter](https://github.com/adhocteam/script_exporter)


### PR DESCRIPTION
The fork is working, the original one does not even compile any more.