### PR TITLE
Add phalerts to the list of webhook integrations

### DIFF
--- a/content/docs/operating/integrations.md
+++ b/content/docs/operating/integrations.md
@@ -44,6 +44,7 @@ For notification mechanisms not natively supported by the Alertmanager, the
 [webhook receiver](/docs/alerting/configuration/#webhook_config) allows for integration.
 
   * [JIRA example](https://github.com/fabxc/jiralerts)
+  * [Phabricator / Maniphest](https://github.com/knyar/phalerts)
   * [SMS](https://github.com/messagebird/sachet): supports [multiple providers](https://github.com/messagebird/sachet/blob/master/examples/config.yaml)
   * [Telegram bot](https://github.com/inCaller/prometheus_bot)
 


### PR DESCRIPTION
This is a webhook service that creates and updates Phabricator [Maniphest](https://www.phacility.com/phabricator/maniphest/) tasks based on alerts.