### PR TITLE
mention slack callback_id

### DIFF
--- a/content/docs/alerting/configuration.md
+++ b/content/docs/alerting/configuration.md
@@ -503,6 +503,7 @@ actions:
   [ <action_config> ... ]
 [ color: <tmpl_string> | default = '{{ if eq .Status "firing" }}danger{{ else }}good{{ end }}' ]
 [ fallback: <tmpl_string> | default = '{{ template "slack.default.fallback" . }}' ]
+[ callback_id: <tmpl_string> | default = '{{ template "slack.default.callbackid" . }}' ]
 fields:
   [ <field_config> ... ]
 [ footer: <tmpl_string> | default = '{{ template "slack.default.footer" . }}' ]

--- a/content/docs/alerting/configuration.md
+++ b/content/docs/alerting/configuration.md
@@ -501,9 +501,9 @@ channel: <tmpl_string>
 # The following parameters define the attachment.
 actions:
   [ <action_config> ... ]
+[ callback_id: <tmpl_string> | default = '{{ template "slack.default.callbackid" . }}' ]
 [ color: <tmpl_string> | default = '{{ if eq .Status "firing" }}danger{{ else }}good{{ end }}' ]
 [ fallback: <tmpl_string> | default = '{{ template "slack.default.fallback" . }}' ]
-[ callback_id: <tmpl_string> | default = '{{ template "slack.default.callbackid" . }}' ]
 fields:
   [ <field_config> ... ]
 [ footer: <tmpl_string> | default = '{{ template "slack.default.footer" . }}' ]


### PR DESCRIPTION
Signed-off-by: Arno Uhlig <arno.uhlig@sap.com>

Update docs for slack `callback_id` after https://github.com/prometheus/alertmanager/pull/1592 is merged