### PR TITLE
fix examples documentation

### DIFF
--- a/content/docs/alerting/notification_examples.md
+++ b/content/docs/alerting/notification_examples.md
@@ -16,7 +16,7 @@ global:
   slack_api_url: '<slack_webhook_url>'
 
 route:
-- receiver: 'slack-notifications'
+  receiver: 'slack-notifications'
   group_by: [alertname, datacenter, app]
 
 receivers:
@@ -84,7 +84,7 @@ global:
   slack_api_url: '<slack_webhook_url>'
 
 route:
-- receiver: 'slack-notifications'
+  receiver: 'slack-notifications'
   group_by: [alertname, datacenter, app]
 
 receivers:


### PR DESCRIPTION
@brian-brazil 
Fix examples documentation.
If used examples from documentation receive the error below:
Checking '/etc/alertmanager/alertmanager.yml'  FAILED: yaml: unmarshal errors:
  line 5: cannot unmarshal !!seq into config.plain