### PR TITLE
Added Traefik to list of Software exposing Prom metrics directly

### DIFF
--- a/content/docs/instrumenting/exporters.md
+++ b/content/docs/instrumenting/exporters.md
@@ -204,6 +204,7 @@ separate exporters are needed:
    * [Skipper](https://github.com/zalando/skipper)
    * [SkyDNS](https://github.com/skynetservices/skydns) (**direct**)
    * [Telegraf](https://github.com/influxdata/telegraf/tree/master/plugins/outputs/prometheus_client)
+   * [Traefik](https://github.com/containous/traefik) (**direct**)
    * [Weave Flux](https://github.com/weaveworks/flux)
 
 The software marked *direct* is also directly instrumented with a Prometheus client library.


### PR DESCRIPTION
Added Traefik to list of Software exposing Prometheus metrics directly

Signed-off-by: vegasbrianc <brian.christner@gmail.com>