### PR TITLE
Fixed anchor links in Configuration pages

### DIFF
--- a/lib/filters/config_linker.rb
+++ b/lib/filters/config_linker.rb
@@ -11,8 +11,8 @@ class ConfigLinker < ::Nanoc::Filter
     configs = doc.xpath('//pre//code')
 
     configs.each do |config|
-      definitions.each do |text, html|
-        config.inner_html = config.inner_html.gsub(html, %(<a href="##{text}">#{html}</a>))
+      definitions.each do |anchor, html|
+        config.inner_html = config.inner_html.gsub(html, %(<a href="##{anchor}">#{html}</a>))
       end
     end
 
@@ -28,19 +28,29 @@ class ConfigLinker < ::Nanoc::Filter
 
     # Initialize dictionary with placeholders which are headers, as these are already linked.
     dict = elements.each_with_object({}) do |e, memo|
-      if e.parent.attr('id') == e.text
-        memo[e.text] = e.inner_html
+      anchor = generate_anchor(e.text)
+
+      if e.parent.attr('id') == anchor
+        memo[anchor] = e.inner_html
       end
     end
 
     # Create anchors for the remaining placeholders.
     elements.each_with_object(dict) do |e, memo|
-      unless memo.include?(e.text)
-        e['id'] = e.text
-        memo[e.text] = e.inner_html
+      anchor = generate_anchor(e.text)
+
+      unless memo.include?(anchor)
+        e['id'] = anchor
+        memo[anchor] = e.inner_html
       end
     end
 
     dict
+  end
+
+  # Replace sequences of non-word characters with single dashes. Remove
+  # extra dashes at the beginning or end.
+  def generate_anchor(text)
+    text.gsub(/\W+/, '-').gsub(/^-+|-+$/, '')
   end
 end


### PR DESCRIPTION
The generation of "Configuration" pages runs the `config_linker.rb` filter to add anchors to `<placeholder>` in code blocks. The generation of these anchors doesn't "slugify" the placeholder text, thus leading to anchors like `<tls_config>`. This is conflicting with the default anchors generated by the markdown compiler for the HTML headers, as well as the extra anchors injected by `add_anchors.rb`.

In this PR I'm uniforming the way anchors are generated, to always "slugify" the text, and have links within the configuration code blocks working correctly. After this change, the `id` in the TOC also matches with the one of non-"Configuration" pages, which is currently different due to side effects introduced by the current logic. 

Fixes https://github.com/prometheus/docs/issues/1304 and https://github.com/prometheus/docs/issues/833.

@brian-brazil 

### Example

**Before the change**:

```
[ <a href="#&lt;tls_config&gt;">&lt;tls_config&gt;</a> ]
```

**After the change**:

```
[ <a href="#tls_config">&lt;tls_config&gt;</a> ]
```