### PR TITLE
operating/security: Remove mention of public security vul reports

### DIFF
--- a/content/docs/operating/security.md
+++ b/content/docs/operating/security.md
@@ -13,9 +13,8 @@ This page describes the general security assumptions of Prometheus and the
 attack vectors that some configurations may enable.
 
 As with any complex systems it is not possible to guarantee that there are no
-bugs. If you find a security bug, please file it in the issue tracker of the
-relevant component. If you prefer to report privately, please do so to the
-maintainers listed in the MAINTAINERS.md of the relevant repository.
+bugs. If you find a security bug please report it privately to the maintainers
+listed in the MAINTAINERS.md of the relevant repository.
 
 ## Prometheus
 


### PR DESCRIPTION
Instead giving people the choice of either reporting security
vulnerabilities publicly via the issue trackers, or privately to the
maintainers of the relevant project, this patch removes the former,
giving us more time to mitigate the problem.

What are your thoughts?