### PR TITLE
docs: add reference to prometheus-kafka integration

### DIFF
--- a/content/docs/operating/integrations.md
+++ b/content/docs/operating/integrations.md
@@ -42,6 +42,7 @@ data volumes.
   * [Graphite](https://github.com/prometheus/prometheus/tree/master/documentation/examples/remote_storage/remote_storage_adapter): write
   * [InfluxDB](https://docs.influxdata.com/influxdb/latest/supported_protocols/prometheus): read and write
   * [IRONdb](https://github.com/circonus-labs/irondb-prometheus-adapter): read and write
+  * [Kafka](https://github.com/Telefonica/prometheus-kafka-adapter): write
   * [M3DB](https://m3db.github.io/m3/integrations/prometheus): read and write
   * [OpenTSDB](https://github.com/prometheus/prometheus/tree/master/documentation/examples/remote_storage/remote_storage_adapter): write
   * [PostgreSQL/TimescaleDB](https://github.com/timescale/prometheus-postgresql-adapter): read and write


### PR DESCRIPTION
@brian-brazil this is a minor change to add a link to [prometheus-kafka-adapter](https://github.com/Telefonica/prometheus-kafka-adapter), a write-only integration for Apache Kafka.

@brian-brazil ping as requested in CONTRIBUTING.md

Signed-off-by: Guido García <guido.garciabernardo@telefonica.com>