### PR TITLE
Clarify that prometheus-announce is _not_ mirrored to prometheus-users

### DIFF
--- a/content/community.html
+++ b/content/community.html
@@ -16,8 +16,8 @@ title: Community
     <p>
       <strong>User mailing lists:</strong>
       <ul>
-        <li><a href="https://groups.google.com/forum/#!forum/prometheus-announce">prometheus-announce</a> – for announcements like new releases</li>
-        <li><a href="https://groups.google.com/forum/#!forum/prometheus-users">prometheus-users</a> – for discussions around Prometheus usage and community support</li>
+        <li><a href="https://groups.google.com/forum/#!forum/prometheus-announce">prometheus-announce</a> – low-traffic list for announcements like new releases.</li>
+        <li><a href="https://groups.google.com/forum/#!forum/prometheus-users">prometheus-users</a> – for discussions around Prometheus usage and community support. Announcements are <em>not</em> generally mirrored from <a href="https://groups.google.com/forum/#!forum/prometheus-announce">prometheus-announce</a>.</li>
       </ul>
     </p>
     <p>


### PR DESCRIPTION
I hope that Google groups doesn't prevent mirroring like this in some
way. So far we have done the mirroring manually, but whenever I asked
around, the consensus seemed to be that we just want to subscribe
prometheus-users@ to prometheus-announce@. If there are no objections
now, please approve this PR, and then I'll try to subscribe as
described.

The reviewers selected here are those that have recently posted to prometheus-announce@. Of course, everybody is encouraged to chime in.

Different thought: There are only 69 subscribers of prometheus-announce@. Perhaps we should, well, announce prometheus-announce@ on prometheus-users@? After we have clarified the mirroring, of course, so that we can explain that you don't need to subscribe to -announce if you are on -users anyway (but you can subscribe to -announce if you want to avoid the traffic from -users but not miss the announcements).