### PR TITLE
Add a page to list all the other types of integrations

### DIFF
--- a/content/docs/alerting/configuration.md
+++ b/content/docs/alerting/configuration.md
@@ -478,3 +478,8 @@ endpoint:
   ]
 }
 ```
+
+
+There is a list of
+[integrations](/docs/operating/integrations/#alertmanager-webhook-receiver) with
+this feature.

--- a/content/docs/operating/configuration.md
+++ b/content/docs/operating/configuration.md
@@ -498,6 +498,10 @@ Each target has a meta label `__meta_filepath` during the
 [relabeling phase](#relabel_config). Its value is set to the
 filepath from which the target was extracted.
 
+There is a list of
+[integrations](/docs/operating/configuration/#<file_sd_config>) with this
+discovery mechanism.
+
 ```
 # Patterns for files from which target groups are extracted.
 files:
@@ -1098,6 +1102,9 @@ tls_config:
 # Optional proxy URL.
 [ proxy_url: <string> ]
 ```
+There is a list of
+[integrations](/docs/operating/integrations/#remote-endpoints-and-storage) with
+this feature.
 
 ### `<remote_read>`
 
@@ -1132,3 +1139,7 @@ tls_config:
 # Optional proxy URL.
 [ proxy_url: <string> ]
 ```
+
+There is a list of
+[integrations](/docs/operating/integrations/#remote-endpoints-and-storage) with
+this feature.

--- a/content/docs/operating/integrations.md
+++ b/content/docs/operating/integrations.md
@@ -1,0 +1,60 @@
+---
+title: Integrations
+sort_rank: 5
+---
+
+# Integrations
+
+In addition to [client libraries](/docs/instrumenting/clientlibs/) and
+[exporters and related libraries](/docs/instrumenting/exporters/), there are
+numerous other generic integration points in Prometheus. This page lists some
+of the integrations with these.
+
+
+Not all integrations are listed here, due to overlapping functionality or still
+being in development. The [exporter default
+port](https://github.com/prometheus/prometheus/wiki/Default-port-allocations)
+wiki page also happens to include a few non-exporter integrations that fit in
+these categories.
+
+## File Service Discovery
+
+For service discovery mechanisms not natively supported by Prometheus,
+[file-based service discovery](/docs/operating/configuration/#<file_sd_config>) provides an interface for integrating.
+
+ * [Docker Swarm](https://github.com/ContainerSolutions/prometheus-swarm-discovery)
+
+## Remote Endpoints and Storage
+
+The [remote write](/docs/operating/configuration/#<remote_write>) and [remote read](/docs/operating/configuration/#remote_read)
+features of Prometheus allow transparently sending and receiving samples. This
+is primarily intended for long term storage. It is recommended that you perform
+careful evaulation of any solution in this space to confirm it can handle your
+data volumes.
+
+  * [Chronix](https://github.com/ChronixDB/chronix.ingester): write
+  * [Graphite](https://github.com/prometheus/prometheus/tree/master/documentation/examples/remote_storage/remote_storage_adapter): write
+  * [InfluxDB](https://github.com/prometheus/prometheus/tree/master/documentation/examples/remote_storage/remote_storage_adapter): read and write
+  * [OpenTSDB](https://github.com/prometheus/prometheus/tree/master/documentation/examples/remote_storage/remote_storage_adapter): write
+  * [PostgreSQL/TimescaleDB](https://github.com/timescale/prometheus-postgresql-adapter): read and write
+
+## Alertmanager Webhook Receiver
+
+For notification mechanisms not natively supported by the Alertmanager, the
+[webhook receiver](/docs/alerting/configuration/#webhook_config) allows for integration.
+
+  * [JIRA example](https://github.com/fabxc/jiralerts)
+  * [SMS](https://github.com/messagebird/sachet): supports [multiple providers](https://github.com/messagebird/sachet/blob/master/examples/config.yaml)
+  * [Telegram bot](https://github.com/inCaller/prometheus_bot)
+
+## Management
+
+Prometheus does not include configuration management functionality, allowing
+you to integrate it with your existing systems or build on top of it.
+
+  * [Prometheus Operator](https://github.com/coreos/prometheus-operator): Manages Prometheus on top of Kubernetes
+  * [Promgen](https://github.com/line/promgen): Web UI and configuration generator for Prometheus and Alertmanager
+
+## Other
+
+  * [PushProx](https://github.com/RobustPerception/PushProx): Proxy to transverse NAT and similar network setups


### PR DESCRIPTION
We've needed one of these for a while, I've seeded it from PRs and ones I know of offhand.

The angle brackets in the links to the config files aren't working, does anyone happen to know what's up there?