### PR TITLE
Adding Thanos to integration of remote write.

### DIFF
--- a/content/docs/operating/integrations.md
+++ b/content/docs/operating/integrations.md
@@ -49,6 +49,7 @@ data volumes.
   * [SignalFx](https://github.com/signalfx/metricproxy#prometheus): write
   * [Splunk](https://github.com/lukemonahan/splunk_modinput_prometheus#prometheus-remote-write): write
   * [TiKV](https://github.com/bragfoo/TiPrometheus): read and write
+  * [Thanos](http://github.com/improbable-eng/thanos): write
   * [VictoriaMetrics](https://github.com/VictoriaMetrics/VictoriaMetrics): write
   * [Wavefront](https://github.com/wavefrontHQ/prometheus-storage-adapter): write
 


### PR DESCRIPTION
Thanos mainly uses remote read to integrate with Prometheus. Recently Thanos receiver was added so we can put it as `write` integration as well. I added `read as client` as well as to me this is important detail. Thanos integrates with Prometheus as remote read client, so technically it interates with read? Thanos does not expose remote read on it's own though.

Thoughts? (: