### PR TITLE
Add iis exporter to the list

### DIFF
--- a/content/docs/instrumenting/exporters.md
+++ b/content/docs/instrumenting/exporters.md
@@ -105,6 +105,7 @@ wide variety of JVM-based applications, for example [Kafka](http://kafka.apache.
    * [Fluentd exporter](https://github.com/V3ckt0r/fluentd_exporter)
    * [Google's mtail log data extractor](https://github.com/google/mtail)
    * [Grok exporter](https://github.com/fstab/grok_exporter)
+   * [IIS exporter] (https://github.com/GrupaPracuj/iislog-prometheus-exporter)
 
 ### Other monitoring systems
    * [Akamai Cloudmonitor exporter](https://github.com/ExpressenAB/cloudmonitor_exporter)


### PR DESCRIPTION
Hi,

We created this exporter to collect metrics from websites hosted on IIS (amount of processed HTTP requests, response times, request sizes etc.).
It watches a given directory with IIS logs, always finds the newest file and exposes live metrics for Prometheus.
