### PR TITLE
Update AlertManager new notifiers recommendation

### DIFF
--- a/content/docs/alerting/configuration.md
+++ b/content/docs/alerting/configuration.md
@@ -214,9 +214,7 @@ source_match_re:
 
 Receiver is a named configuration of one or more notification integrations.
 
-__Other receiver implementations available in version 0.0.4 of Alertmanager
-are not implemented yet. We are gladly accepting any contributions to add them
-to the new implementation.__
+__We're not actively adding new receivers, we recommend implementing custom notification integrations via the [webhook](/docs/alerting/configuration/#webhook_config) receiver.__
 
 ```
 # The unique name of the receiver.


### PR DESCRIPTION
There are several PRs to add new notifiers on AlertManager, and usually, the team will answer that webhooks should be used for now, while a more flexible solution is planned. This PR updates the doc to reflect this opinion.

PRs of new notifiers:
https://github.com/prometheus/alertmanager/pull/391
https://github.com/prometheus/alertmanager/pull/600
https://github.com/prometheus/alertmanager/pull/601
https://github.com/prometheus/alertmanager/pull/1021
https://github.com/prometheus/alertmanager/pull/885
https://github.com/prometheus/alertmanager/pull/1003
https://github.com/prometheus/alertmanager/pull/1012

@stuartnelson3 