### PR TITLE
Add dsari as software which directly provides Prometheus metrics

### DIFF
--- a/content/docs/instrumenting/exporters.md
+++ b/content/docs/instrumenting/exporters.md
@@ -179,6 +179,7 @@ separate exporters are needed:
    * [CRG Roller Derby Scoreboard](https://github.com/rollerderby/scoreboard) (**direct**)
    * [Docker Daemon](https://docs.docker.com/engine/reference/commandline/dockerd/#daemon-metrics)
    * [Doorman](https://github.com/youtube/doorman) (**direct**)
+   * [dsari](https://github.com/rfinnie/dsari)
    * [Etcd](https://github.com/coreos/etcd) (**direct**)
    * [FreeBSD Kernel](https://www.freebsd.org/cgi/man.cgi?query=prometheus_sysctl_exporter&apropos=0&sektion=8&manpath=FreeBSD+12-current&arch=default&format=html)
    * [Grafana](http://docs.grafana.org/administration/metrics/)


### PR DESCRIPTION
FYI, capitalization (or lack thereof) is correct.