### PR TITLE
Fix spelling error in blog

### DIFF
--- a/content/blog/2017-02-20-interview-with-weaveworks.md
+++ b/content/blog/2017-02-20-interview-with-weaveworks.md
@@ -13,7 +13,7 @@ Weaveworks talks about how they choose Prometheus and are now building on it.*
 
 [Weaveworks](https://www.weave.works/) offers [Weave
 Cloud](https://www.weave.works/solution/cloud/), a service which
-"operationalizes" microservices through a combination of open source projects
+"operationalize" microservices through a combination of open source projects
 and software as a service.
 
 Weave Cloud consists of: 

--- a/content/blog/2017-02-20-interview-with-weaveworks.md
+++ b/content/blog/2017-02-20-interview-with-weaveworks.md
@@ -13,7 +13,7 @@ Weaveworks talks about how they choose Prometheus and are now building on it.*
 
 [Weaveworks](https://www.weave.works/) offers [Weave
 Cloud](https://www.weave.works/solution/cloud/), a service which
-"operationalize" microservices through a combination of open source projects
+"operationalizes" microservices through a combination of open source projects
 and software as a service.
 
 Weave Cloud consists of: 

--- a/content/docs/operating/security.md
+++ b/content/docs/operating/security.md
@@ -125,7 +125,7 @@ headers](https://fetch.spec.whatwg.org/#http-cors-protocol) such as
 [XSS](https://en.wikipedia.org/wiki/Cross-site_scripting).
 
 If you are composing PromQL queries that include input from untrusted users
-(e.g. URL paramaters to console templates, or something you built yourself) who
+(e.g. URL parameters to console templates, or something you built yourself) who
 are not meant to be able to run aribtrary PromQL queries make sure any
 untrusted input is appropriately escaped to prevent injection attacks. For
 example `up{job="<user_input>"}` would become `up{job=""} or


### PR DESCRIPTION
Fix spelling error: "paramaters" to "parameters".