### PR TITLE
Add Dell Hardware OMSA exporter

### DIFF
--- a/content/docs/instrumenting/exporters.md
+++ b/content/docs/instrumenting/exporters.md
@@ -58,6 +58,7 @@ wide variety of JVM-based applications, for example [Kafka](http://kafka.apache.
    * [apcupsd exporter](https://github.com/mdlayher/apcupsd_exporter)
    * [BIG-IP exporter](https://github.com/ExpressenAB/bigip_exporter)
    * [Collins exporter](https://github.com/soundcloud/collins_exporter)
+   * [Dell Hardware OMSA exporter](https://github.com/galexrt/dellhw_exporter)
    * [IBM Z HMC exporter](https://github.com/zhmcclient/zhmc-prometheus-exporter)
    * [IoT Edison exporter](https://github.com/roman-vynar/edison_exporter)
    * [IPMI exporter](https://github.com/soundcloud/ipmi_exporter)


### PR DESCRIPTION
Signed-off-by: Alexander Trost <galexrt@googlemail.com>

This adds my [galexrt/dellhw_exporter](https://github.com/galexrt/dellhw_exporter) exporter to the hardware exporter section.
The exporter can export metrics from Dell Hardware using [Dell's OpenManage Server Administrator](https://www.dell.com/support/article/de/de/dedhs1/sln312492/openmanage-server-administrator-omsa?lang=en) service.

If needed, I can provide the `/metrics` output in a few days from a Dell server.