### PR TITLE
added nginxplus_exporter to list of exporters

### DIFF
--- a/content/docs/instrumenting/exporters.md
+++ b/content/docs/instrumenting/exporters.md
@@ -79,6 +79,7 @@ wide variety of JVM-based applications, for example [Kafka](http://kafka.apache.
    * [Apache exporter](https://github.com/Lusitaniae/apache_exporter)
    * [HAProxy exporter](https://github.com/prometheus/haproxy_exporter) (**official**)
    * [Nginx metric library](https://github.com/knyar/nginx-lua-prometheus)
+   * [Nginx Plus exporter](https://github.com/avthart/nginxplus_exporter)
    * [Nginx VTS exporter](https://github.com/hnlq715/nginx-vts-exporter)
    * [Passenger exporter](https://github.com/stuartnelson3/passenger_exporter)
    * [Tinyproxy exporter](https://github.com/igzivkov/tinyproxy_exporter)


### PR DESCRIPTION
NGINX Plus exporter. Exporter using the `ngx_http_status_module` module which provides access to various status information. This module is available as part of NGINX Plus commercial subscription.
http://nginx.org/en/docs/http/ngx_http_status_module.html