### PR TITLE
Adds ACT Fibernet Exporter

### DIFF
--- a/content/docs/instrumenting/exporters.md
+++ b/content/docs/instrumenting/exporters.md
@@ -133,6 +133,7 @@ wide variety of JVM-based applications, for example [Kafka](http://kafka.apache.
    * [StatsD exporter](https://github.com/prometheus/statsd_exporter) (**official**)
 
 ### Miscellaneous
+   * [ACT Fibernet Exporter](https://git.captnemo.in/nemo/prometheus-act-exporter)
    * [Bamboo exporter](https://github.com/AndreyVMarkelov/bamboo-prometheus-exporter)
    * [BIG-IP exporter](https://github.com/ExpressenAB/bigip_exporter)
    * [BIND exporter](https://github.com/digitalocean/bind_exporter)


### PR DESCRIPTION
[ACT](https://www.actcorp.in/) is a Internet Service Provider in India. The provider exposes data usage metrics by scraping it from the ACT portal website.

Looks like this in Grafana:

![image](https://user-images.githubusercontent.com/584253/40926760-a2685b58-683a-11e8-8dde-a0f640713a87.png)
