### PR TITLE
fix missed download page

### DIFF
--- a/content/docs/introduction/first_steps.md
+++ b/content/docs/introduction/first_steps.md
@@ -9,7 +9,7 @@ Welcome to Prometheus! Prometheus is a monitoring platform that collects metrics
 
 ## Downloading Prometheus
 
-[Download the latest release](/download) of Prometheus for your platform, then
+[Download the latest release](https://github.com/prometheus/prometheus/releases) of Prometheus for your platform, then
 extract it:
 
 ```language-bash


### PR DESCRIPTION
Hi,
I found the download page in the document is 404 on github.
How about point to the release page of prometheus directly?
