### PR TITLE
Update link for FreeBSD kernel exposition

### DIFF
--- a/content/docs/instrumenting/exporters.md
+++ b/content/docs/instrumenting/exporters.md
@@ -160,7 +160,7 @@ separate exporters are needed:
    * [CRG Roller Derby Scoreboard](https://github.com/rollerderby/scoreboard) (**direct**)
    * [Doorman](https://github.com/youtube/doorman) (**direct**)
    * [Etcd](https://github.com/coreos/etcd) (**direct**)
-   * [FreeBSD Kernel](https://reviews.freebsd.org/D8792)
+   * [FreeBSD Kernel](https://www.freebsd.org/cgi/man.cgi?query=prometheus_sysctl_exporter&apropos=0&sektion=8&manpath=FreeBSD+12-current&arch=default&format=html)
    * [Kubernetes](https://github.com/kubernetes/kubernetes) (**direct**)
    * [Linkerd](https://github.com/BuoyantIO/linkerd)
    * [Netdata](https://github.com/firehol/netdata)


### PR DESCRIPTION
as discussed in #811, the manpage is core documentation for BSDs. Link it instead of the discussion around adding this.

/cc @RichiH