### PR TITLE
The promtool ships with the server

### DIFF
--- a/content/docs/querying/rules.md
+++ b/content/docs/querying/rules.md
@@ -17,11 +17,11 @@ process. The changes are only applied if all rule files are well-formatted.
 
 ## Syntax-checking rules
 To quickly check whether a rule file is syntactically correct without starting
-a Prometheus server, install and run Prometheus's `promtool` command-line
-utility tool:
+a Prometheus server you can run Prometheus's `promtool` command-line
+utility tool. The `promtool` binary ships with the Prometheus server
+download.
 
 ```bash
-go get github.com/prometheus/prometheus/cmd/promtool
 promtool check-rules /path/to/example.rules
 ```
 

--- a/content/docs/querying/rules.md
+++ b/content/docs/querying/rules.md
@@ -18,8 +18,8 @@ process. The changes are only applied if all rule files are well-formatted.
 ## Syntax-checking rules
 To quickly check whether a rule file is syntactically correct without starting
 a Prometheus server you can run Prometheus's `promtool` command-line
-utility tool. The `promtool` binary ships with the Prometheus server
-download.
+utility tool. The `promtool` binary ships with the Prometheus
+server tarball.
 
 ```bash
 promtool check-rules /path/to/example.rules


### PR DESCRIPTION
You could they could grab the `promtool` standalone with `go get` but that assumes they have Go installed and setup. I think it's more likely they have the Prometheus server download. 