### PR TITLE
fix indentation on node_exporter example

### DIFF
--- a/content/docs/introduction/first_steps.md
+++ b/content/docs/introduction/first_steps.md
@@ -152,8 +152,8 @@ We will configure Prometheus to scrape this new target. To achieve this, add a n
 
 ```
 - job_name: node
-    static_configs:
-      - targets: ['localhost:9100']
+  static_configs:
+    - targets: ['localhost:9100']
 ```
 
 Our new job is called `node`. It scrapes a static target, `localhost` on port `9100`. You would replace this name with the name or IP address of the host you're monitoring. 


### PR DESCRIPTION
This is a tiny tiny change to fix an example in the introduction docs. If used verbatim in its current state, prometheus will fail to start.