### PR TITLE
Parse labels with single quotes

### DIFF
--- a/static/routing-tree.js
+++ b/static/routing-tree.js
@@ -26,7 +26,7 @@ var tooltip = d3.select("body")
     .style("visibility", "hidden");
 
 function parseSearch(searchString) {
-  var labels = searchString.replace(/{|}|\"|\s/g, "").split(",");
+  var labels = searchString.replace(/{|}|\"|\'|\s/g, "").split(",");
   var o = {};
   labels.forEach(function(label) {
     var l = label.split("=");


### PR DESCRIPTION
The regex was only stripping double quotes, it
should also support singles.