### PR TITLE
Add VerneMQ to software exposing Prometheus metrics

### DIFF
--- a/content/docs/instrumenting/exporters.md
+++ b/content/docs/instrumenting/exporters.md
@@ -223,6 +223,7 @@ separate exporters are needed:
    * [SkyDNS](https://github.com/skynetservices/skydns) (**direct**)
    * [Telegraf](https://github.com/influxdata/telegraf/tree/master/plugins/outputs/prometheus_client)
    * [Traefik](https://github.com/containous/traefik)
+   * [VerneMQ](https://github.com/vernemq/vernemq)
    * [Weave Flux](https://github.com/weaveworks/flux)
 
 The software marked *direct* is also directly instrumented with a Prometheus client library.


### PR DESCRIPTION
Hi @brian-brazil 

VerneMQ exports metrics in the Prometheus format on port 8888 by default, so thought I'd add it to the list.

Signed-off-by: Lars Hesel Christensen <lars@larshesel.dk>