### PR TITLE
derived two orange logos from the original grey logo

### DIFF
--- a/static/prometheus_logo_orange_circle.svg
+++ b/static/prometheus_logo_orange_circle.svg
@@ -1,0 +1,50 @@
+<?xml version="1.0" encoding="UTF-8" standalone="no"?>
+<!-- Generator: Adobe Illustrator 16.0.0, SVG Export Plug-In . SVG Version: 6.00 Build 0)  -->
+
+<svg
+   xmlns:dc="http://purl.org/dc/elements/1.1/"
+   xmlns:cc="http://creativecommons.org/ns#"
+   xmlns:rdf="http://www.w3.org/1999/02/22-rdf-syntax-ns#"
+   xmlns:svg="http://www.w3.org/2000/svg"
+   xmlns="http://www.w3.org/2000/svg"
+   xmlns:sodipodi="http://sodipodi.sourceforge.net/DTD/sodipodi-0.dtd"
+   xmlns:inkscape="http://www.inkscape.org/namespaces/inkscape"
+   version="1.1"
+   id="Layer_1"
+   x="0px"
+   y="0px"
+   width="115.333px"
+   height="114px"
+   viewBox="0 0 115.333 114"
+   enable-background="new 0 0 115.333 114"
+   xml:space="preserve"
+   sodipodi:docname="prometheus_logo_orange.svg"
+   inkscape:version="0.92.1 r15371"><metadata
+     id="metadata4495"><rdf:RDF><cc:Work
+         rdf:about=""><dc:format>image/svg+xml</dc:format><dc:type
+           rdf:resource="http://purl.org/dc/dcmitype/StillImage" /><dc:title></dc:title></cc:Work></rdf:RDF></metadata><defs
+     id="defs4493" /><sodipodi:namedview
+     pagecolor="#ffffff"
+     bordercolor="#666666"
+     borderopacity="1"
+     objecttolerance="10"
+     gridtolerance="10"
+     guidetolerance="10"
+     inkscape:pageopacity="0"
+     inkscape:pageshadow="2"
+     inkscape:window-width="1484"
+     inkscape:window-height="886"
+     id="namedview4491"
+     showgrid="false"
+     inkscape:zoom="5.2784901"
+     inkscape:cx="60.603667"
+     inkscape:cy="60.329656"
+     inkscape:window-x="54"
+     inkscape:window-y="7"
+     inkscape:window-maximized="0"
+     inkscape:current-layer="Layer_1" /><g
+     id="Layer_2" /><path
+     style="fill:#e6522c;fill-opacity:1"
+     inkscape:connector-curvature="0"
+     id="path4486"
+     d="M 56.667,0.667 C 25.372,0.667 0,26.036 0,57.332 c 0,31.295 25.372,56.666 56.667,56.666 31.295,0 56.666,-25.371 56.666,-56.666 0,-31.296 -25.372,-56.665 -56.666,-56.665 z m 0,106.055 c -8.904,0 -16.123,-5.948 -16.123,-13.283 H 72.79 c 0,7.334 -7.219,13.283 -16.123,13.283 z M 83.297,89.04 H 30.034 V 79.382 H 83.298 V 89.04 Z M 83.106,74.411 H 30.186 C 30.01,74.208 29.83,74.008 29.66,73.802 24.208,67.182 22.924,63.726 21.677,60.204 c -0.021,-0.116 6.611,1.355 11.314,2.413 0,0 2.42,0.56 5.958,1.205 -3.397,-3.982 -5.414,-9.044 -5.414,-14.218 0,-11.359 8.712,-21.285 5.569,-29.308 3.059,0.249 6.331,6.456 6.552,16.161 3.252,-4.494 4.613,-12.701 4.613,-17.733 0,-5.21 3.433,-11.262 6.867,-11.469 -3.061,5.045 0.793,9.37 4.219,20.099 1.285,4.03 1.121,10.812 2.113,15.113 C 63.797,33.534 65.333,20.5 71,16 c -2.5,5.667 0.37,12.758 2.333,16.167 3.167,5.5 5.087,9.667 5.087,17.548 0,5.284 -1.951,10.259 -5.242,14.148 3.742,-0.702 6.326,-1.335 6.326,-1.335 l 12.152,-2.371 c 10e-4,-10e-4 -1.765,7.261 -8.55,14.254 z" /></svg>

--- a/static/prometheus_logo_orange_invert.svg
+++ b/static/prometheus_logo_orange_invert.svg
@@ -1,0 +1,57 @@
+<?xml version="1.0" encoding="UTF-8" standalone="no"?>
+<!-- Generator: Adobe Illustrator 16.0.0, SVG Export Plug-In . SVG Version: 6.00 Build 0)  -->
+
+<svg
+   xmlns:dc="http://purl.org/dc/elements/1.1/"
+   xmlns:cc="http://creativecommons.org/ns#"
+   xmlns:rdf="http://www.w3.org/1999/02/22-rdf-syntax-ns#"
+   xmlns:svg="http://www.w3.org/2000/svg"
+   xmlns="http://www.w3.org/2000/svg"
+   xmlns:sodipodi="http://sodipodi.sourceforge.net/DTD/sodipodi-0.dtd"
+   xmlns:inkscape="http://www.inkscape.org/namespaces/inkscape"
+   version="1.1"
+   id="Layer_1"
+   x="0px"
+   y="0px"
+   width="70.978569"
+   height="100.4668"
+   viewBox="0 0 70.978569 100.4668"
+   enable-background="new 0 0 115.333 114"
+   xml:space="preserve"
+   sodipodi:docname="prometheus_logo_organge_invert.svg"
+   inkscape:version="0.92.1 r15371"><metadata
+     id="metadata4509"><rdf:RDF><cc:Work
+         rdf:about=""><dc:format>image/svg+xml</dc:format><dc:type
+           rdf:resource="http://purl.org/dc/dcmitype/StillImage" /><dc:title></dc:title></cc:Work></rdf:RDF></metadata><defs
+     id="defs4507" /><sodipodi:namedview
+     pagecolor="#ffffff"
+     bordercolor="#666666"
+     borderopacity="1"
+     objecttolerance="10"
+     gridtolerance="10"
+     guidetolerance="10"
+     inkscape:pageopacity="0"
+     inkscape:pageshadow="2"
+     inkscape:window-width="1492"
+     inkscape:window-height="820"
+     id="namedview4505"
+     showgrid="false"
+     fit-margin-top="0.5"
+     fit-margin-left="0.5"
+     fit-margin-right="0.5"
+     fit-margin-bottom="0.5"
+     inkscape:pagecheckerboard="false"
+     inkscape:zoom="5.6568543"
+     inkscape:cx="24.071797"
+     inkscape:cy="50.196908"
+     inkscape:window-x="173"
+     inkscape:window-y="91"
+     inkscape:window-maximized="0"
+     inkscape:current-layer="Layer_1" /><g
+     id="Layer_2"
+     transform="translate(-21.177684,-6.7558594)" /><path
+     style="opacity:0.997;fill:#e6522c;fill-opacity:1;stroke-width:0.93665701"
+     mask="none"
+     d="m 35.959035,0.5 c -3.434,0.207 -6.867188,6.2587496 -6.867188,11.46875 0,5.032 -1.361281,13.238422 -4.613281,17.732422 -0.221,-9.705 -3.493734,-15.911156 -6.552734,-16.160156 3.143,8.023 -5.56836,17.947641 -5.56836,29.306641 0,5.174 2.017063,10.23675 5.414063,14.21875 -3.538,-0.645 -5.958985,-1.205078 -5.958985,-1.205078 -4.7030002,-1.058 -11.33350028,-2.530063 -11.31250024,-2.414063 1.24700004,3.522 2.53042204,6.979609 7.98242204,13.599609 0.17,0.206 0.349391,0.404422 0.525391,0.607422 H 61.927785 c 6.785,-6.993 8.551781,-14.254906 8.550781,-14.253906 l -12.152344,2.371094 c 0,0 -2.584172,0.633937 -6.326172,1.335937 3.291,-3.889 5.242188,-8.864437 5.242188,-14.148437 0,-7.881 -1.920891,-12.046875 -5.087891,-17.546875 -1.963,-3.409 -4.832031,-10.500969 -2.332031,-16.1679694 -5.667,4.5000004 -7.20225,17.5337974 -7.53125,26.4667974 -0.992,-4.301 -0.828281,-11.083281 -2.113281,-15.113281 C 36.751785,9.868657 32.898035,5.5449996 35.959035,0.5 Z M 8.8555188,72.626953 v 9.65625 h 53.2636722 0.002 v -9.65625 z M 19.367238,86.683594 c 0,7.334997 7.219047,13.283206 16.123047,13.283206 8.904,0 16.121093,-5.949209 16.121093,-13.283206 z"
+     id="path5275"
+     inkscape:connector-curvature="0" /></svg>


### PR DESCRIPTION
The original logo in SVG format was grey only. I add the grey logo colored in orange (same color as used on website). I also add an inverted logo that should work with die cut stickers.