### PR TITLE
Seperate out directly instrumented vs merely exposing.

### DIFF
--- a/content/docs/instrumenting/exporters.md
+++ b/content/docs/instrumenting/exporters.md
@@ -120,6 +120,7 @@ wide variety of JVM-based applications, for example [Kafka](http://kafka.apache.
    * [BIND exporter](https://github.com/digitalocean/bind_exporter)
    * [Blackbox exporter](https://github.com/prometheus/blackbox_exporter) (**official**)
    * [BOSH exporter](https://github.com/cloudfoundry-community/bosh_exporter)
+   * [cAdvisor](https://github.com/google/cadvisor)
    * [Dovecot exporter](https://github.com/kumina/dovecot_exporter)
    * [Jenkins exporter](https://github.com/lovoo/jenkins_exporter)
    * [Kemp LoadBalancer exporter](https://github.com/giantswarm/prometheus-kemp-exporter)
@@ -141,20 +142,24 @@ list](https://groups.google.com/forum/#!forum/prometheus-developers).  We are
 happy to give advice on how to make your exporter as useful and consistent as
 possible.
 
-## Directly instrumented software
+## Software exposing Prometheus metrics
 
-Some third-party software already exposes Prometheus metrics natively, so no
+Some third-party software exposes metrics in the Prometheus format, so no
 separate exporters are needed:
 
-   * [cAdvisor](https://github.com/google/cadvisor)
-   * [Doorman](https://github.com/youtube/doorman)
-   * [Etcd](https://github.com/coreos/etcd)
-   * [Kubernetes-Mesos](https://github.com/mesosphere/kubernetes-mesos)
-   * [Kubernetes](https://github.com/kubernetes/kubernetes)
+   * [Collectd](https://collectd.org/wiki/index.php/Plugin:Write_Prometheus)
+   * [Doorman](https://github.com/youtube/doorman) (**direct**)
+   * [Etcd](https://github.com/coreos/etcd) (**direct**)
+   * [Kubernetes](https://github.com/kubernetes/kubernetes) (**direct**)
+   * [Linkerd](https://github.com/BuoyantIO/linkerd)
+   * [Netdata](https://github.com/firehol/netdata)
+   * [Quobyte](https://www.quobyte.com/) (**direct**)
    * [RobustIRC](http://robustirc.net/)
-   * [Quobyte](https://www.quobyte.com/)
-   * [SkyDNS](https://github.com/skynetservices/skydns)
-   * [Weave Flux](http://weaveworks.github.io/flux/)
+   * [SkyDNS](https://github.com/skynetservices/skydns) (**direct**)
+   * [Telegraf](https://github.com/influxdata/telegraf/tree/master/plugins/outputs/prometheus_client)
+   * [Weave Flux](https://github.com/weaveworks/flux)
+
+The software marked *direct* is also directly instrumented with a Prometheus client library.
 
 ## Other third-party utilities
 


### PR DESCRIPTION
Directly instrumented applications use a Prometheus client library that
follows our guidelines, and can be used as examples of software doing
that.

Software that uses something else to do instrumentation/metrics but
also exposes at one of our formats gets its own category.

Recategorise things accordingly, updating links as needed and
adding some more I know of.
I'm taking Quobyte's word for it that they're directly instrumented,
as it's commercial software and thus I can't check.
kubernetes-mesos has no instrumentation that I can find.