### PR TITLE
adding patterdale as an oracle db exporter

### DIFF
--- a/content/docs/instrumenting/exporters.md
+++ b/content/docs/instrumenting/exporters.md
@@ -40,6 +40,7 @@ wide variety of JVM-based applications, for example [Kafka](http://kafka.apache.
    * [MSSQL server exporter](https://github.com/awaragi/prometheus-mssql-exporter)
    * [MySQL server exporter](https://github.com/prometheus/mysqld_exporter) (**official**)
    * [OpenTSDB Exporter](https://github.com/cloudflare/opentsdb_exporter)
+   * [Oracle DB exporter](https://github.com/tjheslin1/Patterdale)
    * [PgBouncer exporter](http://git.cbaines.net/prometheus-pgbouncer-exporter/about)
    * [PostgreSQL exporter](https://github.com/wrouesnel/postgres_exporter)
    * [ProxySQL exporter](https://github.com/percona/proxysql_exporter)


### PR DESCRIPTION
I created this project to expose metrics for a set of Oracle databases.

The oracle jdbc driver must be provided at runtime due to Oracle's policies.

Furthermore we wanted to run oracle specific queries.