### PR TITLE
Update documentation of the victorops alertmanager receiver

### DIFF
--- a/content/docs/alerting/configuration.md
+++ b/content/docs/alerting/configuration.md
@@ -429,14 +429,14 @@ api_key: <secret>
 # A key used to map the alert to a team.
 [ routing_key: <string> ]
 
-# Describes the behavior of the alert (Critical, Acknowledgement, Info, Recovery).
-[ message_type: <string> ]
+# Describes the behavior of the alert (CRITICAL, WARNING, INFO).
+[ message_type: <tmpl_string> | default = 'CRITICAL' ]
 
 # Contains summary of the alerted problem.
 [ entity_display_name: <string> | default = '{{ template "victorops.default.entity_display_name" . }}' ]
 
 # Contains long explanation of the alerted problem.
-[ state_message: <string> | default = '{{ template "victorops.default.state_message" . }}' ]
+[ state_message: <tmpl_string> | default = '{{ template "victorops.default.state_message" . }}' ]
 
 # The monitoring tool the state message is from.
 [ monitoring_tool: <string> | default = '{{ template "victorops.default.monitoring_tool" . }}' ]


### PR DESCRIPTION
This PR updates the documentation of the victorops alertmanager receiver, after the discussion in https://github.com/prometheus/alertmanager/issues/1018.

Summary:
 - the `message_type` attribute is a template string (or will be once https://github.com/prometheus/alertmanager/pull/1038 is merged)
 - the `state_message` attribute is also template string