### PR TITLE
Add IBM Z HMC exporter

### DIFF
--- a/content/docs/instrumenting/exporters.md
+++ b/content/docs/instrumenting/exporters.md
@@ -148,6 +148,7 @@ wide variety of JVM-based applications, for example [Kafka](http://kafka.apache.
    * [Confluence exporter](https://github.com/AndreyVMarkelov/prom-confluence-exporter)
    * [Dovecot exporter](https://github.com/kumina/dovecot_exporter)
    * [eBPF exporter](https://github.com/cloudflare/ebpf_exporter)
+   * [IBM Z HMC exporter](https://github.com/zhmcclient/zhmc-prometheus-exporter)
    * [Jenkins exporter](https://github.com/lovoo/jenkins_exporter)
    * [JIRA exporter](https://github.com/AndreyVMarkelov/jira-prometheus-exporter)
    * [Kannel exporter](https://github.com/apostvav/kannel_exporter)

--- a/content/docs/instrumenting/exporters.md
+++ b/content/docs/instrumenting/exporters.md
@@ -54,6 +54,7 @@ wide variety of JVM-based applications, for example [Kafka](http://kafka.apache.
 ### Hardware related
    * [apcupsd exporter](https://github.com/mdlayher/apcupsd_exporter)
    * [Collins exporter](https://github.com/soundcloud/collins_exporter)
+   * [IBM Z HMC exporter](https://github.com/zhmcclient/zhmc-prometheus-exporter)
    * [IoT Edison exporter](https://github.com/roman-vynar/edison_exporter)
    * [IPMI exporter](https://github.com/lovoo/ipmi_exporter)
    * [knxd exporter](https://github.com/RichiH/knxd_exporter)
@@ -148,7 +149,6 @@ wide variety of JVM-based applications, for example [Kafka](http://kafka.apache.
    * [Confluence exporter](https://github.com/AndreyVMarkelov/prom-confluence-exporter)
    * [Dovecot exporter](https://github.com/kumina/dovecot_exporter)
    * [eBPF exporter](https://github.com/cloudflare/ebpf_exporter)
-   * [IBM Z HMC exporter](https://github.com/zhmcclient/zhmc-prometheus-exporter)
    * [Jenkins exporter](https://github.com/lovoo/jenkins_exporter)
    * [JIRA exporter](https://github.com/AndreyVMarkelov/jira-prometheus-exporter)
    * [Kannel exporter](https://github.com/apostvav/kannel_exporter)


### PR DESCRIPTION
I would like to add the [zhmc-prometheus-exporter](https://github.com/zhmcclient/zhmc-prometheus-exporter) to the list of known exporters. It is an exporter for metrics from the IBM Z Hardware Management Console (ZHMC). Z is IBM’s product line of mainframe computers.

I have already added the ZHMC exporter to the [list of allocated ports](https://github.com/prometheus/prometheus/wiki/Default-port-allocations), under 9291.

@brian-brazil 
Signed-off-by: Jakob-Naucke <jakob.naucke@ibm.com>