### PR TITLE
Add VictoriaMetrics to remote storage integrations

### DIFF
--- a/content/docs/operating/integrations.md
+++ b/content/docs/operating/integrations.md
@@ -47,7 +47,7 @@ data volumes.
   * [OpenTSDB](https://github.com/prometheus/prometheus/tree/master/documentation/examples/remote_storage/remote_storage_adapter): write
   * [PostgreSQL/TimescaleDB](https://github.com/timescale/prometheus-postgresql-adapter): read and write
   * [SignalFx](https://github.com/signalfx/metricproxy#prometheus): write
-  * [VictoriaMetrics](https://github.com/VictoriaMetrics/VictoriaMetrics): write and direct read via [Extended PromQL](https://github.com/VictoriaMetrics/VictoriaMetrics/wiki/ExtendedPromQL).
+  * [VictoriaMetrics](https://github.com/VictoriaMetrics/VictoriaMetrics): write
 
 ## Alertmanager Webhook Receiver
 

--- a/content/docs/operating/integrations.md
+++ b/content/docs/operating/integrations.md
@@ -47,6 +47,7 @@ data volumes.
   * [OpenTSDB](https://github.com/prometheus/prometheus/tree/master/documentation/examples/remote_storage/remote_storage_adapter): write
   * [PostgreSQL/TimescaleDB](https://github.com/timescale/prometheus-postgresql-adapter): read and write
   * [SignalFx](https://github.com/signalfx/metricproxy#prometheus): write
+  * [VictoriaMetrics](https://github.com/VictoriaMetrics/VictoriaMetrics): write and direct read via [Extended PromQL](https://github.com/VictoriaMetrics/VictoriaMetrics/wiki/ExtendedPromQL).
 
 ## Alertmanager Webhook Receiver
 


### PR DESCRIPTION
Mention that VictoriaMetrics supports direct PromQL querying.