### PR TITLE
Add kafka_exporter to exporters

### DIFF
--- a/content/docs/instrumenting/exporters.md
+++ b/content/docs/instrumenting/exporters.md
@@ -58,8 +58,7 @@ wide variety of JVM-based applications, for example [Kafka](http://kafka.apache.
 
 ### Messaging systems
    * [Beanstalkd exporter](https://github.com/messagebird/beanstalkd_exporter)
-   * [Kafka consumer group exporter](https://github.com/kawamuray/prometheus-kafka-consumer-group-exporter)
-   * [Kafka ZooKeeper exporter](https://github.com/cloudflare/kafka_zookeeper_exporter)
+   * [Kafka exporter](https://github.com/danielqsj/kafka_exporter)
    * [NATS exporter](https://github.com/nats-io/prometheus-nats-exporter)
    * [NSQ exporter](https://github.com/lovoo/nsq_exporter)
    * [Mirth Connect exporter](https://github.com/vynca/mirth_exporter)


### PR DESCRIPTION
A faster and easier-to-use kafka exporter.

Compared with current two exporters: `Kafka consumer group exporter` and `Kafka ZooKeeper exporter`.
kafka_exporter get metrics directly from kafka cluster, which is more faster and easier-to-use.
And metrics of kafka_exporter contains all metrics of the above two exporters.
