### PR TITLE
Add link to webhook receiver implementations

### DIFF
--- a/content/docs/alerting/configuration.md
+++ b/content/docs/alerting/configuration.md
@@ -215,7 +215,7 @@ source_match_re:
 
 Receiver is a named configuration of one or more notification integrations.
 
-__We're not actively adding new receivers, we recommend implementing custom notification integrations via the [webhook](/docs/alerting/configuration/#webhook_config) receiver.__
+__We're not actively adding new receivers, we recommend implementing custom notification integrations via the [webhook](/docs/alerting/configuration/#webhook_config) receiver. Check [this list](https://prometheus.io/docs/operating/integrations/#alertmanager-webhook-receiver) for already implemented webhook receiver integrations.__
 
 ```
 # The unique name of the receiver.


### PR DESCRIPTION
Might be useful for readers of the documentation to check for existing webhook implementations before they start rolling their own.