### PR TITLE
docs/alerting: updating pagerduty_url default

### DIFF
--- a/content/docs/alerting/configuration.md
+++ b/content/docs/alerting/configuration.md
@@ -77,7 +77,7 @@ global:
   [ slack_api_url: <string> ]
   [ victorops_api_key: <string> ]
   [ victorops_api_url: <string> | default = "https://alert.victorops.com/integrations/generic/20131114/alert/" ]
-  [ pagerduty_url: <string> | default = "https://events.pagerduty.com/generic/2010-04-15/create_event.json" ]
+  [ pagerduty_url: <string> | default = "https://events.pagerduty.com/v2/enqueue" ]
   [ opsgenie_api_url: <string> | default = "https://api.opsgenie.com/" ]
   [ hipchat_url: <string> | default = "https://api.hipchat.com/" ]
   [ hipchat_auth_token: <secret> ]


### PR DESCRIPTION
It has been changed to use the Pagerduty v2 API by default in Alertmanager.

https://github.com/prometheus/alertmanager/blob/master/config/config.go#L324