### PR TITLE
Update routing-tree to support label values containing spaces (solves #1201)

### DIFF
--- a/static/routing-tree.js
+++ b/static/routing-tree.js
@@ -26,7 +26,7 @@ var tooltip = d3.select("body")
     .style("visibility", "hidden");
 
 function parseSearch(searchString) {
-  var labels = searchString.replace(/{|}|\"|\'|\s/g, "").split(",");
+  var labels = searchString.replace(/{|}|\"|\'/g, "").split(",");
   var o = {};
   labels.forEach(function(label) {
     var l = label.split("=");

--- a/static/routing-tree.js
+++ b/static/routing-tree.js
@@ -29,7 +29,7 @@ function parseSearch(searchString) {
   var labels = searchString.replace(/{|}|\"|\'/g, "").split(",");
   var o = {};
   labels.forEach(function(label) {
-    var l = label.split("=");
+    var l = label.trim().split("=");
     o[l[0]] = l[1];
   });
   return o;


### PR DESCRIPTION
As mentioned on #1201, if label values in [Routing Tree Editor](https://prometheus.io/webtools/alerting/routing-tree-editor/) contain spaces, the routes are not properly matched.

The pull request updates the `parseSearch()` function with the following:

- All spaces are no longer being automatically replaced when parsing the initial search string
- In case there we spaces between the commas separating multiple labels matchers, the spaces are trimmed.

Tested this locally and it seems to indeed solve the issue - the labels that values contain spaces are properly matched now.

Since this is my first PR here, please let me know if I am doing something incorrectly here.