### PR TITLE
Improve base units table

### DIFF
--- a/content/docs/practices/naming.md
+++ b/content/docs/practices/naming.md
@@ -75,13 +75,13 @@ The list is not exhaustive.
 | Family | Base unit | Remark | 
 | -------| --------- | ------ |
 | Time   | seconds   |        |
-| Temperature | celsius | Celsius is the most common one encountered in practice |
+| Temperature | celsius | _celsius_ is preferred over _kelvin_ for practical reasons. |
 | Length | meters | |
 | Bytes  | bytes | | 
-| Bits   | bytes | |
-| Percent | ratio(*) | Values are 0-1. <br/> *) Usually 'ratio' is not used as suffix, but rather A\_per\_B. Exceptions are e.g. disk\_usage\_ratio  |
+| Bits   | bytes | To avoid confusion combining different metrics, always use _bytes_, even where _bits_ appear more common. |
+| Percent | ratio | Values are 0–1 (rather than 0–100). `ratio` is only used as a suffix for names like `disk_usage_ratio`. The usual metric name follows the pattern `A_per_B`. |
 | Voltage | volts | |
-| Electric current | amperes | | 
+| Electric current | amperes | |
 | Energy | joules | |
-| Weight | grams | |
+| Mass   | grams | _grams_ is preferred over _kilograms_ to avoid issues with the _kilo_ prefix. |
  


### PR DESCRIPTION
- Fixed numerous typographical and puncuation nits.
- Fixed weight → mass.
- Added note about deliberately using grams rather than kilogram
  and aligned existing similar note about celsius with it.
- Call out that `bytes` for bits is not a typo.
- Reworded and -formatted the note for `ratio` as the asterisk seemed
  needless and disrupting the flow.

@janvanoort