### PR TITLE
link to metricbeat prometheus, and fix a typo

### DIFF
--- a/content/docs/instrumenting/writing_exporters.md
+++ b/content/docs/instrumenting/writing_exporters.md
@@ -378,7 +378,7 @@ definitely exclude it.
 
 ### Machine and process metrics
 
-Many systems, for example Elasticsearch, expose machine metrics such a
+Many systems, for example Elasticsearch, expose machine metrics such as
 CPU, memory and filesystem information. As the [node
 exporter](https://github.com/prometheus/node_exporter) provides these in
 the Prometheus ecosystem, such metrics should be dropped.

--- a/content/docs/operating/integrations.md
+++ b/content/docs/operating/integrations.md
@@ -37,7 +37,7 @@ data volumes.
   * [Chronix](https://github.com/ChronixDB/chronix.ingester): write
   * [Cortex](https://github.com/cortexproject/cortex): read and write
   * [CrateDB](https://github.com/crate/crate_adapter): read and write
-  * [Elasticsearch](https://github.com/infonova/prometheusbeat): write
+  * [Elasticsearch](https://www.elastic.co/guide/en/beats/metricbeat/current/metricbeat-module-prometheus.html): write
   * [Gnocchi](https://gnocchi.xyz/prometheus.html): write
   * [Graphite](https://github.com/prometheus/prometheus/tree/master/documentation/examples/remote_storage/remote_storage_adapter): write
   * [InfluxDB](https://docs.influxdata.com/influxdb/latest/supported_protocols/prometheus): read and write


### PR DESCRIPTION
This updates the Remote Endpoints and Storage  Elasticsearch bullet to point to the docs for Elastic's Prometheus module.

I also found a random typo that I found

@brian-brazil 