### PR TITLE
Change VO config routing_key to reflect that it is a template string.

### DIFF
--- a/content/docs/alerting/configuration.md
+++ b/content/docs/alerting/configuration.md
@@ -552,7 +552,7 @@ VictorOps notifications are sent out via the [VictorOps API](https://help.victor
 [ api_url: <string> | default = global.victorops_api_url ]
 
 # A key used to map the alert to a team.
-routing_key: <string>
+routing_key: <tmpl_string>
 
 # Describes the behavior of the alert (CRITICAL, WARNING, INFO).
 [ message_type: <tmpl_string> | default = 'CRITICAL' ]


### PR DESCRIPTION
As per this issue: https://github.com/prometheus/alertmanager/issues/1404 I am updating the VO Config docs to show that routing_key is a tmpl_string and can be templated.