### PR TITLE
Fix Elasticsearch remote write integration link

### DIFF
--- a/content/docs/operating/integrations.md
+++ b/content/docs/operating/integrations.md
@@ -38,7 +38,7 @@ data volumes.
   * [Chronix](https://github.com/ChronixDB/chronix.ingester): write
   * [Cortex](https://github.com/cortexproject/cortex): read and write
   * [CrateDB](https://github.com/crate/crate_adapter): read and write
-  * [Elasticsearch](https://www.elastic.co/guide/en/beats/metricbeat/current/metricbeat-module-prometheus.html): write
+  * [Elasticsearch](https://github.com/infonova/prometheusbeat): write
   * [Gnocchi](https://gnocchi.xyz/prometheus.html): write
   * [Graphite](https://github.com/prometheus/prometheus/tree/master/documentation/examples/remote_storage/remote_storage_adapter): write
   * [InfluxDB](https://docs.influxdata.com/influxdb/latest/supported_protocols/prometheus): read and write


### PR DESCRIPTION
Reverts a change from #1324, which changed the remote write integration link for Elasticsearch. That link points to an Elastic project that can scrape Prometheus exporters, not something that implements remote write.

This reverts the change so that the link points to the previous project, prometheusbeat: https://github.com/infonova/prometheusbeat

Fixes prometheus/prometheus#5528

Signed-off-by: Callum Styan <callumstyan@gmail.com>