### PR TITLE
Add prosafe_exporter

### DIFF
--- a/content/docs/instrumenting/exporters.md
+++ b/content/docs/instrumenting/exporters.md
@@ -60,6 +60,7 @@ wide variety of JVM-based applications, for example [Kafka](http://kafka.apache.
    * [knxd exporter](https://github.com/RichiH/knxd_exporter)
    * [Node/system metrics exporter](https://github.com/prometheus/node_exporter) (**official**)
    * [NVIDIA GPU exporter](https://github.com/mindprince/nvidia_gpu_prometheus_exporter)
+   * [ProSAFE exporter](https://github.com/dalance/prosafe_exporter)
    * [Ubiquiti UniFi exporter](https://github.com/mdlayher/unifi_exporter)
 
 ### Messaging systems


### PR DESCRIPTION
Adding an exporter for NETGEAR switches supported by ProSAFE Plus utility.