### PR TITLE
remove ref to HipChat

### DIFF
--- a/content/docs/alerting/overview.md
+++ b/content/docs/alerting/overview.md
@@ -9,7 +9,7 @@ nav_icon: sliders
 Alerting with Prometheus is separated into two parts. Alerting rules in
 Prometheus servers send alerts to an Alertmanager. The [Alertmanager](../alertmanager)
 then manages those alerts, including silencing, inhibition, aggregation and
-sending out notifications via methods such as email, PagerDuty and HipChat.
+sending out notifications via methods such as email, on-call notification systems, and chat platforms.
 
 The main steps to setting up alerting and notifications are:
 


### PR DESCRIPTION
HipChat is no more. Replaced specific product references with generic descriptions.