### PR TITLE
Link to the data model from naming.

### DIFF
--- a/content/docs/practices/naming.md
+++ b/content/docs/practices/naming.md
@@ -14,6 +14,7 @@ practices, e.g. naming conventions, differently.
 
 A metric name...
 
+* ...must comply with the [data model](/docs/concepts/data_model/#metric-names-and-labels) for valid characters.
 * ...should have a (single-word) application prefix relevant to the domain the
   metric belongs to. The prefix is sometimes referred to as `namespace` by
   client libraries. For metrics specific to an application, the prefix is


### PR DESCRIPTION
Make it easier to find the list of valid characters in metric names by
linking the data model page from the naming best practices page.

Signed-off-by: Ben Kochie <superq@gmail.com>