### PR TITLE
Edited deadlinks in the Guides to get to the configuation page

### DIFF
--- a/content/docs/guides/basic-auth.md
+++ b/content/docs/guides/basic-auth.md
@@ -6,7 +6,7 @@ title: Basic auth
 
 Prometheus does not directly support [basic authentication](https://en.wikipedia.org/wiki/Basic_access_authentication) (aka "basic auth") for connections to the Prometheus [expression browser](/docs/visualization/browser) and [HTTP API](/docs/prometheus/latest/querying/api). If you'd like to enforce basic auth for those connections, we recommend using Prometheus in conjunction with a [reverse proxy](https://www.nginx.com/resources/glossary/reverse-proxy-server/) and applying authentication at the proxy layer. You can use any reverse proxy you like with Prometheus, but in this guide we'll provide an [nginx example](#nginx-example).
 
-NOTE: Although basic auth connections *to* Prometheus instances are not supported, basic auth is supported for connections *from* Prometheus instances to [scrape targets](../prometheus/latest/configuration/configuration/#<scrape_config>).
+NOTE: Although basic auth connections *to* Prometheus instances are not supported, basic auth is supported for connections *from* Prometheus instances to [scrape targets](../../prometheus/latest/configuration/configuration/#<scrape_config>).
 
 ## nginx example
 

--- a/content/docs/guides/tls-encryption.md
+++ b/content/docs/guides/tls-encryption.md
@@ -9,6 +9,7 @@ Prometheus does not directly support [Transport Layer Security](https://en.wikip
 
 NOTE: Although TLS connections *to* Prometheus instances are not supported, TLS is supported for connections *from* Prometheus instances to [scrape targets](../../prometheus/latest/configuration/configuration/#<tls_config>).
 
+
 ## nginx example
 
 Let's say that you want to run a Prometheus instance behind an [nginx](https://www.nginx.com/) server available at the `example.com` domain (which you own), and for all Prometheus endpoints to be available via the `/prometheus` endpoint. The full URL for Prometheus' `/metrics` endpoint would thus be:

--- a/content/docs/guides/tls-encryption.md
+++ b/content/docs/guides/tls-encryption.md
@@ -7,7 +7,7 @@ sort_rank: 1
 
 Prometheus does not directly support [Transport Layer Security](https://en.wikipedia.org/wiki/Transport_Layer_Security) (TLS) encryption for connections to Prometheus instances (i.e. to the expression browser or [HTTP API](../../prometheus/latest/querying/api)). If you would like to enforce TLS for those connections, we recommend using Prometheus in conjunction with a [reverse proxy](https://www.nginx.com/resources/glossary/reverse-proxy-server/) and applying TLS at the proxy layer. You can use any reverse proxy you like with Prometheus, but in this guide we'll provide an [nginx example](#nginx-example).
 
-NOTE: Although TLS connections *to* Prometheus instances are not supported, TLS is supported for connections *from* Prometheus instances to [scrape targets](../prometheus/latest/configuration/configuration/#<tls_config>).
+NOTE: Although TLS connections *to* Prometheus instances are not supported, TLS is supported for connections *from* Prometheus instances to [scrape targets](../../prometheus/latest/configuration/configuration/#<tls_config>).
 
 ## nginx example
 


### PR DESCRIPTION
Fixed the dead link for scrape targets URL in the note at the top of the page, this was still including ../guides/ in the URL. Added the extra ../ to remove this. 