### PR TITLE
Add exporter for App Connect Enterprise

### DIFF
--- a/content/docs/instrumenting/exporters.md
+++ b/content/docs/instrumenting/exporters.md
@@ -66,6 +66,7 @@ wide variety of JVM-based applications, for example [Kafka](http://kafka.apache.
    * [Ubiquiti UniFi exporter](https://github.com/mdlayher/unifi_exporter)
 
 ### Messaging systems
+   * [App Connect Enterprise exporter](https://github.com/ot4i/ace-docker)
    * [Beanstalkd exporter](https://github.com/messagebird/beanstalkd_exporter)
    * [Gearman exporter](https://github.com/bakins/gearman-exporter)
    * [Kafka exporter](https://github.com/danielqsj/kafka_exporter)

--- a/content/docs/instrumenting/exporters.md
+++ b/content/docs/instrumenting/exporters.md
@@ -66,7 +66,6 @@ wide variety of JVM-based applications, for example [Kafka](http://kafka.apache.
    * [Ubiquiti UniFi exporter](https://github.com/mdlayher/unifi_exporter)
 
 ### Messaging systems
-   * [App Connect Enterprise exporter](https://github.com/ot4i/ace-docker)
    * [Beanstalkd exporter](https://github.com/messagebird/beanstalkd_exporter)
    * [Gearman exporter](https://github.com/bakins/gearman-exporter)
    * [Kafka exporter](https://github.com/danielqsj/kafka_exporter)
@@ -189,6 +188,7 @@ possible.
 Some third-party software exposes metrics in the Prometheus format, so no
 separate exporters are needed:
 
+   * [App Connect Enterprise](https://github.com/ot4i/ace-docker)
    * [Ballerina](https://ballerina.io/)
    * [Ceph](http://docs.ceph.com/docs/master/mgr/prometheus/)
    * [Collectd](https://collectd.org/wiki/index.php/Plugin:Write_Prometheus)


### PR DESCRIPTION
App Connect Enterprise is an integration product (formally known as IBM Integration Bus or WebSphere Message Broker)

The exporter is available at https://github.com/ot4i/ace-docker and further work is planned to de-couple from this repository so it can be more readily included in projects