### PR TITLE
Add Azure Monitor exporter (azure_metrics_exporter)

### DIFF
--- a/content/docs/instrumenting/exporters.md
+++ b/content/docs/instrumenting/exporters.md
@@ -133,6 +133,7 @@ wide variety of JVM-based applications, for example [Kafka](http://kafka.apache.
    * [Akamai Cloudmonitor exporter](https://github.com/ExpressenAB/cloudmonitor_exporter)
    * [Alibaba Cloudmonitor exporter](https://github.com/aylei/aliyun-exporter)
    * [AWS CloudWatch exporter](https://github.com/prometheus/cloudwatch_exporter) (**official**)
+   * [Azure Monitor exporter](https://github.com/RobustPerception/azure_metrics_exporter)
    * [Cloud Foundry Firehose exporter](https://github.com/cloudfoundry-community/firehose_exporter)
    * [Collectd exporter](https://github.com/prometheus/collectd_exporter) (**official**)
    * [Google Stackdriver exporter](https://github.com/frodenas/stackdriver_exporter)


### PR DESCRIPTION
As this exporter is no longer WIP, it would be nice and useful to have it listed here.
I propose the label "Azure Monitor exporter" to align with Microsoft's naming.

Signed-off-by: Louis-Félix Tessier <louisfelix@gmail.com>