### PR TITLE
Use escaped #<file_sd_config> in integration links.

### DIFF
--- a/content/docs/operating/integrations.md
+++ b/content/docs/operating/integrations.md
@@ -20,7 +20,7 @@ these categories.
 ## File Service Discovery
 
 For service discovery mechanisms not natively supported by Prometheus,
-[file-based service discovery](/docs/operating/configuration/#<file_sd_config>) provides an interface for integrating.
+[file-based service discovery](/docs/operating/configuration/#%3Cfile_sd_config%3E) provides an interface for integrating.
 
  * [Docker Swarm](https://github.com/ContainerSolutions/prometheus-swarm-discovery)
 


### PR DESCRIPTION
Escape the links in the same way known-working FAQ.md does.
See the link to configuration#<scrape_config>:
https://prometheus.io/docs/introduction/faq/#why-don-t-the-prometheus-server-components-support-tls-or-authentication-can-i-add-those

Thanks!