### PR TITLE
Fix link to instrumentation practices docs

### DIFF
--- a/content/docs/instrumenting/writing_exporters.md
+++ b/content/docs/instrumenting/writing_exporters.md
@@ -7,7 +7,7 @@ sort_rank: 5
 
 If you are instrumenting your own code, the [general rules of how to
 instrument code with a Prometheus client
-library](/docs/practices/instrumentation/) should be followed. When
+library](/content/docs/practices/instrumentation.md) should be followed. When
 taking metrics from another monitoring or instrumentation system, things
 tend not to be so black and white.
 


### PR DESCRIPTION
It seems that the documentation has been rearranged at some time in the past and not all links to other documentation pages point to their intended locations.  This change fixes the link to the instrumentation practices documentation.  This pull request is submitted in the hope that it is helpful.  If you want anything changed I will gladly update it and resubmit.