### PR TITLE
Add .editorconfig rules

### DIFF
--- a/.editorconfig
+++ b/.editorconfig
@@ -1,0 +1,13 @@
+root = true
+
+[*]
+end_of_line = 1f
+insert_final_newline = true
+charset = utf-8
+
+[*.{css,html,js,md,rb,sh,yaml,yml}]
+indent_style = space
+indent_size = 2
+
+[Makefile]
+indent_style = tab

--- a/.editorconfig
+++ b/.editorconfig
@@ -1,7 +1,7 @@
 root = true
 
 [*]
-end_of_line = 1f
+end_of_line = lf
 insert_final_newline = true
 charset = utf-8
 
@@ -11,3 +11,4 @@ indent_size = 2
 
 [Makefile]
 indent_style = tab
+


### PR DESCRIPTION
This PR adds a [`.editorconfig`](https://editorconfig.org/) file that enforces conventions in editors that support it. The following is enforced:

* Unix-style newlines
* Newline at the end of files
* 2-space indentation across file types (HTML, Markdown, Ruby, etc.)
* Tabbed indentation in the Makefile

cc @juliusv