### PR TITLE
Add Couchbase exporter to Databases exporters list

### DIFF
--- a/content/docs/instrumenting/exporters.md
+++ b/content/docs/instrumenting/exporters.md
@@ -33,6 +33,7 @@ wide variety of JVM-based applications, for example [Kafka](http://kafka.apache.
    * [Aerospike exporter](https://github.com/alicebob/asprom)
    * [ClickHouse exporter](https://github.com/f1yegor/clickhouse_exporter)
    * [Consul exporter](https://github.com/prometheus/consul_exporter) (**official**)
+   * [Couchbase exporter](https://github.com/blakelead/couchbase_exporter)
    * [CouchDB exporter](https://github.com/gesellix/couchdb-exporter)
    * [ElasticSearch exporter](https://github.com/justwatchcom/elasticsearch_exporter)
    * [EventStore exporter](https://github.com/marcinbudny/eventstore_exporter)


### PR DESCRIPTION
I'm writing an exporter for Couchbase community for versions 4.5.1 and 5.1.1 (other versions may work but I did not test them).

I believe it is mature enough to be submitted to the official list (I'm using it for work), but I also know that I still have some work to do, especially when it comes to testing, performance and best-practices.

