### PR TITLE
docs/instrumentation/exporters: Add modbus exporter

### DIFF
--- a/content/docs/instrumenting/exporters.md
+++ b/content/docs/instrumenting/exporters.md
@@ -63,6 +63,7 @@ wide variety of JVM-based applications, for example [Kafka](http://kafka.apache.
    * [IoT Edison exporter](https://github.com/roman-vynar/edison_exporter)
    * [IPMI exporter](https://github.com/soundcloud/ipmi_exporter)
    * [knxd exporter](https://github.com/RichiH/knxd_exporter)
+   * [Modbus exporter](https://github.com/mxinden/modbus_exporter)
    * [Netgear Cable Modem Exporter](https://github.com/ickymettle/netgear_cm_exporter)
    * [Netgear Router exporter](https://github.com/DRuggeri/netgear_exporter)
    * [Node/system metrics exporter](https://github.com/prometheus/node_exporter) (**official**)


### PR DESCRIPTION
Prometheus exporter which retrieves stats from a modbus tcp system and
exports them via HTTP for Prometheus consumption.

Very much looking forward to any feedback!