### PR TITLE
Fix 'make bundle' crash for nokogiri

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -68,10 +68,12 @@ GEM
     nenv (0.3.0)
     nokogiri (1.8.4)
       mini_portile2 (~> 2.3.0)
+      pkg-config (= 1.3.1)
     notiffany (0.1.1)
       nenv (~> 0.1)
       shellany (~> 0.0)
     parallel (1.12.1)
+    pkg-config (1.3.1)
     pry (0.11.3)
       coderay (~> 1.1.0)
       method_source (~> 0.9.0)
@@ -124,4 +126,4 @@ DEPENDENCIES
   rspec
 
 BUNDLED WITH
-   1.16.2
+   1.16.5


### PR DESCRIPTION
In my system `make bundle` crashed saying `pkg-config` not found while installing `nokogiri` gem. Though `nokogiri` doesn't mention it to be a dependency, installing `pkg-config` gem first prevents installation of `nokogiri` from crashing.

I have no idea about Ruby, so please let me know if I have missed something here.

Signed-off-by: Ganesh Vernekar <cs15btech11018@iith.ac.in>