### PR TITLE
Add apache yarn and apache airflow exporters

### DIFF
--- a/content/docs/instrumenting/exporters.md
+++ b/content/docs/instrumenting/exporters.md
@@ -129,7 +129,6 @@ wide variety of JVM-based applications, for example [Kafka](http://kafka.apache.
 
 ### Miscellaneous
    * [Apache Airflow exporter](https://github.com/PBWebMedia/airflow-prometheus-exporter)
-   * [Apache Hadoop YARN exporter](https://github.com/PBWebMedia/yarn-prometheus-exporter)
    * [BIG-IP exporter](https://github.com/ExpressenAB/bigip_exporter)
    * [BIND exporter](https://github.com/digitalocean/bind_exporter)
    * [Bitbucket exporter](https://github.com/AndreyVMarkelov/prom-bitbucket-exporter)

--- a/content/docs/instrumenting/exporters.md
+++ b/content/docs/instrumenting/exporters.md
@@ -128,6 +128,8 @@ wide variety of JVM-based applications, for example [Kafka](http://kafka.apache.
    * [StatsD exporter](https://github.com/prometheus/statsd_exporter) (**official**)
 
 ### Miscellaneous
+   * [Apache Airflow exporter](https://github.com/PBWebMedia/airflow-prometheus-exporter)
+   * [Apache Hadoop YARN exporter](https://github.com/PBWebMedia/yarn-prometheus-exporter)
    * [BIG-IP exporter](https://github.com/ExpressenAB/bigip_exporter)
    * [BIND exporter](https://github.com/digitalocean/bind_exporter)
    * [Bitbucket exporter](https://github.com/AndreyVMarkelov/prom-bitbucket-exporter)


### PR DESCRIPTION
I could not find exporters for [Apache Airflow](https://airflow.apache.org/) and [Apache YARN](https://hadoop.apache.org/docs/current/hadoop-yarn/hadoop-yarn-site/YARN.html), so we decided to create it ourselves and publish the exporters on our github and the docker hub.