### PR TITLE
Provide vendored Ruby setup

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -11,7 +11,11 @@ tmp/
 # Crash Log
 crash.log
 
-# OS X file
-static/.DS_Store
+# macOS artifacts
+.DS_Store
 
 prometheus_rsa
+
+# Ruby artifacts
+.bundle/
+vendor/

--- a/Makefile
+++ b/Makefile
@@ -1,12 +1,18 @@
+NANOC      = bundle exec nanoc
+GUARD      = bundle exec guard
 DOWNLOADS := prometheus alertmanager blackbox_exporter consul_exporter graphite_exporter haproxy_exporter memcached_exporter mysqld_exporter node_exporter pushgateway statsd_exporter
 
 build: clean downloads compile
+
+bundle:
+	bundle config build.nokogiri --use-system-libraries
+	bundle install --path vendor
 
 clean:
 	rm -rf output downloads repositories
 
 compile:
-	bundle exec nanoc
+	$(NANOC)
 
 downloads: $(DOWNLOADS:%=downloads/%/repo.json) $(DOWNLOADS:%=downloads/%/releases.json)
 
@@ -20,4 +26,10 @@ downloads/%/releases.json:
 	@echo "curl -sf -H 'Accept: application/vnd.github.v3+json' <GITHUB_AUTHENTICATION> https://api.github.com/repos/prometheus/$*/releases > $@"
 	@curl -sf -H 'Accept: application/vnd.github.v3+json' $(GITHUB_AUTHENTICATION) https://api.github.com/repos/prometheus/$*/releases > $@
 
-.PHONY: build compile deploy
+guard:
+	$(GUARD)
+
+serve:
+	$(NANOC) view
+
+.PHONY: build bundle clean compile downloads serve

--- a/README.md
+++ b/README.md
@@ -15,12 +15,12 @@ As a guideline, please keep the documentation generally applicable and avoid use
 
 ## Prerequisites
 
-You need to have a working Ruby environment set up and then install the
-necessary gems:
+You need to have a working Ruby environment set up (including [bundler](https://bundler.io/))
+and then install the necessary gems:
 
 ```bash
 cd docs
-bundle
+make bundle
 ```
 
 ## Building
@@ -39,9 +39,9 @@ To run a local server that displays the generated site, run:
 
 ```bash
 # Rebuild the site whenever relevant files change:
-bundle exec guard
-# Start the local development server:
-bundle exec nanoc view
+make guard
+# Start the local development server in a separate shell:
+make serve
 ```
 
 You should now be able to view the generated site at


### PR DESCRIPTION
Getting Ruby set up properly can be tricky when working with global gems (as the current Ruby setup does). This PR changes the Ruby setup to use [vendoring](http://ryan.mcgeary.org/2011/02/09/vendor-everything-still-applies/) instead of global gems, which should obviate issues faced by some users.