### PR TITLE
integration: Adding Gnocchi

### DIFF
--- a/content/docs/operating/integrations.md
+++ b/content/docs/operating/integrations.md
@@ -36,6 +36,7 @@ data volumes.
   * [Chronix](https://github.com/ChronixDB/chronix.ingester): write
   * [Cortex](https://github.com/weaveworks/cortex): read and write
   * [CrateDB](https://github.com/crate/crate_adapter): read and write
+  * [Gnocchi](https://gnocchi.xyz/prometheus.html): write
   * [Graphite](https://github.com/prometheus/prometheus/tree/master/documentation/examples/remote_storage/remote_storage_adapter): write
   * [InfluxDB](https://github.com/prometheus/prometheus/tree/master/documentation/examples/remote_storage/remote_storage_adapter): read and write
   * [OpenTSDB](https://github.com/prometheus/prometheus/tree/master/documentation/examples/remote_storage/remote_storage_adapter): write


### PR DESCRIPTION
Gnocchi can be used as remote endpoints and storage.

This change adds this in the documentation.