### PR TITLE
Fix YAML display in node exporter's guide

### DIFF
--- a/content/docs/guides/node-exporter.md
+++ b/content/docs/guides/node-exporter.md
@@ -65,6 +65,7 @@ curl http://localhost:9100/metrics | grep "node_"
 Your locally running Prometheus instance needs to be properly configured in order to access Node Exporter metrics. The following [`scrape_config`](../prometheus/latest/configuration/configuration/#<scrape_config>) block (in a `prometheus.yml` configuration file) will tell the Prometheus instance to scrape from the Node Exporter via `localhost:9100`:
 
 <a id="config"></a>
+
 ```yaml
 scrape_configs:
 - job_name: 'node'


### PR DESCRIPTION
The [YAML example](https://prometheus.io/docs/guides/node-exporter/#config) for the node exporter in the guide is broken:

![screenshot from 2018-09-07 10-47-40](https://user-images.githubusercontent.com/28908/45208733-9aac9500-b28b-11e8-8454-c88c16bc1cf0.png)

I suppose that adding a new line will fix this display glitch.