### PR TITLE
add RocketMQ expoter link

### DIFF
--- a/content/docs/instrumenting/exporters.md
+++ b/content/docs/instrumenting/exporters.md
@@ -90,6 +90,7 @@ wide variety of JVM-based applications, for example [Kafka](http://kafka.apache.
    * [MQTT blackbox exporter](https://github.com/inovex/mqtt_blackbox_exporter)
    * [RabbitMQ exporter](https://github.com/kbudde/rabbitmq_exporter)
    * [RabbitMQ Management Plugin exporter](https://github.com/deadtrickster/prometheus_rabbitmq_exporter)
+   * [RocketMQ exporter](https://github.com/apache/rocketmq-exporter)
 
 ### Storage
    * [Ceph exporter](https://github.com/digitalocean/ceph_exporter)


### PR DESCRIPTION
    RocketMQ  graduated from the community in 2017 to become Apache's top project，
    RocketMQ covers more than 40% of the news domain scenarios in China alone.
    I found that the RocketMQ project does not have a very good open source solution for monitoring, so I personally developed a prometheus RocketMQ exporter, which can very well collect RocketMQ monitoring indicators and leverage the powerful ProQL capabilities and completeness of prometheus。
     The repository address is as follows: https://github.com/apache/rocketmq-exporter. Now, many users in the Apache RocketMQ community are using the prometheus RocketMQ exporter as their monitoring solution for the operation and maintenance of RocketMQ. This project has also received strong support from the founder of Apache RocketMQ, vongosling