### PR TITLE
List concourse integration

### DIFF
--- a/content/docs/instrumenting/exporters.md
+++ b/content/docs/instrumenting/exporters.md
@@ -166,6 +166,7 @@ separate exporters are needed:
 
    * [Ceph](http://docs.ceph.com/docs/master/mgr/prometheus/)
    * [Collectd](https://collectd.org/wiki/index.php/Plugin:Write_Prometheus)
+   * [Concourse](https://concourse.ci/) (**direct**)
    * [CRG Roller Derby Scoreboard](https://github.com/rollerderby/scoreboard) (**direct**)
    * [Doorman](https://github.com/youtube/doorman) (**direct**)
    * [Etcd](https://github.com/coreos/etcd) (**direct**)

--- a/content/docs/instrumenting/exporters.md
+++ b/content/docs/instrumenting/exporters.md
@@ -166,7 +166,7 @@ separate exporters are needed:
 
    * [Ceph](http://docs.ceph.com/docs/master/mgr/prometheus/)
    * [Collectd](https://collectd.org/wiki/index.php/Plugin:Write_Prometheus)
-   * [Concourse](https://concourse.ci/) (**direct**)
+   * [Concourse](https://concourse.ci/)
    * [CRG Roller Derby Scoreboard](https://github.com/rollerderby/scoreboard) (**direct**)
    * [Doorman](https://github.com/youtube/doorman) (**direct**)
    * [Etcd](https://github.com/coreos/etcd) (**direct**)


### PR DESCRIPTION
As of the latest release, concourse ci can export metrics to prometheus: https://github.com/concourse/atc/blob/master/metric/emitter/prometheus.go.