### PR TITLE
Make Spelling Consistent

### DIFF
--- a/content/docs/operating/security.md
+++ b/content/docs/operating/security.md
@@ -112,7 +112,7 @@ resulting from additional load and failed scrapes.
 ## Authentication, Authorization, and Encryption
 
 Prometheus and its components do not provide any server-side
-authentication, authorisation or encryption. If you require this, it is
+authentication, authorization or encryption. If you require this, it is
 recommended to use a reverse proxy.
 
 As administrative and mutating endpoints are intended to be accessed via simple

--- a/content/docs/operating/security.md
+++ b/content/docs/operating/security.md
@@ -12,7 +12,7 @@ environments.
 This page describes the general security assumptions of Prometheus and the
 attack vectors that some configurations may enable.
 
-As with any complex systems it is not possible to guarantee that there are no
+As with any complex system, it is not possible to guarantee that there are no
 bugs. If you find a security bug please report it privately to the maintainers
 listed in the MAINTAINERS.md of the relevant repository and CC
 prometheus-team@googlegroups.com. We will fix the issue and coordinate a


### PR DESCRIPTION
Change Authorisation to Authorization to be consistent with the other usages of it.

Signed-off-by: Daniel Eisterhold <deisterhold@gmail.com>