### PR TITLE
Added EventStore exporter to the list

### DIFF
--- a/content/docs/instrumenting/exporters.md
+++ b/content/docs/instrumenting/exporters.md
@@ -35,6 +35,7 @@ wide variety of JVM-based applications, for example [Kafka](http://kafka.apache.
    * [Consul exporter](https://github.com/prometheus/consul_exporter) (**official**)
    * [CouchDB exporter](https://github.com/gesellix/couchdb-exporter)
    * [ElasticSearch exporter](https://github.com/justwatchcom/elasticsearch_exporter)
+   * [EventStore exporter](https://github.com/marcinbudny/eventstore_exporter)
    * [Memcached exporter](https://github.com/prometheus/memcached_exporter) (**official**)
    * [MongoDB exporter](https://github.com/dcu/mongodb_exporter)
    * [MSSQL server exporter](https://github.com/awaragi/prometheus-mssql-exporter)


### PR DESCRIPTION
Adds [EventStore exporter](https://github.com/marcinbudny/eventstore_exporter) to the list. EventStore is an... [event store](https://eventstore.org/).