### PR TITLE
Add karma dashboard to the list of integrations

### DIFF
--- a/content/docs/operating/integrations.md
+++ b/content/docs/operating/integrations.md
@@ -70,4 +70,5 @@ you to integrate it with your existing systems or build on top of it.
 
 ## Other
 
+  * [karma](https://github.com/prymitive/karma): alert dashboard
   * [PushProx](https://github.com/RobustPerception/PushProx): Proxy to transverse NAT and similar network setups


### PR DESCRIPTION
Signed-off-by: Łukasz Mierzwa <l.mierzwa@gmail.com>

@brian-brazil pointed that page as the best place to add this

I've added a new category for it since it didn't seem to be a good fit for any existing one. I hope the wording is correct.
It's would be a good idea to add a link to the API docs but I don't see those linked anywhere in [docs](https://prometheus.io/docs/alerting/alertmanager/), only in the [README](https://github.com/prometheus/alertmanager/blob/master/README.md#api), so I wasn't sure about that. The least we could add right now is probably the `API v2 is still under heavy development and thereby subject to change.` note, but then I'm not sure if the integration page is the right place to track API status, so I decided to leave that decision to someone else.