### PR TITLE
fix some typos in community website

### DIFF
--- a/content/community.html
+++ b/content/community.html
@@ -57,7 +57,7 @@ title: Community
 
     <h1>Developer summits</h1>
     <p>
-      We strive to be as open and public as possible. Technical discussions happen on the development list, our in-person meeting notes are public, and we have public calls. Below, you can find links to our developer summits at PromCon 2017 & 2018, respectively. These deveolper summits are open to join upon request as long as we have capacity. Preference is given to friendly projects and companies, plus diversity. Attendees are free not to be listed in the public meeting notes.
+      We strive to be as open and public as possible. Technical discussions happen on the development list, our in-person meeting notes are public, and we have public calls. Below, you can find links to our developer summits at PromCon 2017 & 2018, respectively. These developer summits are open to join upon request as long as we have capacity. Preference is given to friendly projects and companies, plus diversity. Attendees are free not to be listed in the public meeting notes.
     </p>
     <p>
       <a href="https://docs.google.com/document/d/1DaHFao0saZ3MDt9yuuxLaCQg8WGadO8s44i3cxSARcM/edit#heading=h.bbvw42ndm0nb">2017 developer summit notes</a>

--- a/content/docs/practices/naming.md
+++ b/content/docs/practices/naming.md
@@ -65,7 +65,7 @@ unbounded sets of values.
 
 ## Base units
 
-Prometheus does not have any units hard coded. For better compability, base
+Prometheus does not have any units hard coded. For better compatibility, base
 units should be used. The following lists some metrics families with their base unit.
 The list is not exhaustive.
 


### PR DESCRIPTION
1. "deveolper" to "developer" in line 60.
2. "compability" to "compatibility" in line 68.