### PR TITLE
nit: right associative example

### DIFF
--- a/content/docs/querying/operators.md
+++ b/content/docs/querying/operators.md
@@ -248,4 +248,4 @@ highest to lowest.
 
 Operators on the same precedence level are left-associative. For example,
 `2 * 3 % 2` is equivalent to `(2 * 3) % 2`. However `^` is right associative,
-so `2 * 3 ^ 2` is equivalent to `2 * (3 ^ 2)`.
+so `2 ^ 3 ^ 2` is equivalent to `2 ^ (3 ^ 2)`.


### PR DESCRIPTION
See: https://prometheus.io/docs/querying/operators/#binary-operator-precedence

`2 * 3 ^ 2` being equivalent to `2 * (3 ^ 2)` doesn't actually demonstrate that `^` is right associative. It just follows from operator precedence. The significance of right associativity is better exemplified by something of same precedence level as `^`.