### PR TITLE
Replace "goroutines" with "concurrent requests" in gauge example

### DIFF
--- a/content/docs/concepts/metric_types.md
+++ b/content/docs/concepts/metric_types.md
@@ -36,7 +36,7 @@ arbitrarily go up and down.
 
 Gauges are typically used for measured values like temperatures or current
 memory usage, but also "counts" that can go up and down, like the number of
-running goroutines.
+concurrent requests.
 
 Client library usage documentation for gauges:
 


### PR DESCRIPTION
Not everyone reading this paragraph will know what a "goroutine" is. Since the previous paragraph mentions "you can use a counter to represent the number of requests served", I updated this one to also use requests as an example.