### PR TITLE
Added link to Butler Config Management in integrations document.

### DIFF
--- a/content/docs/operating/integrations.md
+++ b/content/docs/operating/integrations.md
@@ -70,6 +70,7 @@ you to integrate it with your existing systems or build on top of it.
 
   * [Prometheus Operator](https://github.com/coreos/prometheus-operator): Manages Prometheus on top of Kubernetes
   * [Promgen](https://github.com/line/promgen): Web UI and configuration generator for Prometheus and Alertmanager
+  * [Butler CMS](https://github.com/adobe/butler): CMS for managing cluster Prometheus and Alertmanager configurations.
 
 ## Other
 


### PR DESCRIPTION
Hi @brian-brazil ,

I just wanted to create a PR to include the Butler CMS tool, which we use internally, as a configuration management tool for Prometheus, Alertmanager, and other tools.

I was hoping to get it included in the list.

Please let me know your thoughts.

thanks,
stegen