### PR TITLE
Fix some spelling errors in Prometheus' Blog

### DIFF
--- a/content/docs/introduction/comparison.md
+++ b/content/docs/introduction/comparison.md
@@ -109,7 +109,7 @@ Prometheus, by contrast, supports the float64 data type with limited support for
 strings, and millisecond resolution timestamps.
 
 InfluxDB uses a variant of a [log-structured merge tree for storage with a write ahead log](https://docs.influxdata.com/influxdb/v1.2/concepts/storage_engine/),
-sharded by time. This is much more suitable to event logging than Prometheus's
+shared by time. This is much more suitable to event logging than Prometheus's
 append-only file per time series approach.
 
 [Logs and Metrics and Graphs, Oh My!](https://blog.raintank.io/logs-and-metrics-and-graphs-oh-my/)

--- a/content/docs/introduction/comparison.md
+++ b/content/docs/introduction/comparison.md
@@ -109,7 +109,7 @@ Prometheus, by contrast, supports the float64 data type with limited support for
 strings, and millisecond resolution timestamps.
 
 InfluxDB uses a variant of a [log-structured merge tree for storage with a write ahead log](https://docs.influxdata.com/influxdb/v1.2/concepts/storage_engine/),
-shared by time. This is much more suitable to event logging than Prometheus's
+sharded by time. This is much more suitable to event logging than Prometheus's
 append-only file per time series approach.
 
 [Logs and Metrics and Graphs, Oh My!](https://blog.raintank.io/logs-and-metrics-and-graphs-oh-my/)

--- a/content/docs/practices/histograms.md
+++ b/content/docs/practices/histograms.md
@@ -85,7 +85,7 @@ buckets are
 corrects for that.
 
 The calculation does not exactly match the traditional Apdex score, as it
-includes errors in the satisified and tolerable parts of the calculation.
+includes errors in the satisfied and tolerable parts of the calculation.
 
 ## Quantiles
 


### PR DESCRIPTION
Fix some spelling errors in the docs: 
1. "sharded" to "shared" in line 112.
2. "satisified" to "satisfied" in line 88.