### PR TITLE
Replace lovoo/ipmi_exporter by soundcloud/ipmi_exporter

### DIFF
--- a/content/docs/instrumenting/exporters.md
+++ b/content/docs/instrumenting/exporters.md
@@ -54,7 +54,7 @@ wide variety of JVM-based applications, for example [Kafka](http://kafka.apache.
    * [apcupsd exporter](https://github.com/mdlayher/apcupsd_exporter)
    * [Collins exporter](https://github.com/soundcloud/collins_exporter)
    * [IoT Edison exporter](https://github.com/roman-vynar/edison_exporter)
-   * [IPMI exporter](https://github.com/lovoo/ipmi_exporter)
+   * [IPMI exporter](https://github.com/soundcloud/ipmi_exporter)
    * [knxd exporter](https://github.com/RichiH/knxd_exporter)
    * [Node/system metrics exporter](https://github.com/prometheus/node_exporter) (**official**)
    * [Ubiquiti UniFi exporter](https://github.com/mdlayher/unifi_exporter)


### PR DESCRIPTION
Frankly, I would prefer to list both as they have quite different
approaches. Lovoo's exporter runs on the IPMI-supervised host and uses
the `dev/ipmi0` device to server metrics. This is straight-forward but
doesn't work if the host is powered down. However, in some secnarios,
it's the whole point of IPMI to be able to work with machines while
they are powered down or stuck in the boot process. If you need
metrics in those scenarios, too, the SoundCloud exporter works
better. It uses the blackbox exporter approach and is thus (arguably)
a tad more complicated to set up.

If I _had_ to choose one and only one IPMI exporter, I would pick the
SoundCloud one as it covers all scenarios.  Since @brian-brazil has so far
insisted to only ever list one solution for a certain thing to
export, this commit _replaces_ the Lovoo exporter by the SoundCloud
exporter.

Discuss!

@brian-brazil see above.
@juliusv as another non-SC Promethean to help decide here.
@bitfehler is the main author of SC's IPMI exporter.
