### PR TITLE
Add conntrack_exporter to exporters

### DIFF
--- a/content/docs/instrumenting/exporters.md
+++ b/content/docs/instrumenting/exporters.md
@@ -54,6 +54,7 @@ wide variety of JVM-based applications, for example [Kafka](http://kafka.apache.
    * [IPMI exporter](https://github.com/lovoo/ipmi_exporter)
    * [knxd exporter](https://github.com/RichiH/knxd_exporter)
    * [Node/system metrics exporter](https://github.com/prometheus/node_exporter) (**official**)
+   * [conntrack network connection exporter](https://github.com/hiveco/conntrack_exporter)
    * [Ubiquiti UniFi exporter](https://github.com/mdlayher/unifi_exporter)
 
 ### Messaging systems


### PR DESCRIPTION
Uses libnetfilter_conntrack for direct access to the Linux kernel's connection table and exports network connections like this:

```
# HELP conntrack_open_connections How many open connections are there to the remote host?
# TYPE conntrack_open_connections gauge
conntrack_open_connections{host="10.0.1.5:3306"} 49
```

This exporter was created because we had trouble pinning down why sometimes connections from an app to redis were timing out, and when we used this exporter to graph the network connections on a redis instance we saw that instead of 3-4 stable connections our apps were creating far more and they were intermittent. Saved the day for us, and it wasn't possible to do this with node_exporter's `tcpstat` because the latter sums up all connections from everywhere and doesn't break them down by remote host.

This exporter also has almost zero overhead. We ran it in production and there was no noticeable increase in CPU or RAM usage, so we have plans to roll it out on all internal boxes.

Small writeup why this is complementary to node_exporter's `tcpstat` is [here](https://github.com/hiveco/conntrack_exporter#doesnt-prometheus-already-monitor-the-systems-connections-natively).

This doesn't go against Prometheus's guidelines against label explosion [here](https://prometheus.io/docs/practices/naming/#labels) because as mentioned in [this FAQ](https://github.com/hiveco/conntrack_exporter#should-i-run-this-on-a-server-that-listens-for-external-internet-connections), it's supposed to be run on an internal, non-public facing server. Therefore the number of metric:label pairs created should be very reasonable.