### PR TITLE
Add JMeter exporter to list

### DIFF
--- a/content/docs/instrumenting/exporters.md
+++ b/content/docs/instrumenting/exporters.md
@@ -161,7 +161,7 @@ wide variety of JVM-based applications, for example [Kafka](http://kafka.apache.
    * [Ethereum Client exporter](https://github.com/31z4/ethereum-prometheus-exporter)
    * [Jenkins exporter](https://github.com/lovoo/jenkins_exporter)
    * [JIRA exporter](https://github.com/AndreyVMarkelov/jira-prometheus-exporter)
-   * [JMeter exporter](https://github.com/johrstrom/jmeter-prometheus-plugin)
+   * [JMeter plugin](https://github.com/johrstrom/jmeter-prometheus-plugin)
    * [Kannel exporter](https://github.com/apostvav/kannel_exporter)
    * [Kemp LoadBalancer exporter](https://github.com/giantswarm/prometheus-kemp-exporter)
    * [Kibana Exporter](https://github.com/pjhampton/kibana-prometheus-exporter)

--- a/content/docs/instrumenting/exporters.md
+++ b/content/docs/instrumenting/exporters.md
@@ -161,7 +161,7 @@ wide variety of JVM-based applications, for example [Kafka](http://kafka.apache.
    * [Ethereum Client exporter](https://github.com/31z4/ethereum-prometheus-exporter)
    * [Jenkins exporter](https://github.com/lovoo/jenkins_exporter)
    * [JIRA exporter](https://github.com/AndreyVMarkelov/jira-prometheus-exporter)
-   * [JMeter](https://github.com/johrstrom/jmeter-prometheus-plugin)
+   * [JMeter exporter](https://github.com/johrstrom/jmeter-prometheus-plugin)
    * [Kannel exporter](https://github.com/apostvav/kannel_exporter)
    * [Kemp LoadBalancer exporter](https://github.com/giantswarm/prometheus-kemp-exporter)
    * [Kibana Exporter](https://github.com/pjhampton/kibana-prometheus-exporter)

--- a/content/docs/instrumenting/exporters.md
+++ b/content/docs/instrumenting/exporters.md
@@ -161,6 +161,7 @@ wide variety of JVM-based applications, for example [Kafka](http://kafka.apache.
    * [Ethereum Client exporter](https://github.com/31z4/ethereum-prometheus-exporter)
    * [Jenkins exporter](https://github.com/lovoo/jenkins_exporter)
    * [JIRA exporter](https://github.com/AndreyVMarkelov/jira-prometheus-exporter)
+   * [JMeter](https://github.com/johrstrom/jmeter-prometheus-plugin)
    * [Kannel exporter](https://github.com/apostvav/kannel_exporter)
    * [Kemp LoadBalancer exporter](https://github.com/giantswarm/prometheus-kemp-exporter)
    * [Kibana Exporter](https://github.com/pjhampton/kibana-prometheus-exporter)


### PR DESCRIPTION
@brian-brazil for your review. I notice you look at the repositories of the exporters, so I'll add this info that you may be concerned with.

* I publish a shaded (fat) jar for users with a lot of the io.prometheus java_client libs within it for convenience. I build the jar with your LICENSE and NOTICE, but [it's not actually copyrighted](https://github.com/prometheus/client_java/blob/master/LICENSE#L189) to anyone.
