### PR TITLE
Point out that docs are open source and can be edited

### DIFF
--- a/README.md
+++ b/README.md
@@ -3,6 +3,16 @@
 This repository contains both the content and the static-site generator code for the
 Prometheus documentation site.
 
+## Contributing Changes
+
+See [`CONTRIBUTING.md`](CONTRIBUTING.md) for general instructions for new Prometheus contributors.
+
+The main documentation contents of this website are located in the [`content/docs`](content/docs) directory.
+
+Documentation concerning the Prometheus server is [maintained in the Prometheus server repository](https://github.com/prometheus/prometheus/tree/master/docs) and cloned into the website at build time.
+
+As a guideline, please keep the documentation generally applicable and avoid use-case-specific changes.
+
 ## Prerequisites
 
 You need to have a working Ruby environment set up and then install the

--- a/content/css/docs.css
+++ b/content/css/docs.css
@@ -398,6 +398,14 @@ footer {
   margin-left: 0;
 }
 
+.doc-content .open-source-notice {
+  color: #666;
+  background-color: #f5f5f5;
+  text-align: center;
+  padding: 0.8em;
+  margin-top: 1.5em;
+}
+
 .toc {
   padding: 1em;
   background-color: #f5f5f5;

--- a/layouts/docs.html
+++ b/layouts/docs.html
@@ -13,7 +13,7 @@
     <div class="col-md-9 doc-content">
       <%= yield %>
       <p class="open-source-notice">
-          <i class="fa fa-file"></i> This documentation is <a href="https://github.com/prometheus/docs">open-source</a>. Please help improve it by filing issues or pull requests.
+          <i class="fa fa-file"></i> This documentation is <a href="https://github.com/prometheus/docs#contributing-changes">open-source</a>. Please help improve it by filing issues or pull requests.
       </p>
     </div>
 

--- a/layouts/docs.html
+++ b/layouts/docs.html
@@ -12,6 +12,9 @@
 
     <div class="col-md-9 doc-content">
       <%= yield %>
+      <p class="open-source-notice">
+          <i class="fa fa-file"></i> This documentation is <a href="https://github.com/prometheus/docs">open-source</a>. Please help improve it by filing issues or pull requests.
+      </p>
     </div>
 
   </div>


### PR DESCRIPTION
This adds a little banner at the bottom of all the pages under "Docs":

![docs-notice](https://user-images.githubusercontent.com/538008/40673212-6b35ac30-6371-11e8-9fa2-c4d41d939461.png)

It does not yet handle the case of Prometheus server docs being in a separate repo, but maybe that should just be better explained as part of the README.md of the docs repo we are linking to.