### PR TITLE
link to currently used OpsGenie API version

### DIFF
--- a/content/docs/alerting/configuration.md
+++ b/content/docs/alerting/configuration.md
@@ -551,7 +551,7 @@ value: <tmpl_string>
 
 ## `<opsgenie_config>`
 
-OpsGenie notifications are sent via the [OpsGenie API](https://www.opsgenie.com/docs/web-api/alert-api).
+OpsGenie notifications are sent via the [OpsGenie API](https://docs.opsgenie.com/docs/alert-api).
 
 ```yaml
 # Whether or not to notify about resolved alerts.


### PR DESCRIPTION
since https://github.com/prometheus/alertmanager/pull/1061 new API is
used.

Signed-off-by: Bartosz Jakubski <b.jakubski@gmail.com>