### PR TITLE
alerting: Remove reference to legacy /api/alerts endpoint

### DIFF
--- a/content/docs/alerting/clients.md
+++ b/content/docs/alerting/clients.md
@@ -46,6 +46,3 @@ the time since the alert was last received.
 
 The `generatorURL` field is a unique back-link which identifies the causing
 entity of this alert in the client.
-
-Alertmanager also supports a legacy endpoint on `/api/alerts` which is
-compatible with Prometheus versions 0.16.2 and lower.


### PR DESCRIPTION
With Alertmanager PR #1362 [1] Alertmanager does not support the legacy
`api/alerts` endpoint anymore. This patch has been released with
Alertmanager v0.15.0.

[1] https://github.com/prometheus/alertmanager/pull/1362

Signed-off-by: Max Leonard Inden <IndenML@gmail.com>