### PR TITLE
Add link_names option to slack_config

### DIFF
--- a/content/docs/alerting/configuration.md
+++ b/content/docs/alerting/configuration.md
@@ -388,6 +388,7 @@ channel: <tmpl_string>
 [ pretext: <tmpl_string> | default = '{{ template "slack.default.pretext" . }}' ]
 [ text: <tmpl_string> | default = '{{ template "slack.default.text" . }}' ]
 [ fallback: <tmpl_string> | default = '{{ template "slack.default.fallback" . }}' ]
+[ link_names: <boolean> | default = false ]
 ```
 
 


### PR DESCRIPTION
https://github.com/prometheus/alertmanager/blob/master/config/notifiers.go#L223