### PR TITLE
content: clarifications around adding a new team member in governance

### DIFF
--- a/content/governance.md
+++ b/content/governance.md
@@ -32,9 +32,11 @@ Team member status may be given to those who have made ongoing contributions to 
 
 New members may be proposed by any existing member by email to [prometheus-team][team]. It is highly desirable to reach consensus about acceptance of a new member. However, the proposal is ultimately voted on by a formal [supermajority vote](#supermajority-vote).
 
-If the new member proposal is accepted, the proposed team member should be contacted privately to confirm or deny their acceptance of team membership. If they choose to accept, the following steps should be taken:
+If the new member proposal is accepted, the proposed team member should be contacted privately via email to confirm or deny their acceptance of team membership. This email should also be CC'd to [prometheus-team][team] for record keeping purposes.
 
-* Team members are added to the [GitHub organization][gh] as _Owner_. They should however respect the maintainers of each project.
+If they choose to accept, the following steps are taken:
+
+* Team members are added to the [GitHub organization][gh] as _Owner_.
 
 * Team members are added to the [team mailing list][team].
 

--- a/content/governance.md
+++ b/content/governance.md
@@ -32,7 +32,15 @@ Team member status may be given to those who have made ongoing contributions to 
 
 New members may be proposed by any existing member by email to [prometheus-team][team]. It is highly desirable to reach consensus about acceptance of a new member. However, the proposal is ultimately voted on by a formal [supermajority vote](#supermajority-vote).
 
-Team members are added to the [GitHub organization][gh] as _Owner_. They should however respect the maintainers of each project.
+If the new member proposal is accepted, the proposed team member should be contacted privately to confirm or deny their acceptance of team membership. If they choose to accept, the following steps should be taken:
+
+* Team members are added to the [GitHub organization][gh] as _Owner_. They should however respect the maintainers of each project.
+
+* Team members are added to the [team mailing list][team].
+
+* Team members are added to the list of team members in this document.
+
+* New team members are announced on the [developers mailing list][devs] by an existing team member.
 
 Team members may retire at any time by emailing [the team][team].
 

--- a/content/governance.md
+++ b/content/governance.md
@@ -32,7 +32,7 @@ Team member status may be given to those who have made ongoing contributions to 
 
 New members may be proposed by any existing member by email to [prometheus-team][team]. It is highly desirable to reach consensus about acceptance of a new member. However, the proposal is ultimately voted on by a formal [supermajority vote](#supermajority-vote).
 
-If the new member proposal is accepted, the proposed team member should be contacted privately via email to confirm or deny their acceptance of team membership. This email should also be CC'd to [prometheus-team][team] for record keeping purposes.
+If the new member proposal is accepted, the proposed team member should be contacted privately via email to confirm or deny their acceptance of team membership. This email will also be CC'd to [prometheus-team][team] for record keeping purposes.
 
 If they choose to accept, the following steps are taken:
 

--- a/content/governance.md
+++ b/content/governance.md
@@ -32,16 +32,13 @@ Team member status may be given to those who have made ongoing contributions to 
 
 New members may be proposed by any existing member by email to [prometheus-team][team]. It is highly desirable to reach consensus about acceptance of a new member. However, the proposal is ultimately voted on by a formal [supermajority vote](#supermajority-vote).
 
-If the new member proposal is accepted, the proposed team member should be contacted privately via email to confirm or deny their acceptance of team membership. This email will also be CC'd to [prometheus-team][team] for record keeping purposes.
+If the new member proposal is accepted, the proposed team member should be contacted privately via email to confirm or deny their acceptance of team membership. This email will also be CC'd to [prometheus-team][team] for record-keeping purposes.
 
 If they choose to accept, the following steps are taken:
 
 * Team members are added to the [GitHub organization][gh] as _Owner_.
-
 * Team members are added to the [team mailing list][team].
-
 * Team members are added to the list of team members in this document.
-
 * New team members are announced on the [developers mailing list][devs] by an existing team member.
 
 Team members may retire at any time by emailing [the team][team].


### PR DESCRIPTION
I propose these changes to our governance process to clarify some of the steps taken when adding Krasi as a new member of the Prometheus team.

@juliusv mentioned this in an email in the group:
> Btw., the governance only states about new team members, "Team members are added to the GitHub organization as Owner.". It doesn't state explicitly that they should also be added to the prometheus-team mailing list, although the definition at the top implies it: "Team members: Any members of the private prometheus-team Google group."

It feels like it's worth explicitly stating this.  I have also added a couple bullets so that team members have a checklist for adding new members.

I'll create a thread on developers regarding these changes, so that we can gather feedback and comments on the wording, process, etc.

If the response is favorable, I will call a formal vote on the list at a later time.

**Please only comment on GitHub for minor changes such as wording, grammer, etc.**  In depth discussion should take place on the developers thread here, per our governance: https://groups.google.com/forum/#!topic/prometheus-developers/qr9rbdZUsnY.