### PR TITLE
Document existence of firing and resolved alerts lists

### DIFF
--- a/content/docs/alerting/notifications.md
+++ b/content/docs/alerting/notifications.md
@@ -25,12 +25,14 @@ Note that some fields are evaluated as text, and others as HTML which will affec
 | Receiver | string | Defines the receiver's name that the notification will be sent to (slack, email etc.). |
 | Status | string | Defined as firing if at least one alert is firing, otherwise resolved. |
 | Alerts | [Alert](#alert) | List of all alert objects in this group ([see below](#alert)). |
-| Alerts.Firing | [Alert](#alert) | List of currently firing alert objects in this group ([see below](#alert)). |
-| Alerts.Resolved | [Alert](#alert) | List of resolved alert objects in this group ([see below](#alert)). |
 | GroupLabels | [KV](#kv) | The labels these alerts were grouped by. |
 | CommonLabels | [KV](#kv) | The labels common to all of the alerts. |
 | CommonAnnotations | [KV](#kv) | Set of common annotations to all of the alerts. Used for longer additional strings of information about the alert. |
 | ExternalURL | string | Backlink to the Alertmanager that sent the notification. |
+
+The `Alerts` type exposes functions for filtering alerts:
+ - `Alerts.Firing` returns a list of currently firing alert objects in this group
+ - `Alerts.Resolved` returns a list of resolved alert objects in this group
 
 ## Alert
 

--- a/content/docs/alerting/notifications.md
+++ b/content/docs/alerting/notifications.md
@@ -24,7 +24,9 @@ Note that some fields are evaluated as text, and others as HTML which will affec
 | ------------- | ------------- | -------- |
 | Receiver | string | Defines the receiver's name that the notification will be sent to (slack, email etc.). |
 | Status | string | Defined as firing if at least one alert is firing, otherwise resolved. |
-| Alerts | [Alert](#alert) | List of alert objects ([see below](#alert)). |
+| Alerts | [Alert](#alert) | List of all alert objects in this group ([see below](#alert)). |
+| Alerts.Firing | [Alert](#alert) | List of currently firing alert objects in this group ([see below](#alert)). |
+| Alerts.Resolved | [Alert](#alert) | List of resolved alert objects in this group ([see below](#alert)). |
 | GroupLabels | [KV](#kv) | The labels these alerts were grouped by. |
 | CommonLabels | [KV](#kv) | The labels common to all of the alerts. |
 | CommonAnnotations | [KV](#kv) | Set of common annotations to all of the alerts. Used for longer additional strings of information about the alert. |


### PR DESCRIPTION
I wasn't able to find any docs that describe the `.Firing` and `.Resolved` collections. 