### PR TITLE
correct number of options in global config block

### DIFF
--- a/content/docs/introduction/first_steps.md
+++ b/content/docs/introduction/first_steps.md
@@ -53,7 +53,7 @@ scrape_configs:
 
 There are three blocks of configuration in the example configuration file: `global`, `rule_files`, and `scrape_configs`. 
 
-The `global` block controls the Prometheus server's global configuration. We have three options present. The first, `scrape_interval`, controls how often Prometheus will scrape targets. You can override this for individual targets. In this case the global setting is to scrape every 15 seconds. The `evaluation_interval` option controls how often Prometheus will evaluate rules. Prometheus uses rules to create new time series and to generate alerts.
+The `global` block controls the Prometheus server's global configuration. We have two options present. The first, `scrape_interval`, controls how often Prometheus will scrape targets. You can override this for individual targets. In this case the global setting is to scrape every 15 seconds. The `evaluation_interval` option controls how often Prometheus will evaluate rules. Prometheus uses rules to create new time series and to generate alerts.
 
 The `rule_files` block specifies the location of any rules we want the Prometheus server to load. For now we've got no rules.
 


### PR DESCRIPTION
I'm digging into prometheus for the first time today by reading all of the official docs. I noted that the number of options mentioned as being present in the global config block seems to be incorrect. Have I missed something or is this actually wrong?

Thanks so much for making this project available to the world, I'm really excited to start using it 💃 !