### PR TITLE
Add Tankerkönig API Exporter

### DIFF
--- a/content/docs/instrumenting/exporters.md
+++ b/content/docs/instrumenting/exporters.md
@@ -126,6 +126,7 @@ wide variety of JVM-based applications, for example [Kafka](http://kafka.apache.
    * [Pagespeed exporter](https://github.com/foomo/pagespeed_exporter)
    * [Rancher exporter](https://github.com/infinityworksltd/prometheus-rancher-exporter)
    * [Speedtest exporter](https://github.com/nlamirault/speedtest_exporter)
+   * [Tankerkönig API Exporter](https://github.com/lukasmalkmus/tankerkoenig_exporter)
 
 ### Logging
    * [Fluentd exporter](https://github.com/V3ckt0r/fluentd_exporter)


### PR DESCRIPTION
Updated https://github.com/lukasmalkmus/tankerkoenig_exporter recently and thought why not add it to the docs.

@brian-brazil 