### PR TITLE
Add Simon Pasquer to Prometheus team

### DIFF
--- a/content/governance.md
+++ b/content/governance.md
@@ -63,6 +63,7 @@ The current team members are:
 * Matthias Rampke
 * Max Inden
 * Richard Hartmann
+* Simon Pasquer
 * Steve Durrheimer
 * Stuart Nelson
 * Tobias Schmidt


### PR DESCRIPTION
Signed-off-by: Richard Hartmann <richih@richih.org>