### PR TITLE
Add Ballerina to the list of software exposing Prometheus metrics

### DIFF
--- a/content/docs/instrumenting/exporters.md
+++ b/content/docs/instrumenting/exporters.md
@@ -178,6 +178,7 @@ possible.
 Some third-party software exposes metrics in the Prometheus format, so no
 separate exporters are needed:
 
+   * [Ballerina](https://ballerina.io/)
    * [Ceph](http://docs.ceph.com/docs/master/mgr/prometheus/)
    * [Collectd](https://collectd.org/wiki/index.php/Plugin:Write_Prometheus)
    * [Concourse](https://concourse-ci.org/)


### PR DESCRIPTION
[Ballerina](https://ballerina.io/) is a programming language for integration. Ballerina services are by default [observable](https://ballerina.io/learn/how-to-observe-ballerina-code/) and it supports Prometheus. Ballerina run-time will start an HTTP endpoint for Prometheus to scrape metrics when observability is enabled.

This PR adds Ballerina to the list of software exposing Prometheus metrics.