### PR TITLE
Fix label matching in routing tree editor

### DIFF
--- a/static/routing-tree.js
+++ b/static/routing-tree.js
@@ -159,7 +159,7 @@ function massage(root) {
     for (var key in root.match_re) {
       var o = {};
       o.isRegex = true;
-      o.value = new RegExp(root.match_re[key]);
+      o.value = new RegExp("^(?:" + root.match_re[key] + ")$");
       o.name = key;
       matchers.push(o);
     }

--- a/static/routing-tree.js
+++ b/static/routing-tree.js
@@ -115,7 +115,10 @@ function matchLabels(matchers, labelSet) {
 
 // Compare single matcher to labelSet
 function matchLabel(matcher, labelSet) {
-  var v = labelSet[matcher.name];
+  var v = "";
+  if (matcher.name in labelSet) {
+    v = labelSet[matcher.name];
+  }
 
   if (matcher.isRegex) {
     return matcher.value.test(v)


### PR DESCRIPTION
Hi @brian-brazil,

Label matching in routing tree editor is not consistent with Alertmanager:
- Unset labels must match empty string. [Source][1].
- Regexps must be anchored with start / end and wrapped in a non-capturing group. [Source][2].

Fixes #919.

[1]: https://github.com/prometheus/alertmanager/blob/v0.11.0/types/match.go#L69-L81
[2]: https://github.com/prometheus/alertmanager/blob/v0.11.0/config/config.go#L486-L498
