### PR TITLE
Fix typo in operating/security

### DIFF
--- a/content/docs/operating/security.md
+++ b/content/docs/operating/security.md
@@ -126,7 +126,7 @@ headers](https://fetch.spec.whatwg.org/#http-cors-protocol) such as
 
 If you are composing PromQL queries that include input from untrusted users
 (e.g. URL parameters to console templates, or something you built yourself) who
-are not meant to be able to run aribtrary PromQL queries make sure any
+are not meant to be able to run arbitrary PromQL queries make sure any
 untrusted input is appropriately escaped to prevent injection attacks. For
 example `up{job="<user_input>"}` would become `up{job=""} or
 some_metric{zzz=""}` if the `<user_input>` was `"} or some_metric{zzz="`.


### PR DESCRIPTION
Changed `aribtrary` to `arbitrary`.