### PR TITLE
Remove broken link to logo author's website

### DIFF
--- a/content/community.html
+++ b/content/community.html
@@ -101,7 +101,7 @@ title: Community
       Special thanks to <a href="https://digitalocean.com/">DigitalOcean</a> for providing hosting resources.
     </p>
     <p>
-      The Prometheus logo was contributed by <a href="http://www.makingstuffmove.com/">Robin Greenwood</a>.
+      The Prometheus logo was contributed by Robin Greenwood.
     </p>
   </div>
 </div>


### PR DESCRIPTION
The website doesn't exist anymore and no comparable online presence
exists.

Fixes https://github.com/prometheus/docs/issues/794

Signed-off-by: Julius Volz <julius.volz@gmail.com>