### PR TITLE
Add RabbitMQ to software that exposes Prometheus metrics natively

### DIFF
--- a/content/docs/instrumenting/exporters.md
+++ b/content/docs/instrumenting/exporters.md
@@ -234,6 +234,7 @@ separate exporters are needed:
    * [Netdata](https://github.com/firehol/netdata)
    * [Pretix](https://pretix.eu/)
    * [Quobyte](https://www.quobyte.com/) (**direct**)
+   * [RabbitMQ](https://rabbitmq.com/prometheus.html)
    * [RobustIRC](http://robustirc.net/)
    * [ScyllaDB](http://github.com/scylladb/scylla)
    * [Skipper](https://github.com/zalando/skipper)


### PR DESCRIPTION
RabbitMQ - as of v3.8.0 - exposes Prometheus metrics directly.

The link points to the next version of RabbitMQ. We will update it to https://www.rabbitmq.com/prometheus.html as soon as v3.8.0 becomes generally available.

cc @michaelklishin