### PR TITLE
Add Cachet exporter to the list

### DIFF
--- a/content/docs/instrumenting/exporters.md
+++ b/content/docs/instrumenting/exporters.md
@@ -146,6 +146,7 @@ wide variety of JVM-based applications, for example [Kafka](http://kafka.apache.
    * [Blackbox exporter](https://github.com/prometheus/blackbox_exporter) (**official**)
    * [BOSH exporter](https://github.com/cloudfoundry-community/bosh_exporter)
    * [cAdvisor](https://github.com/google/cadvisor)
+   * [Cachet exporter](https://github.com/ContaAzul/cachet_exporter)
    * [Confluence exporter](https://github.com/AndreyVMarkelov/prom-confluence-exporter)
    * [Dovecot exporter](https://github.com/kumina/dovecot_exporter)
    * [eBPF exporter](https://github.com/cloudflare/ebpf_exporter)


### PR DESCRIPTION
Hi!

We, at ContaAzul, created an exporter to collect some metrics from Cachet status page (number of incidents by status and number of components by status). Its use the Cachet API to scrape the data.

The metrics exposed are:
```
cachet_up
cachet_scrape_duration_seconds
cachet_incidents_total
cachet_components_total
```

And it can be used to take insights about incidents and, if necessary, make some alerts on 
forgotten open incidents.

@brian-brazil can you have a look please?