### PR TITLE
Add micrometer (jvm) to list third party utilities

### DIFF
--- a/content/docs/instrumenting/exporters.md
+++ b/content/docs/instrumenting/exporters.md
@@ -231,5 +231,6 @@ practices.
    * Java/JVM: [EclipseLink metrics collector](https://github.com/VitaNuova/eclipselinkexporter)
    * Java/JVM: [Hystrix metrics publisher](https://github.com/ahus1/prometheus-hystrix)
    * Java/JVM: [Jersey metrics collector](https://github.com/VitaNuova/jerseyexporter)
+   * Java/JVM: [Micrometer instrumentation library](https://github.com/micrometer-metrics/micrometer)
    * Python-Django: [django-prometheus](https://github.com/korfuri/django-prometheus)
    * Node.js: [swagger-stats](https://github.com/slanatech/swagger-stats)


### PR DESCRIPTION
Micrometer is the default metrics library for spring boot (as of 2.0).

http://micrometer.io/
http://micrometer.io/docs/registry/prometheus
https://spring.io/blog/2018/03/16/micrometer-spring-boot-2-s-new-application-metrics-collector
https://docs.spring.io/spring-boot/docs/current/reference/html/production-ready-metrics.html