### PR TITLE
Add openmetrics-php/exposition-text as PHP client library

### DIFF
--- a/content/docs/instrumenting/clientlibs.md
+++ b/content/docs/instrumenting/clientlibs.md
@@ -31,7 +31,7 @@ Unofficial third-party client libraries:
 * [.NET / C#](https://github.com/andrasm/prometheus-net)
 * [Node.js](https://github.com/siimon/prom-client)
 * [Perl](https://metacpan.org/pod/Net::Prometheus)
-* [PHP](https://github.com/Jimdo/prometheus_client_php)
+* PHP - [Jimdo](https://github.com/Jimdo/prometheus_client_php) / [openmetrics-php](https://github.com/openmetrics-php/exposition-text)
 * [Rust](https://github.com/pingcap/rust-prometheus)
 
 When Prometheus scrapes your instance's HTTP endpoint, the client library


### PR DESCRIPTION
## Proposed changes

This PR adds [openmetrics-php/exposition-text](https://github.com/openmetrics-php/exposition-text) as a second client library for PHP.

The library implements the text exposition format described by prometheus / openmetrics.io and ships with a [PSR-7](https://www.php-fig.org/psr/psr-7/) compatible HTTP response implementation.

The library supports PHP >= 7.1.