### PR TITLE
Add send_resolved doc to pushover, and victorops

### DIFF
--- a/content/docs/alerting/configuration.md
+++ b/content/docs/alerting/configuration.md
@@ -334,6 +334,9 @@ service_key: <tmpl_secret>
 Pushover notifications are sent via the [Pushover API](https://pushover.net/api).
 
 ```
+# Whether or not to notify about resolved alerts.
+[ send_resolved: <boolean> | default = true ]
+
 # The recipient user’s user key.
 user_key: <secret>
 
@@ -421,6 +424,9 @@ api_key: <secret>
 VictorOps notifications are sent out via the [VictorOps API](https://help.victorops.com/knowledge-base/victorops-restendpoint-integration/)
 
 ```
+# Whether or not to notify about resolved alerts.
+[ send_resolved: <boolean> | default = true ]
+
 # The API key to use when talking to the VictorOps API.
 [ api_key: <secret> | default = global.victorops_api_key ]
 


### PR DESCRIPTION
I've added send_resolved to both pushover, and victorops.

1) Those are the only two not showing this option, form all other receivers
2) The send_resolved default is true for both, and for me make them even more important to document
