### PR TITLE
Added Alt text to HostingAdvice Logo

### DIFF
--- a/content/index.html
+++ b/content/index.html
@@ -133,7 +133,7 @@ layout: jumbotron
           <a href="https://www.fosdem.org/"><img src="assets/company-logos/Fosdem.png"/></a>
           <a href="https://freshtracks.io/"><img src="assets/company-logos/FreshTracks.png"/></a>
           <a href="https://giantswarm.io/"><img src="assets/company-logos/giantswarm.png"/></a>
-          <a href="https://www.hostingadvice.com/"><img src="assets/company-logos/HostingAdvice.png"/></a>
+          <a href="https://www.hostingadvice.com/"><img src="assets/company-logos/HostingAdvice.png" alt="HostingAdvice.com"/></a>
           <a href="http://improbable.io/"><img src="assets/company-logos/Improbable.png"/></a>
           <a href="https://www.jodel-app.com/"><img src="assets/company-logos/Jodel.png"/></a>
           <a href="https://www.justwatch.com/"><img src="assets/company-logos/JustWatch.png"/></a>


### PR DESCRIPTION
Signed-off-by: PJ Fancher <pj@digitalbrands.com>

Sorry, forgot alt text for the logo. Out editor has been talking with Julius Volz and Juilus ok'd the alt text inclusion. Thanks for you help.