### PR TITLE
Add Splunk(read and write) to list of remote storages

### DIFF
--- a/content/docs/operating/integrations.md
+++ b/content/docs/operating/integrations.md
@@ -47,7 +47,6 @@ data volumes.
   * [OpenTSDB](https://github.com/prometheus/prometheus/tree/master/documentation/examples/remote_storage/remote_storage_adapter): write
   * [PostgreSQL/TimescaleDB](https://github.com/timescale/prometheus-postgresql-adapter): read and write
   * [SignalFx](https://github.com/signalfx/metricproxy#prometheus): write
-  * [Splunk](https://github.com/lukemonahan/splunk_modinput_prometheus#prometheus-remote-write): write
   * [Splunk](https://github.com/kebe7jun/ropee): read and write
   * [TiKV](https://github.com/bragfoo/TiPrometheus): read and write
   * [Thanos](http://github.com/improbable-eng/thanos): write

--- a/content/docs/operating/integrations.md
+++ b/content/docs/operating/integrations.md
@@ -48,6 +48,7 @@ data volumes.
   * [PostgreSQL/TimescaleDB](https://github.com/timescale/prometheus-postgresql-adapter): read and write
   * [SignalFx](https://github.com/signalfx/metricproxy#prometheus): write
   * [Splunk](https://github.com/lukemonahan/splunk_modinput_prometheus#prometheus-remote-write): write
+  * [Splunk](https://github.com/kebe7jun/ropee): read and write
   * [TiKV](https://github.com/bragfoo/TiPrometheus): read and write
   * [Thanos](http://github.com/improbable-eng/thanos): write
   * [VictoriaMetrics](https://github.com/VictoriaMetrics/VictoriaMetrics): write


### PR DESCRIPTION
Ropee is a prometheus remote storage adapter for splunk designed by @DaoCloud.
