### PR TITLE
add link to Netgear Cable Modem exporter

### DIFF
--- a/content/docs/instrumenting/exporters.md
+++ b/content/docs/instrumenting/exporters.md
@@ -64,6 +64,7 @@ wide variety of JVM-based applications, for example [Kafka](http://kafka.apache.
    * [NVIDIA GPU exporter](https://github.com/mindprince/nvidia_gpu_prometheus_exporter)
    * [ProSAFE exporter](https://github.com/dalance/prosafe_exporter)
    * [Ubiquiti UniFi exporter](https://github.com/mdlayher/unifi_exporter)
+   * [Netgear Cable Modem Exporter](https://github.com/ickymettle/netgear_cm_exporter)
 
 ### Messaging systems
    * [Beanstalkd exporter](https://github.com/messagebird/beanstalkd_exporter)

--- a/content/docs/instrumenting/exporters.md
+++ b/content/docs/instrumenting/exporters.md
@@ -60,11 +60,11 @@ wide variety of JVM-based applications, for example [Kafka](http://kafka.apache.
    * [IoT Edison exporter](https://github.com/roman-vynar/edison_exporter)
    * [IPMI exporter](https://github.com/soundcloud/ipmi_exporter)
    * [knxd exporter](https://github.com/RichiH/knxd_exporter)
+   * [Netgear Cable Modem Exporter](https://github.com/ickymettle/netgear_cm_exporter)
    * [Node/system metrics exporter](https://github.com/prometheus/node_exporter) (**official**)
    * [NVIDIA GPU exporter](https://github.com/mindprince/nvidia_gpu_prometheus_exporter)
    * [ProSAFE exporter](https://github.com/dalance/prosafe_exporter)
    * [Ubiquiti UniFi exporter](https://github.com/mdlayher/unifi_exporter)
-   * [Netgear Cable Modem Exporter](https://github.com/ickymettle/netgear_cm_exporter)
 
 ### Messaging systems
    * [Beanstalkd exporter](https://github.com/messagebird/beanstalkd_exporter)


### PR DESCRIPTION
Not sure what the protocol is for adding third party exporters to the docs page. I recently published an exporter for Netgear Cable Modems, this PR adds a link to that repo.

If this isn't an appropriate change that's totally cool, let me know and we can close it.

