### PR TITLE
Use escaped #<remote_read> and #<remote_write> in integration links.

### DIFF
--- a/content/docs/operating/integrations.md
+++ b/content/docs/operating/integrations.md
@@ -26,7 +26,7 @@ For service discovery mechanisms not natively supported by Prometheus,
 
 ## Remote Endpoints and Storage
 
-The [remote write](/docs/operating/configuration/#<remote_write>) and [remote read](/docs/operating/configuration/#remote_read)
+The [remote write](/docs/operating/configuration/#%3Cremote_write%3E) and [remote read](/docs/operating/configuration/#%3Cremote_read%3E)
 features of Prometheus allow transparently sending and receiving samples. This
 is primarily intended for long term storage. It is recommended that you perform
 careful evaulation of any solution in this space to confirm it can handle your


### PR DESCRIPTION
Neither of these anchor tags work atm.

Escape the links in the same way known-working FAQ.md does.
See the link to configuration#<scrape_config>:
https://prometheus.io/docs/introduction/faq/#why-don-t-the-prometheus-server-components-support-tls-or-authentication-can-i-add-those