### PR TITLE
Clarify use of colons in metric names

### DIFF
--- a/content/docs/concepts/data_model.md
+++ b/content/docs/concepts/data_model.md
@@ -21,6 +21,9 @@ The _metric name_ specifies the general feature of a system that is measured
 may contain ASCII letters and digits, as well as underscores and colons. It
 must match the regex `[a-zA-Z_:][a-zA-Z0-9_:]*`.
 
+Note: The colons are reserved user defined recording rules. They should not
+be used by exporters or direct instrumentation.
+
 Labels enable Prometheus's dimensional data model: any given combination of
 labels for the same metric name identifies a particular dimensional
 instantiation of that metric (for example: all HTTP requests that used the

--- a/content/docs/instrumenting/writing_exporters.md
+++ b/content/docs/instrumenting/writing_exporters.md
@@ -125,8 +125,8 @@ Converting `camelCase` to `snake_case` is desirable, though doing so
 automatically doesn’t always produce nice results for things like
 `myTCPExample` or `isNaN` so sometimes it’s best to leave them as-is.
 
-Exposed metrics should not contain colons, these are reserved for users
-to use when aggregating.
+Exposed metrics should not contain colons, these are reserved for user
+defined recording rules to use when aggregating.
 
 Only `[a-zA-Z0-9:_]` are valid in metric names, any other characters
 should be sanitized to an underscore.


### PR DESCRIPTION
* Make sure to mention that colons are reserved in the data model.
* Cleanup wording to explain what "users" means.

Signed-off-by: Ben Kochie <superq@gmail.com>