### PR TITLE
Fix broken link in `alerting/rules.md` to `querying/rules.md`

### DIFF
--- a/content/docs/alerting/rules.md
+++ b/content/docs/alerting/rules.md
@@ -12,7 +12,7 @@ vector elements at a given point in time, the alert counts as active for these
 elements' label sets.
 
 Alerting rules are configured in Prometheus in the same way as [recording
-rules](../../querying/rules).
+rules](../querying/rules).
 
 ### Defining alerting rules
 

--- a/content/docs/alerting/rules.md
+++ b/content/docs/alerting/rules.md
@@ -12,7 +12,7 @@ vector elements at a given point in time, the alert counts as active for these
 elements' label sets.
 
 Alerting rules are configured in Prometheus in the same way as [recording
-rules](../querying/rules).
+rules](../querying/rules.md).
 
 ### Defining alerting rules
 


### PR DESCRIPTION
There was a typo in `content/docs/alerting/rules.md` resulting in a broken link. I think this is probably what you guys meant?

@brian-brazil 