### PR TITLE
Integrations: Add link to sshified project

### DIFF
--- a/content/docs/operating/integrations.md
+++ b/content/docs/operating/integrations.md
@@ -68,3 +68,4 @@ you to integrate it with your existing systems or build on top of it.
 ## Other
 
   * [PushProx](https://github.com/RobustPerception/PushProx): Proxy to transverse NAT and similar network setups
+  * [sshified](https://github.com/hoffie/sshified): Proxies scrapes over SSH for authentication, encryption and simplification of firewall rules


### PR DESCRIPTION
This PR adds a reference linking to [sshified](https://github.com/hoffie/sshified) on the integrations page.

sshified is a daemon which proxies prometheus' http requests to remote hosts via ssh, therefore providing authentication, encryption and simplified network management (e.g. when crossing firewalls).
Disclaimer: Author speaking here.

Cc @brian-brazil 