### PR TITLE
added Naemon exporter

### DIFF
--- a/content/docs/instrumenting/exporters.md
+++ b/content/docs/instrumenting/exporters.md
@@ -108,6 +108,7 @@ wide variety of JVM-based applications, for example [Kafka](http://kafka.apache.
    * [JavaMelody exporter](https://github.com/fschlag/javamelody-prometheus-exporter)
    * [JMX exporter](https://github.com/prometheus/jmx_exporter) (**official**)
    * [Munin exporter](https://github.com/pvdh/munin_exporter)
+   * [Naemon exporter](https://github.com/Griesbacher/Iapetos)
    * [New Relic exporter](https://github.com/jfindley/newrelic_exporter)
    * [Pingdom exporter](https://github.com/giantswarm/prometheus-pingdom-exporter)
    * [scollector exporter](https://github.com/tgulacsi/prometheus_scollector)


### PR DESCRIPTION
This is an exporter for the Naemon Monitoringsystem. It is using the NEB Interface which is basically introduced by Nagios, so it should work with them, too. But there is still a strange bug which is currently preventing this.
Therefore I would only put Naemon in the title, because that is the system it is properly working with.