### PR TITLE
Fixed broken link to Alertmanager configuration

### DIFF
--- a/content/docs/alerting/overview.md
+++ b/content/docs/alerting/overview.md
@@ -14,5 +14,5 @@ sending out notifications via methods such as email, PagerDuty and HipChat.
 The main steps to setting up alerting and notifications are:
 
 * Setup and [configure](../configuration) the Alertmanager
-* [Configure Prometheus](../prometheus/latest/configuration/configuration/#<alertmanager_config>) to talk to the Alertmanager
+* [Configure Prometheus](../../prometheus/latest/configuration/configuration/#<alertmanager_config>) to talk to the Alertmanager
 * Create [alerting rules](../rules) in Prometheus


### PR DESCRIPTION
On this page:

https://prometheus.io/docs/alerting/overview/

This link is broken:

https://prometheus.io/docs/alerting/prometheus/latest/configuration/configuration/#%3Calertmanager_config

This fixes it.