### PR TITLE
add osquery_exporter to the list of exporters

### DIFF
--- a/content/docs/instrumenting/exporters.md
+++ b/content/docs/instrumenting/exporters.md
@@ -120,6 +120,7 @@ wide variety of JVM-based applications, for example [Kafka](http://kafka.apache.
    * [Nagios / Naemon exporter](https://github.com/Griesbacher/Iapetos)
    * [New Relic exporter](https://github.com/jfindley/newrelic_exporter)
    * [NRPE exporter](https://github.com/robustperception/nrpe_exporter)
+   * [Osquery exporter](https://github.com/zwopir/osquery_exporter)
    * [Pingdom exporter](https://github.com/giantswarm/prometheus-pingdom-exporter)
    * [scollector exporter](https://github.com/tgulacsi/prometheus_scollector)
    * [Sensu exporter](https://github.com/reachlin/sensu_exporter)


### PR DESCRIPTION
add osquery_exporter to the list of exporters. The exporter exports metrics retreived via osquery (https://osquery.io) as prometheus metrics. 