### PR TITLE
Update routing-tree to add tooltip that shows receiver configs on text mouseOver

### DIFF
--- a/static/routing-tree.js
+++ b/static/routing-tree.js
@@ -291,6 +291,7 @@ function aggregateMatchers(node) {
 }
 
 function getReceiverConfigs(name, receivers) {
+  if (!receivers) return;
   return receivers.find(function(e){
     return e.name == name;
   });

--- a/static/routing-tree.js
+++ b/static/routing-tree.js
@@ -232,7 +232,11 @@ function update(root) {
       .on("mouseover", function(d) {
         d3.select(this).style("fill", color);
 
-        text = jsyaml.dump(d.receiver_configs).replace(/ /g, '\u00a0').split("\n");
+        text = ["<receiver config missing>"];
+        if (typeof(d.receiverConfig) !== 'undefined') {
+          text = jsyaml.dump(d.receiverConfig).replace(/ /g, '\u00a0').split("\n");
+        }
+
         text.forEach(function(t) {
           tooltip.append("div").text(t);
         });
@@ -290,7 +294,7 @@ function aggregateMatchers(node) {
   return matchers
 }
 
-function getReceiverConfigs(name, receivers) {
+function getReceiverConfig(name, receivers) {
   if (!receivers) return;
   return receivers.find(function(e){
     return e.name == name;

--- a/static/routing-tree.js
+++ b/static/routing-tree.js
@@ -168,7 +168,7 @@ function massage(root, receivers) {
 
   root.matchers = matchers;
 
-  root.receiver_configs = getReceiverConfigs(root.receiver, receivers);
+  root.receiverConfig = getReceiverConfig(root.receiver, receivers);
 
   if (!root.children) return;
 

--- a/static/routing-tree.js
+++ b/static/routing-tree.js
@@ -130,16 +130,17 @@ function matchLabel(matcher, labelSet) {
 // Load the parsed config and create the tree
 function loadConfig(config) {
   root = config.route;
+  receivers = config.receivers;
 
   root.parent = null;
-  massage(root)
+  massage(root, receivers);
 
   update(root);
 }
 
 // Translate AlertManager names to expected d3 tree names, convert AlertManager
 // Match and MatchRE objects to js objects.
-function massage(root) {
+function massage(root, receivers) {
   if (!root) return;
 
   root.children = root.routes
@@ -167,11 +168,13 @@ function massage(root) {
 
   root.matchers = matchers;
 
+  root.receiver_configs = getReceiverConfigs(root.receiver, receivers);
+
   if (!root.children) return;
 
   root.children.forEach(function(child) {
     child.parent = root;
-    massage(child)
+    massage(child, receivers)
   });
 }
 
@@ -225,7 +228,25 @@ function update(root) {
       .attr("dy", ".31em")
       .attr("text-anchor", function(d) { return d.x < 180 ? "start" : "end"; })
       .attr("transform", function(d) { return d.x < 180 ? "translate(8)" : "rotate(180)translate(-8)"; })
-      .text(function(d) { return d.receiver; });
+      .text(function(d) { return d.receiver; })
+      .on("mouseover", function(d) {
+        d3.select(this).style("fill", color);
+
+        text = jsyaml.dump(d.receiver_configs).replace(/ /g, '\u00a0').split("\n");
+        text.forEach(function(t) {
+          tooltip.append("div").text(t);
+        });
+
+        return tooltip.style("visibility", "visible");
+      })
+      .on("mousemove", function() {
+        return tooltip.style("top", (d3.event.pageY-10)+"px").style("left",(d3.event.pageX+10)+"px");
+      })
+      .on("mouseout", function(d) {
+        d3.select(this).style("fill", null);
+        tooltip.text("");
+        return tooltip.style("visibility", "hidden");
+      });
 
   node.select(".node circle").style("fill", function(d) {
     return d.matched ? color : "#fff";
@@ -267,4 +288,10 @@ function aggregateMatchers(node) {
     n = n.parent;
   }
   return matchers
+}
+
+function getReceiverConfigs(name, receivers) {
+  return receivers.find(function(e){
+    return e.name == name;
+  });
 }


### PR DESCRIPTION
This is a rather small change (read: hack) I am using on a local branch which I find useful when working with complex receiver configs. It shows a tooltip when hovering on top of the receiver name in the tree. This currently shows the raw yaml of the receiver config.

I'm far from a javascript expert, so I'll be the first to admit the code is probably not that great but possibly 'good enough' to be considered, hence why I'm opening this PR.

Additional ideas:
- Add a checkbox to toggle showing receiver configs or not (disabled by defaul?)
- Improve format and readability of the tooltip content since a complex recipient config can span many lines.