### PR TITLE
Update getting_started docs

### DIFF
--- a/content/docs/introduction/getting_started.md
+++ b/content/docs/introduction/getting_started.md
@@ -66,8 +66,8 @@ Prometheus build directory and run:
 
 ```language-bash
 # Start Prometheus.
-# By default, Prometheus stores its database in ./data (flag -storage.local.path).
-./prometheus -config.file=prometheus.yml
+# By default, Prometheus stores its database in ./data (flag --storage.local.path).
+./prometheus --config.file=prometheus.yml
 ```
 
 Prometheus should start up and it should show a status page about itself at


### PR DESCRIPTION
Prometheus uses two dashes instead of one dash for its arguments (latest darwin download)

@brian-brazil 