### PR TITLE
Clarify that Marathon server is selected at random

### DIFF
--- a/content/docs/operating/configuration.md
+++ b/content/docs/operating/configuration.md
@@ -722,6 +722,8 @@ See below for the configuration options for Marathon discovery:
 
 ```
 # List of URLs to be used to contact Marathon servers.
+# A server will be selected randomly; it is assumed that all servers are
+# responsible for the same tasks.
 # You need to provide at least one server URL, but should provide URLs for
 # all masters you have running.
 servers:


### PR DESCRIPTION
Both I and a colleague had assumed that you could specify multiple
Marathon masters, where each master is responsible for a different group
of tasks. The Marathon service discovery selects servers at random:

https://github.com/prometheus/prometheus/blob/2a9ca394dd92dec53efe3cb3add75e346f201cc7/discovery/marathon/marathon.go#L186

Make that clear in the documentation.