### PR TITLE
Correct the version reference in the webhook spec

### DIFF
--- a/content/docs/alerting/configuration.md
+++ b/content/docs/alerting/configuration.md
@@ -459,7 +459,7 @@ endpoint:
 
 ```
 {
-  "version": "3",
+  "version": "4",
   "groupKey": <number>     // key identifying the group of alerts (e.g. to deduplicate)
   "status": "<resolved|firing>",
   "receiver": <string>,

--- a/content/docs/alerting/configuration.md
+++ b/content/docs/alerting/configuration.md
@@ -460,7 +460,7 @@ endpoint:
 ```
 {
   "version": "4",
-  "groupKey": <string>    // key identifying the group of alerts (e.g. to deduplicate)
+  "groupKey": <string>,    // key identifying the group of alerts (e.g. to deduplicate)
   "status": "<resolved|firing>",
   "receiver": <string>,
   "groupLabels": <object>,

--- a/content/docs/alerting/configuration.md
+++ b/content/docs/alerting/configuration.md
@@ -460,7 +460,7 @@ endpoint:
 ```
 {
   "version": "4",
-  "groupKey": <number>     // key identifying the group of alerts (e.g. to deduplicate)
+  "groupKey": <string>    // key identifying the group of alerts (e.g. to deduplicate)
   "status": "<resolved|firing>",
   "receiver": <string>,
   "groupLabels": <object>,


### PR DESCRIPTION
The version expressed by the AlertManager was changed in the following
commit: 

  https://github.com/prometheus/alertmanager/commit/3269bc39e121452abdce24db1d3d9003d99184d1

This updates the documentation to reflect that change. 

Design Notes:

  This wasn't checked against the full spec. The author has judged that
  this change was to the values of the spec, rather than the keys.