### PR TITLE
Fix typos in blogs

### DIFF
--- a/content/blog/2017-06-14-interview-with-latelier-animation.md
+++ b/content/blog/2017-06-14-interview-with-latelier-animation.md
@@ -84,7 +84,7 @@ Since all the data is available through the HTTP protocol, we wrote a
 store it in a [MySQL](https://www.mysql.com/) database accessed via a web
 application that creates a live floor map. This allows us to know with a simple
 mouse over which user is seated where with what type of hardware.  We also
-created another page with user’s picture & departement information, it helps
+created another page with user’s picture & department information, it helps
 new employees know who’s their neighbour.  The website is still an ongoing
 project so please don’t judge the look, we’re sysadmins after all not web
 designers :-)

--- a/content/docs/alerting/configuration.md
+++ b/content/docs/alerting/configuration.md
@@ -379,7 +379,7 @@ PagerDuty provides documentation on how to integrate [here](https://www.pagerdut
 # Whether or not to notify about resolved alerts.
 [ send_resolved: <boolean> | default = true ]
 
-# The following two options are mututally exclusive.
+# The following two options are mutually exclusive.
 # The PagerDuty integration key (when using PagerDuty integration type `Events API v2`).
 routing_key: <tmpl_secret>
 # The PagerDuty integration key (when using PagerDuty integration type `Prometheus`).


### PR DESCRIPTION
Fix some typos:
1. "departement" to "department" in line 87.
2. "mututally" to "mutually" in line 382.