### PR TITLE
Add exporter for Alibaba Cloud

### DIFF
--- a/content/docs/instrumenting/exporters.md
+++ b/content/docs/instrumenting/exporters.md
@@ -118,6 +118,7 @@ wide variety of JVM-based applications, for example [Kafka](http://kafka.apache.
 
 ### Other monitoring systems
    * [Akamai Cloudmonitor exporter](https://github.com/ExpressenAB/cloudmonitor_exporter)
+   * [Alibaba Cloudmonitor exporter](https://github.com/aylei/aliyun-exporter)
    * [AWS CloudWatch exporter](https://github.com/prometheus/cloudwatch_exporter) (**official**)
    * [Cloud Foundry Firehose exporter](https://github.com/cloudfoundry-community/firehose_exporter)
    * [Collectd exporter](https://github.com/prometheus/collectd_exporter) (**official**)


### PR DESCRIPTION
Add exporter for Alibaba Cloud, default port has been signed in [Default port allocations](https://github.com/prometheus/prometheus/wiki/Default-port-allocations) as 9525

Signed-off-by: alei <rayingecho@gmail.com>