### PR TITLE
Correct flag in Getting Started guide

### DIFF
--- a/content/docs/introduction/getting_started.md
+++ b/content/docs/introduction/getting_started.md
@@ -67,7 +67,7 @@ Prometheus build directory and run:
 ```language-bash
 # Start Prometheus.
 # By default, Prometheus stores its database in ./data (flag -storage.local.path).
-./prometheus -config.file=prometheus.yml
+./prometheus --config.file=prometheus.yml
 ```
 
 Prometheus should start up and it should show a status page about itself at


### PR DESCRIPTION
I was going through the Getting Started guide and this bit me. The `config.file` flag should be followed by double dashes, not a single dash, in order to work right.

@brian-brazil 