### PR TITLE
Add correct defaults to Alertmanager route config

### DIFF
--- a/content/docs/alerting/configuration.md
+++ b/content/docs/alerting/configuration.md
@@ -133,16 +133,16 @@ match_re:
 # How long to initially wait to send a notification for a group
 # of alerts. Allows to wait for an inhibiting alert to arrive or collect
 # more initial alerts for the same group. (Usually ~0s to few minutes.)
-[ group_wait: <duration> ]
+[ group_wait: <duration> | default = 30s ]
 
 # How long to wait before sending a notification about new alerts that
 # are added to a group of alerts for which an initial notification has
-# already been sent. (Usually ~5min or more.)
-[ group_interval: <duration> ]
+# already been sent. (Usually ~5m or more.)
+[ group_interval: <duration> | default = 5m ]
 
 # How long to wait before sending a notification again if it has already
 # been sent successfully for an alert. (Usually ~3h or more).
-[ repeat_interval: <duration> ]
+[ repeat_interval: <duration> | default = 4h ]
 
 # Zero or more child routes.
 routes:


### PR DESCRIPTION
Don't think we should have those open phrases "Usually ~X". I've changed it to have the correct defaults. 

https://github.com/prometheus/alertmanager/blob/master/dispatch/route.go#L31