### PR TITLE
Document pushgateway admin-api with wipe method

### DIFF
--- a/content/docs/operating/security.md
+++ b/content/docs/operating/security.md
@@ -90,7 +90,7 @@ delete the metrics contained within. As the Pushgateway is usually scraped with
 create any time series in Prometheus.
 
 The `--web.enable-admin-api` flag controls access to the
-administrative HTTP API which includes functionality as wiping all the existing
+administrative HTTP API which includes functionality such as wiping all the existing
 metric groups. This is disabled by default. If enabled, administrative
 functionality will be accessible under the `/api/*/admin/` paths.
 

--- a/content/docs/operating/security.md
+++ b/content/docs/operating/security.md
@@ -90,7 +90,7 @@ delete the metrics contained within. As the Pushgateway is usually scraped with
 create any time series in Prometheus.
 
 The `--web.enable-admin-api` flag controls access to the
-administrative HTTP API which includes functionality such as wiping all the existing
+administrative HTTP API, which includes functionality such as wiping all the existing
 metric groups. This is disabled by default. If enabled, administrative
 functionality will be accessible under the `/api/*/admin/` paths.
 

--- a/content/docs/operating/security.md
+++ b/content/docs/operating/security.md
@@ -89,6 +89,11 @@ delete the metrics contained within. As the Pushgateway is usually scraped with
 `honor_labels` enabled, this means anyone with access to the Pushgateway can
 create any time series in Prometheus.
 
+The `--web.enable-admin-api` flag controls access to the
+administrative HTTP API which includes functionality such as to wipe all the existing
+metric groups. This is disabled by default. If enabled, administrative
+functionality will be accessible under the `/api/*/admin/` paths.
+
 ## Exporters
 
 Exporters generally only talk to one configured instance with a preset set of

--- a/content/docs/operating/security.md
+++ b/content/docs/operating/security.md
@@ -90,7 +90,7 @@ delete the metrics contained within. As the Pushgateway is usually scraped with
 create any time series in Prometheus.
 
 The `--web.enable-admin-api` flag controls access to the
-administrative HTTP API which includes functionality such as to wipe all the existing
+administrative HTTP API which includes functionality as wiping all the existing
 metric groups. This is disabled by default. If enabled, administrative
 functionality will be accessible under the `/api/*/admin/` paths.
 


### PR DESCRIPTION
This is complementary to https://github.com/prometheus/pushgateway/pull/285 adding a small update on the admin-api being available now in pushgateway as well