### PR TITLE
Change the maintainer of apache_exporter.

### DIFF
--- a/content/docs/instrumenting/exporters.md
+++ b/content/docs/instrumenting/exporters.md
@@ -74,7 +74,7 @@ wide variety of JVM-based applications, for example [Kafka](http://kafka.apache.
    * [ScaleIO exporter](https://github.com/syepes/sio2prom)
 
 ### HTTP
-   * [Apache exporter](https://github.com/neezgee/apache_exporter)
+   * [Apache exporter](https://github.com/Lusitaniae/apache_exporter)
    * [HAProxy exporter](https://github.com/prometheus/haproxy_exporter) (**official**)
    * [Nginx metric library](https://github.com/knyar/nginx-lua-prometheus)
    * [Nginx VTS exporter](https://github.com/hnlq715/nginx-vts-exporter)


### PR DESCRIPTION
Hi Prometheus developers!

I'm not very effective as Apache exporter maintainer since I don't actually use it and don't have enough time to do it properly. Luckily, Pedro (Lusitaniae@) is ready to take over it. Please consider it and, if have no other plans for this exporter, update the documentation. Thank you!