### PR TITLE
Add link to SignalFx

### DIFF
--- a/content/docs/operating/integrations.md
+++ b/content/docs/operating/integrations.md
@@ -39,6 +39,7 @@ data volumes.
   * [InfluxDB](https://github.com/prometheus/prometheus/tree/master/documentation/examples/remote_storage/remote_storage_adapter): read and write
   * [OpenTSDB](https://github.com/prometheus/prometheus/tree/master/documentation/examples/remote_storage/remote_storage_adapter): write
   * [PostgreSQL/TimescaleDB](https://github.com/timescale/prometheus-postgresql-adapter): read and write
+  * [SignalFx](https://github.com/signalfx/metricproxy#prometheus): write
 
 ## Alertmanager Webhook Receiver
 


### PR DESCRIPTION
We support the SignalFx metric proxy as Prometheus Remote Storage.