### PR TITLE
move development mailing list info to Contributing section

### DIFF
--- a/content/community.html
+++ b/content/community.html
@@ -14,11 +14,8 @@ title: Community
       (for the easiest start, <a href="https://riot.im/app/#/room/#freenode_#prometheus:matrix.org">join via Riot</a>)
     </p>
     <p>
-      <strong>Mailing lists:</strong>
-      <ul>
-        <li><a href="https://groups.google.com/forum/#!forum/prometheus-users">prometheus-users</a> – for discussions around Prometheus usage and community support</li>
-        <li><a href="https://groups.google.com/forum/#!forum/prometheus-developers">prometheus-developers</a> – for discussions around Prometheus development</li>
-      </ul>
+      <strong>Usage mailing list:</strong>
+      <a href="https://groups.google.com/forum/#!forum/prometheus-users">prometheus-users</a> – for discussions around Prometheus usage and community support
     </p>
     <p>
       <strong>Twitter:</strong>
@@ -32,6 +29,7 @@ title: Community
       <a href="https://groups.google.com/forum/#!forum/prometheus-users">prometheus-users</a>
       mailing list rather than filing a GitHub issue.
     </p>
+
     <p>
       <em>Please do not ask individual project members for
       support. Use the channels above instead, where the whole
@@ -48,6 +46,10 @@ title: Community
       for instructions on how to submit changes. If you are planning on making
       more elaborate or controversial changes, please discuss them on the mailing
       list before sending a pull request.
+    </p>
+    <p>
+      <strong>Development mailing list:</strong>
+      <a href="https://groups.google.com/forum/#!forum/prometheus-developers">prometheus-developers</a> – for discussions around Prometheus development
     </p>
 
     <h1>Project Governance</h1>


### PR DESCRIPTION
Even though there's a note stating what each mailing list is for, the dev mailing list still receives a lot of usage related questions. This PR moves the dev mailing list info to the `Contributing` section of the `Community` docs.

@brian-brazil @juliusv 