### PR TITLE
Added link to AWS SNS forwarder in integrations docs.

### DIFF
--- a/content/docs/operating/integrations.md
+++ b/content/docs/operating/integrations.md
@@ -52,6 +52,7 @@ data volumes.
 For notification mechanisms not natively supported by the Alertmanager, the
 [webhook receiver](/docs/alerting/configuration/#webhook_config) allows for integration.
 
+  * [AWS SNS](https://github.com/DataReply/alertmanager-sns-forwarder)
   * [DingTalk](https://github.com/timonwong/prometheus-webhook-dingtalk)
   * [IRC Bot](https://github.com/multimfi/bot)
   * [JIRAlert](https://github.com/free/jiralert)
@@ -59,7 +60,6 @@ For notification mechanisms not natively supported by the Alertmanager, the
   * [prom2teams](https://github.com/idealista/prom2teams): forwards notifications to Microsoft Teams
   * [SMS](https://github.com/messagebird/sachet): supports [multiple providers](https://github.com/messagebird/sachet/blob/master/examples/config.yaml)
   * [Telegram bot](https://github.com/inCaller/prometheus_bot)
-  * [AWS SNS](https://github.com/DataReply/alertmanager-sns-forwarder)
 
 ## Management
 

--- a/content/docs/operating/integrations.md
+++ b/content/docs/operating/integrations.md
@@ -59,6 +59,7 @@ For notification mechanisms not natively supported by the Alertmanager, the
   * [prom2teams](https://github.com/idealista/prom2teams): forwards notifications to Microsoft Teams
   * [SMS](https://github.com/messagebird/sachet): supports [multiple providers](https://github.com/messagebird/sachet/blob/master/examples/config.yaml)
   * [Telegram bot](https://github.com/inCaller/prometheus_bot)
+  * [AWS SNS](https://github.com/DataReply/alertmanager-sns-forwarder)
 
 ## Management
 


### PR DESCRIPTION
Related to https://github.com/prometheus/alertmanager/issues/157. I wrote a webhook receiver for Alertmanager to forward to AWS SNS, this PR adds the link to its repo to the Prometheus integrations docs.

As per the contribution guide I'm addressing the maintainer, @brian-brazil 