### PR TITLE
Use iapetos upstream clojure client

### DIFF
--- a/content/docs/instrumenting/exporters.md
+++ b/content/docs/instrumenting/exporters.md
@@ -251,7 +251,7 @@ make use of one of the normal Prometheus client libraries under the hood. As
 for all independently maintained software, we cannot vet all of them for best
 practices.
 
-   * Clojure: [prometheus-clj](https://github.com/soundcloud/prometheus-clj)
+   * Clojure: [iapetos](https://github.com/clj-commons/iapetos) 
    * Go: [go-metrics instrumentation library](https://github.com/armon/go-metrics)
    * Go: [gokit](https://github.com/peterbourgon/gokit)
    * Go: [prombolt](https://github.com/mdlayher/prombolt)


### PR DESCRIPTION
The soundcloud exporter is outdated the community effort of the client is hosted in clj commons, iapetos 