### PR TITLE
Change route part

### DIFF
--- a/content/docs/alerting/configuration.md
+++ b/content/docs/alerting/configuration.md
@@ -130,6 +130,31 @@ current node.
 [ receiver: <string> ]
 [ group_by: '[' <labelname>, ... ']' ]
 
+# How long to initially wait to send a notification for a group
+# of alerts. Allows to wait for an inhibiting alert to arrive or collect
+# more initial alerts for the same group. (Usually ~0s to few minutes.)
+[ group_wait: <duration> | default = 30s ]
+
+# How long to wait before sending a notification about new alerts that
+# are added to a group of alerts for which an initial notification has
+# already been sent. (Usually ~5m or more.)
+[ group_interval: <duration> | default = 5m ]
+
+# How long to wait before sending a notification again if it has already
+# been sent successfully for an alert. (Usually ~3h or more).
+[ repeat_interval: <duration> | default = 4h ]
+
+# Zero or more child routes.
+routes:
+  [ - <routes> ... ]
+```
+
+## `<routes>`
+
+```yaml
+[ receiver: <string> ]
+[ group_by: '[' <labelname>, ... ']' ]
+
 # Whether an alert should continue matching subsequent sibling nodes.
 [ continue: <boolean> | default = false ]
 


### PR DESCRIPTION
I duplicate route and change it to routes.

Reason for that is the following error:
`Loading configuration file failed" file=/opt/alertmanager/config/alertmanager.yml err="cannot have continue in root route"`