### PR TITLE
Add a PHP-FPM exporter to the list of exporters

### DIFF
--- a/content/docs/instrumenting/exporters.md
+++ b/content/docs/instrumenting/exporters.md
@@ -119,6 +119,9 @@ wide variety of JVM-based applications, for example [Kafka](http://kafka.apache.
    * [SNMP exporter](https://github.com/prometheus/snmp_exporter) (**official**)
    * [StatsD exporter](https://github.com/prometheus/statsd_exporter) (**official**)
 
+### Interpreters 
+   * [PHP-FPM exporter](https://github.com/bakins/php-fpm-exporter)
+
 ### Miscellaneous
    * [BIG-IP exporter](https://github.com/ExpressenAB/bigip_exporter)
    * [BIND exporter](https://github.com/digitalocean/bind_exporter)

--- a/content/docs/instrumenting/exporters.md
+++ b/content/docs/instrumenting/exporters.md
@@ -119,9 +119,6 @@ wide variety of JVM-based applications, for example [Kafka](http://kafka.apache.
    * [SNMP exporter](https://github.com/prometheus/snmp_exporter) (**official**)
    * [StatsD exporter](https://github.com/prometheus/statsd_exporter) (**official**)
 
-### Interpreters 
-   * [PHP-FPM exporter](https://github.com/bakins/php-fpm-exporter)
-
 ### Miscellaneous
    * [BIG-IP exporter](https://github.com/ExpressenAB/bigip_exporter)
    * [BIND exporter](https://github.com/digitalocean/bind_exporter)
@@ -133,6 +130,7 @@ wide variety of JVM-based applications, for example [Kafka](http://kafka.apache.
    * [Kemp LoadBalancer exporter](https://github.com/giantswarm/prometheus-kemp-exporter)
    * [Meteor JS web framework exporter](https://atmospherejs.com/sevki/prometheus-exporter)
    * [Minecraft exporter module](https://github.com/Baughn/PrometheusIntegration)
+   * [PHP-FPM exporter](https://github.com/bakins/php-fpm-exporter)
    * [PowerDNS exporter](https://github.com/ledgr/powerdns_exporter)
    * [Process exporter](https://github.com/ncabatoff/process-exporter)
    * [rTorrent exporter](https://github.com/mdlayher/rtorrent_exporter)


### PR DESCRIPTION
Currently, there is a large set of exporters available for a lot of different software tools.
However, the popular runtime "PHP-FPM", used for executing PHP script through the
FastCGI protocol, is not listed.

Various exporters currently exist, and the author has not tested any (including the
suggested) extensively. However, a quick review of the available options shows that,
in the authors limited review, this appears to be well constructed, thought out and
documented.

This commit adds the exporter to the canonical list for easy discovery. 

Design Notes:

Alternatives considered were:
- https://github.com/peakgames/php-fpm-prometheus/ (no releases, less docs)
- https://github.com/blablacar/phpfpm-prometheus-exporter (no docs)