### PR TITLE
Remove Conor Broderick

### DIFF
--- a/content/governance.md
+++ b/content/governance.md
@@ -52,7 +52,6 @@ The current team members are:
 * Ben Kochie
 * Björn Rabenstein
 * Brian Brazil
-* Conor Broderick
 * Fabian Reinartz
 * Frederic Branczyk
 * Goutham Veeramachaneni


### PR DESCRIPTION
As per CAMUFFJNFUM-bnBuehsxhxgAZwyMG7i4E8rz30POAdu2pZFy1sg@mail.gmail.com , @Conorbro requested to be removed from Prometheus team.

Signed-off-by: Richard Hartmann <richih@richih.org>