### PR TITLE
Change admonition template

### DIFF
--- a/content/docs/instrumenting/exposition_formats.md
+++ b/content/docs/instrumenting/exposition_formats.md
@@ -13,7 +13,7 @@ establish the actual format to use. A server will prefer receiving the
 protocol-buffer format, and will fall back to the text-based format if the
 client does not support the former.
 
-NOTE: **NOTE:** Prometheus 2.0 removed support for the protocol-buffer format
+NOTE: Prometheus 2.0 removed support for the protocol-buffer format
 and only supports the text-based format.
 
 The majority of users should use the existing [client libraries](/docs/instrumenting/clientlibs/)

--- a/lib/filters/admonition.rb
+++ b/lib/filters/admonition.rb
@@ -28,6 +28,7 @@ class AdmonitionFilter < Nanoc::Filter
   def generate(kind, content)
     %[<div class="admonition-wrapper #{kind}">] +
     %[<div class="admonition alert alert-#{BOOSTRAP_MAPPING[kind]}">] +
+    "<strong>#{kind.upcase}:</strong> " +
     content +
     %[</div></div>]
   end


### PR DESCRIPTION
This is a small change that automatically adds the admonition type to admonition blocks, i.e. this syntax...

```
NOTE: Foo bar baz.
```

...is turned into...

> **NOTE: ** Foo bar baz

...without needing to use `NOTE: **NOTE** Foo bar baz`.

At the moment admonition blocks aren't widely used but I plan on using them a lot in the coming weeks.