### PR TITLE
Add aws-health-exporter to the list of exporters

### DIFF
--- a/content/docs/instrumenting/exporters.md
+++ b/content/docs/instrumenting/exporters.md
@@ -85,6 +85,7 @@ wide variety of JVM-based applications, for example [Kafka](http://kafka.apache.
 
 ### APIs
    * [AWS ECS exporter](https://github.com/slok/ecs-exporter)
+   * [AWS Health exporter](https://github.com/Jimdo/aws-health-exporter)
    * [Cloudflare exporter](https://github.com/wehkamp/docker-prometheus-cloudflare-exporter)
    * [DigitalOcean exporter](https://github.com/metalmatze/digitalocean_exporter)
    * [Docker Cloud exporter](https://github.com/infinityworksltd/docker-cloud-exporter)


### PR DESCRIPTION
We developed a prometheus exporter for the AWS Health API and would like to add it to the list of exporters. 

https://github.com/Jimdo/aws-health-exporter

Please have a look @brian-brazil.