### PR TITLE
Fix the sample for Apdex score

### DIFF
--- a/content/docs/practices/histograms.md
+++ b/content/docs/practices/histograms.md
@@ -75,8 +75,11 @@ following expression yields the Apdex score for each job over the last
     (
       sum(rate(http_request_duration_seconds_bucket{le="0.3"}[5m])) by (job)
     +
-      sum(rate(http_request_duration_seconds_bucket{le="1.2"}[5m])) by (job)
-    ) / 2 / sum(rate(http_request_duration_seconds_count[5m])) by (job)
+      (sum(rate(http_request_duration_seconds_bucket{le="1.2"}[5m])) by (job)
+      -
+      sum(rate(http_request_duration_seconds_bucket{le="0.3"}[5m])) by (job)
+      ) / 2 
+    ) / sum(rate(http_request_duration_seconds_count[5m])) by (job)
 
 Note that we divide the sum of both buckets. The reason is that the histogram
 buckets are


### PR DESCRIPTION
Please refer to the link of Apdex score:
https://en.wikipedia.org/wiki/Apdex

There is an example which demonstrate the score method:

if there are 100 samples with a target time of 3 seconds, where 60 are
below 3 seconds, 30 are between 3 and 12 seconds, and the remaining 10
are above 12 seconds, the Apdex score is:

  Apdex3=(60+30/2)/100=0.75

So the sample need to fix against the method.

Signed-off-by: shangxdy <shang.xiaodong@zte.com.cn>