### PR TITLE
Adding Reference to Promregator

### DIFF
--- a/content/docs/operating/integrations.md
+++ b/content/docs/operating/integrations.md
@@ -76,3 +76,4 @@ you to integrate it with your existing systems or build on top of it.
 
   * [karma](https://github.com/prymitive/karma): alert dashboard
   * [PushProx](https://github.com/RobustPerception/PushProx): Proxy to transverse NAT and similar network setups
+  * [Promregator](https://github.com/promregator/promregator): discovery and scraping for Cloud Foundry applications


### PR DESCRIPTION
Promregator provides discovery and facilitates scraping of Cloud-Foundry-based applications. Amongst another mechanism, it also uses the file-based service discovery approach to communicate the result of discovery to Prometheus. 
After some time of incubation of the project, I (as the maintainer of Promregator) would like to ask for referencing the project in Prometheus' docs.

@brian-brazil ping to you, as requested in CONTRIBUTING.md.
Signed-off-by: Nico Schmoigl <github@schmoigl-online.de>