### PR TITLE
Prevent regex matches on undefined labels

### DIFF
--- a/static/routing-tree.js
+++ b/static/routing-tree.js
@@ -118,6 +118,9 @@ function matchLabel(matcher, labelSet) {
   var v = labelSet[matcher.name];
 
   if (matcher.isRegex) {
+    // Prevent regex matches on undefined labels.
+    if (undefined === v) return false;
+    
     return matcher.value.test(v)
   }
 

--- a/static/routing-tree.js
+++ b/static/routing-tree.js
@@ -119,8 +119,8 @@ function matchLabel(matcher, labelSet) {
 
   if (matcher.isRegex) {
     // Prevent regex matches on undefined labels.
-    if (undefined === v) return false;
-    
+    if (undefined === v) v = '';
+
     return matcher.value.test(v)
   }
 


### PR DESCRIPTION
In the routing tree editor, given the following `config.yml`:
```yaml
route:
  receiver: A
  routes:
    - receiver: B
      match_re:
        app: .+
    - receiver: C
      match:
        system: foo
```

A label set of `{system="foo"}` is shown as routing to receiver B when it'll actually route to receiver C.

Root of the problem is that in `matcher.value.test(v)`, undefined values of `v` are cast to a string `'undefined'`. This resolves the issue by explicitly checking for undefined label values.

@brian-brazil