### PR TITLE
Fixed transformation of svg pane

### DIFF
--- a/static/routing-tree.js
+++ b/static/routing-tree.js
@@ -42,7 +42,7 @@ function resetSVG() {
     .attr("width", diameter)
     .attr("height", diameter - 150)
     .append("g")
-    .attr("transform", "translate(" + diameter / 2 + "," + (diameter / 2 - 200) + ")");
+    .attr("transform", "translate(" + diameter / 2 + "," + (diameter / 2) + ")");
 }
 
 // Click handler for reading config.yml


### PR DESCRIPTION
There is an offset of 200 (pixels?) on svg pane, when visualizing more complex things. I have removed subtraction of magic constant and it seems it is working properly.
@brian-brazil please have a look at it. You can test it with these data:
```
  route:
    group_by: ['env', 'alertname']
    group_wait: 30s
    group_interval: 1m
    repeat_interval: 2h
    receiver: prometheus-alerts
    routes:
    - match_re:
        alertname: ^notifyd
      receiver: perl-E-alerts-prod
    - match_re:
        env: ".*-E"
      receiver: perl-E-alerts-prod
    - match_re:
        instance: ^rcentrala
      receiver: perl-E-alerts-prod
    - match_re:
        job: ^(kafka|zookeeper)$
      receiver: frontend-alerts
      continue: true #also continue matching after this match
    - match_re:
        alertname: ^NoBet2Hours$
      receiver: perl-E-alerts
      continue: true
    - match:
        job: projection
        env: prod
        alertname: ErrorLogged
      receiver: projection-errors
      continue: true
    - match:
        env: prod
      receiver: prometheus-alerts
```
Test can be done online at https://prometheus.io/webtools/alerting/routing-tree-editor/