### PR TITLE
Add Google Stackdriver & Shield exporters to the list of exporters

### DIFF
--- a/content/docs/instrumenting/exporters.md
+++ b/content/docs/instrumenting/exporters.md
@@ -133,6 +133,7 @@ wide variety of JVM-based applications, for example [Kafka](http://kafka.apache.
    * [Process exporter](https://github.com/ncabatoff/process-exporter)
    * [rTorrent exporter](https://github.com/mdlayher/rtorrent_exporter)
    * [Script exporter](https://github.com/adhocteam/script_exporter)
+   * [Shield exporter](https://github.com/cloudfoundry-community/shield_exporter)
    * [SMTP/Maildir MDA blackbox prober](https://github.com/cherti/mailexporter)
    * [Transmission exporter](https://github.com/metalmatze/transmission-exporter)
    * [Unbound exporter](https://github.com/kumina/unbound_exporter)

--- a/content/docs/instrumenting/exporters.md
+++ b/content/docs/instrumenting/exporters.md
@@ -102,6 +102,7 @@ wide variety of JVM-based applications, for example [Kafka](http://kafka.apache.
    * [AWS CloudWatch exporter](https://github.com/prometheus/cloudwatch_exporter) (**official**)
    * [Cloud Foundry Firehose exporter](https://github.com/cloudfoundry-community/firehose_exporter)
    * [Collectd exporter](https://github.com/prometheus/collectd_exporter) (**official**)
+   * [Google Stackdriver exporter](https://github.com/frodenas/stackdriver_exporter)
    * [Graphite exporter](https://github.com/prometheus/graphite_exporter) (**official**)
    * [Heka dashboard exporter](https://github.com/docker-infra/heka_exporter)
    * [Heka exporter](https://github.com/imgix/heka_exporter)


### PR DESCRIPTION
This PR adds to the [exporters page](https://prometheus.io/docs/instrumenting/exporters/) the following exporters:

* [Google Stackdriver exporter](https://github.com/frodenas/stackdriver_exporter)
* [Shield exporter](https://github.com/cloudfoundry-community/shield_exporter)