### PR TITLE
Add Promitor, an Azure Monitor exporter for Prometheus

### DIFF
--- a/content/docs/instrumenting/exporters.md
+++ b/content/docs/instrumenting/exporters.md
@@ -123,6 +123,7 @@ wide variety of JVM-based applications, for example [Kafka](http://kafka.apache.
    * [Akamai Cloudmonitor exporter](https://github.com/ExpressenAB/cloudmonitor_exporter)
    * [Alibaba Cloudmonitor exporter](https://github.com/aylei/aliyun-exporter)
    * [AWS CloudWatch exporter](https://github.com/prometheus/cloudwatch_exporter) (**official**)
+   * [Azure Monitor exporter / Promitor](https://github.com/tomkerkhove/promitor)
    * [Cloud Foundry Firehose exporter](https://github.com/cloudfoundry-community/firehose_exporter)
    * [Collectd exporter](https://github.com/prometheus/collectd_exporter) (**official**)
    * [Google Stackdriver exporter](https://github.com/frodenas/stackdriver_exporter)


### PR DESCRIPTION
Add Promitor, an Azure Monitor exporter for Prometheus