### PR TITLE
Add bitcoind-exporter to the list of misc. exporters

### DIFF
--- a/content/docs/instrumenting/exporters.md
+++ b/content/docs/instrumenting/exporters.md
@@ -166,6 +166,7 @@ wide variety of JVM-based applications, for example [Kafka](http://kafka.apache.
 ### Miscellaneous
    * [ACT Fibernet Exporter](https://git.captnemo.in/nemo/prometheus-act-exporter)
    * [BIND exporter](https://github.com/digitalocean/bind_exporter)
+   * [Bitcoind exporter](https://github.com/LePetitBloc/bitcoind-exporter)
    * [Blackbox exporter](https://github.com/prometheus/blackbox_exporter) (**official**)
    * [BOSH exporter](https://github.com/cloudfoundry-community/bosh_exporter)
    * [cAdvisor](https://github.com/google/cadvisor)


### PR DESCRIPTION
Hi there,

Our [bitcoind-exporter](https://github.com/LePetitBloc/bitcoind-exporter) is finally ready.
`Bitcoind` is the official bitcoin daemon, this exporter rely on the **bitcoin** JsonRPC API to get chain synchronization metrics, wallet balances, address balances, etc...

Hence I'm proposing to add it to the list.

Before anything, we would be glad to get a review of the exposed metrics, here's an example:

```
# HELP bitcoind_best_block_index The block height or index
# TYPE bitcoind_best_block_index gauge
bitcoind_best_block_index 69019

# HELP bitcoind_best_block_timestamp_seconds The block time in seconds since epoch (Jan 1 1970 GMT)
# TYPE bitcoind_best_block_timestamp_seconds gauge
bitcoind_best_block_timestamp_seconds 1522746083

# HELP bitcoind_chain_difficulty The proof-of-work difficulty as a multiple of the minimum difficulty
# TYPE bitcoind_chain_difficulty gauge
bitcoind_chain_difficulty 3511060552899.72

# HELP bitcoind_wallet_version the wallet version
# TYPE bitcoind_wallet_version gauge
bitcoind_wallet_version{ticker="BTC"} 71000

# HELP bitcoind_wallet_balance_total the total balance of the wallet
# TYPE bitcoind_wallet_balance_total gauge
bitcoind_wallet_balance_total{status="unconfirmed"} 2.7345
bitcoind_wallet_balance_total{status="immature"} 0
bitcoind_wallet_balance_total{status="confirmed"} 42.73453501

# HELP bitcoind_wallet_transactions_total the total number of transactions in the wallet
# TYPE bitcoind_wallet_transactions_total gauge
bitcoind_wallet_transactions_total 77

# HELP bitcoind_wallet_key_pool_oldest_timestamp_seconds the timestamp of the oldest pre-generated key in the key pool
# TYPE bitcoind_wallet_key_pool_oldest_timestamp_seconds gauge
bitcoind_wallet_key_pool_oldest_timestamp_seconds 1516231938

# HELP bitcoind_wallet_key_pool_size_total How many new keys are pre-generated.
# TYPE bitcoind_wallet_key_pool_size_total gauge
bitcoind_wallet_key_pool_size_total 1000

# HELP bitcoind_wallet_unlocked_until_timestamp_seconds the timestamp that the wallet is unlocked for transfers, or 0 if the wallet is locked
# TYPE bitcoind_wallet_unlocked_until_timestamp_seconds gauge
bitcoind_wallet_unlocked_until_timestamp_seconds 0

# HELP bitcoind_wallet_pay_tx_fee_per_kilo_bytes the transaction fee configuration, set in Unit/kB
# TYPE bitcoind_wallet_pay_tx_fee_per_kilo_bytes gauge
bitcoind_wallet_pay_tx_fee_per_kilo_bytes 0

# HELP bitcoind_address_balance_total address balance
# TYPE bitcoind_address_balance_total gauge
bitcoind_address_balance_total{address="1FxZE15d8bt381EuDckdDdp7vw8FUiLzu6"} 41.00683469
bitcoind_address_balance_total{address="1QAm6J6jLmcm7ce87ujrSdmjPNX9fgRUYZ"} 1.72770032
```

We also reserved the port number `9439` at https://github.com/prometheus/prometheus/wiki/Default-port-allocations

Cheers.