### PR TITLE
Fix a typo in client.md

### DIFF
--- a/content/docs/alerting/clients.md
+++ b/content/docs/alerting/clients.md
@@ -25,7 +25,7 @@ the following format:
       ...
     },
     "annotations": {
-      "<annotationname>": "<annotationvalue>",
+      "<labelname>": "<labelvalue>",
     },
     "startsAt": "<rfc3339>",
     "endsAt": "<rfc3339>",

--- a/content/docs/alerting/clients.md
+++ b/content/docs/alerting/clients.md
@@ -25,10 +25,10 @@ the following format:
       ...
     },
     "annotations": {
-      "<labelname>": "<labelvalue>",
+      "<annotationname>": "<annotationvalue>",
     },
     "startsAt": "<rfc3339>",
-    "endsAt": "<rfc3339>"
+    "endsAt": "<rfc3339>",
     "generatorURL": "<generator_url>"
   },
   ...


### PR DESCRIPTION
Signed-off-by: Ben Clapp <email@bencl.app>

Just fixes a small typo in the example format for the `/api/v1/alerts` endpoint that was bugging me. 

@brian-brazil 