### PR TITLE
Added RavenDB exporter to the list

### DIFF
--- a/content/docs/instrumenting/exporters.md
+++ b/content/docs/instrumenting/exporters.md
@@ -44,6 +44,7 @@ wide variety of JVM-based applications, for example [Kafka](http://kafka.apache.
    * [PgBouncer exporter](http://git.cbaines.net/prometheus-pgbouncer-exporter/about)
    * [PostgreSQL exporter](https://github.com/wrouesnel/postgres_exporter)
    * [ProxySQL exporter](https://github.com/percona/proxysql_exporter)
+   * [RavenDB exporter](https://github.com/marcinbudny/ravendb_exporter)
    * [Redis exporter](https://github.com/oliver006/redis_exporter)
    * [RethinkDB exporter](https://github.com/oliver006/rethinkdb_exporter)
    * [SQL exporter](https://github.com/free/sql_exporter)


### PR DESCRIPTION
This PR extends the list of exporters with [one for RavenDB](https://github.com/marcinbudny/ravendb_exporter). RavenDB is a [document database](https://ravendb.net/).