### PR TITLE
Added pgbouncer exporter to exporters list

### DIFF
--- a/content/docs/instrumenting/exporters.md
+++ b/content/docs/instrumenting/exporters.md
@@ -41,6 +41,7 @@ wide variety of JVM-based applications, for example [Kafka](http://kafka.apache.
    * [MySQL server exporter](https://github.com/prometheus/mysqld_exporter) (**official**)
    * [OpenTSDB Exporter](https://github.com/cloudflare/opentsdb_exporter)
    * [PgBouncer exporter](http://git.cbaines.net/prometheus-pgbouncer-exporter/about)
+   * [PgBouncer exporter with support for multiple backends](https://github.com/spreaker/prometheus-pgbouncer-exporter)
    * [PostgreSQL exporter](https://github.com/wrouesnel/postgres_exporter)
    * [ProxySQL exporter](https://github.com/percona/proxysql_exporter)
    * [Redis exporter](https://github.com/oliver006/redis_exporter)


### PR DESCRIPTION
I've added to the list of exporter another exporter for pgbouncer (PostgresSQL connections pooler) whose main difference for the already-existing one is supporting multiple pgbouncer backends.

---

#### Why supporting multiple pgbouncer instances?

PgBouncer is a single thread application and so can only saturate a single CPU core on high load. In high load environments, it's common practice to run multiple pgbouncer processes per machine (one for each CPU core) and load balance traffic among them. Ideally we want to run a single exporter instance per machine, capable to monitor 1+ pgbouncer(s) running on the machine itself.