### PR TITLE
Replace github.com/fabxc/jiralerts with github.com/alin-sinpalean/jiralert

### DIFF
--- a/content/docs/operating/integrations.md
+++ b/content/docs/operating/integrations.md
@@ -43,7 +43,7 @@ data volumes.
 For notification mechanisms not natively supported by the Alertmanager, the
 [webhook receiver](/docs/alerting/configuration/#webhook_config) allows for integration.
 
-  * [JIRA example](https://github.com/fabxc/jiralerts)
+  * [JIRAlert](https://github.com/alin-sinpalean/jiralert)
   * [Phabricator / Maniphest](https://github.com/knyar/phalerts)
   * [SMS](https://github.com/messagebird/sachet): supports [multiple providers](https://github.com/messagebird/sachet/blob/master/examples/config.yaml)
   * [Telegram bot](https://github.com/inCaller/prometheus_bot)


### PR DESCRIPTION
As a followup to https://github.com/prometheus/alertmanager/pull/1012 and the discussion there, I am adding JIRAlert as the webhook handler for JIRA.