### PR TITLE
Add note about long term metric storage

### DIFF
--- a/content/docs/introduction/comparison.md
+++ b/content/docs/introduction/comparison.md
@@ -5,6 +5,13 @@ sort_rank: 4
 
 # Comparison to alternatives
 
+> **Important note**
+> Prometheus focuses on monitoring the "here-and-now" it is designed to capture
+> data for a limited number of days. If you need long-term trends you will need
+> to consider using a remote data adapter and a time series database that supports
+> downsampling metrics and dropping fidelity over time such as Graphite Carbon or 
+> InfluxDB
+
 ## Prometheus vs. Graphite
 
 ### Scope


### PR DESCRIPTION
I feel the current comparison is **highly** misleading. After reading this page an argument is made that Prometheus is superior and most solutions out there are inferior. 

Long-term metrics, by-design, are not handled by prometheus. You can capture a couple of weeks of data, but not years, there are no downsampling options and memory usage is quite high. 

I feel is is EXTREMELY important to highlight this design decision here so sysadmins of the world do not get confused.