### PR TITLE
add MQTT push gateway

### DIFF
--- a/content/docs/instrumenting/exporters.md
+++ b/content/docs/instrumenting/exporters.md
@@ -69,6 +69,7 @@ wide variety of JVM-based applications, for example [Kafka](http://kafka.apache.
    * [NSQ exporter](https://github.com/lovoo/nsq_exporter)
    * [Mirth Connect exporter](https://github.com/vynca/mirth_exporter)
    * [MQTT blackbox exporter](https://github.com/inovex/mqtt_blackbox_exporter)
+   * [MQTT push gateway](https://github.com/Svedrin/mqtt-pushgateway)
    * [RabbitMQ exporter](https://github.com/kbudde/rabbitmq_exporter)
    * [RabbitMQ Management Plugin exporter](https://github.com/deadtrickster/prometheus_rabbitmq_exporter)
 


### PR DESCRIPTION
Hi,

I'm building a push gateway for MQTT, and since I couldn't find anything that exists already, I thought I'd share.

I allocated port 9466 on the [default port allocations](https://github.com/prometheus/prometheus/wiki/Default-port-allocations) page.

I'm not sure if the section is correct, but since I didn't find an obviously better one, I thought I'd add it right next to the existing MQTT exporter.


Signed-off-by: Michael Ziegler <diese-addy@funzt-halt.net>
