### PR TITLE
Add new phpfpm exporter to list

### DIFF
--- a/content/docs/instrumenting/exporters.md
+++ b/content/docs/instrumenting/exporters.md
@@ -140,6 +140,7 @@ wide variety of JVM-based applications, for example [Kafka](http://kafka.apache.
    * [Meteor JS web framework exporter](https://atmospherejs.com/sevki/prometheus-exporter)
    * [Minecraft exporter module](https://github.com/Baughn/PrometheusIntegration)
    * [PHP-FPM exporter](https://github.com/bakins/php-fpm-exporter)
+   * [PHP-FPM status exporter](https://github.com/Lusitaniae/phpfpm_exporter)
    * [PowerDNS exporter](https://github.com/ledgr/powerdns_exporter)
    * [Process exporter](https://github.com/ncabatoff/process-exporter)
    * [rTorrent exporter](https://github.com/mdlayher/rtorrent_exporter)


### PR DESCRIPTION
Reasons to include an additional exporter for phpfpm:
- It scrapes the status page via unix sockets. (The alternative scrapes via http)
- Automatic builds with release to GH, Quay and Docker.
- Ability to monitor multiple phpfpm pools.
- Ability to include script metrics (such as opcache metrics)

@brian-brazil Let me know what you think