### PR TITLE
Fix spelling of Simon Pasquier

### DIFF
--- a/content/governance.md
+++ b/content/governance.md
@@ -63,7 +63,7 @@ The current team members are:
 * Matthias Rampke
 * Max Inden
 * Richard Hartmann
-* Simon Pasquer
+* Simon Pasquier
 * Steve Durrheimer
 * Stuart Nelson
 * Tobias Schmidt


### PR DESCRIPTION
Signed-off-by: Julius Volz <julius.volz@gmail.com>