### PR TITLE
Add AWS EC2 security group exporter

### DIFF
--- a/content/docs/instrumenting/exporters.md
+++ b/content/docs/instrumenting/exporters.md
@@ -112,6 +112,7 @@ wide variety of JVM-based applications, for example [Kafka](http://kafka.apache.
    * [WebDriver exporter](https://github.com/mattbostock/webdriver_exporter)
 
 ### APIs
+   * [AWS EC2 security group exporter](https://github.com/cytopia/aws-ec2-sg-exporter)
    * [AWS ECS exporter](https://github.com/slok/ecs-exporter)
    * [AWS Health exporter](https://github.com/Jimdo/aws-health-exporter)
    * [AWS SQS exporter](https://github.com/jmal98/sqs_exporter)


### PR DESCRIPTION
# Add AWS EC2 security group exporter

### PR Scope
This PR adds [aws-ec2-sg-exporter](https://github.com/cytopia/aws-ec2-sg-exporter) to the list of available exporters.

### What is it
A dockerized<strong><sup>[1]</sup></strong> Prometheus exporter that compares desired/wanted IPv4/IPv6 CIDR against currently applied inbound CIDR rules by protocol and port number in your AWS security group(s) per region.

> <strong><sup>[1]</sup></strong>: If you want to use this exporter without Docker jump here: [Usage without Docker](https://github.com/cytopia/aws-ec2-sg-exporter#usage-without-docker)

### Motivation

Some IP addresses ranges such as Cloudfront edge nodes or SaaS hosts might change frequently and you possibly want to ensure that those are always in sync with what you have currently defined in
your security group. This exporter does exactly this and can easily be hooked up with Alertmanager to trigger alerts in case you get out of sync.

### Meta
Signed-off-by: cytopia <cytopia@everythingcli.org>

@brian-brazil 
