### PR TITLE
Update PagerDuty link in Alertmanager config

### DIFF
--- a/content/docs/alerting/configuration.md
+++ b/content/docs/alerting/configuration.md
@@ -295,7 +295,8 @@ room_id: <tmpl_string>
 
 ## `<pagerduty_config>`
 
-PagerDuty notifications are sent via the [PagerDuty API](https://www.pagerduty.com/docs/guides/prometheus-integration-guide/).
+PagerDuty notifications are sent via the [PagerDuty API](https://developer.pagerduty.com/documentation/integration/events).
+PagerDuty provides documentation on how to integrate [here](https://www.pagerduty.com/docs/guides/prometheus-integration-guide/).
 
 ```
 # Whether or not to notify about resolved alerts.

--- a/content/docs/alerting/configuration.md
+++ b/content/docs/alerting/configuration.md
@@ -295,7 +295,7 @@ room_id: <tmpl_string>
 
 ## `<pagerduty_config>`
 
-PagerDuty notifications are sent via the [PagerDuty API](https://developer.pagerduty.com/documentation/integration/events).
+PagerDuty notifications are sent via the [PagerDuty API](https://www.pagerduty.com/docs/guides/prometheus-integration-guide/).
 
 ```
 # Whether or not to notify about resolved alerts.


### PR DESCRIPTION
PagerDuty has a page specifically for integrating
with Prometheus/Alertmanager, which seems like a
good idea to link to from our documentation.

Link: https://www.pagerduty.com/docs/guides/prometheus-integration-guide/