### PR TITLE
update clientlibs - fork on php client

### DIFF
--- a/content/docs/instrumenting/clientlibs.md
+++ b/content/docs/instrumenting/clientlibs.md
@@ -31,7 +31,7 @@ Unofficial third-party client libraries:
 * [.NET / C#](https://github.com/andrasm/prometheus-net)
 * [Node.js](https://github.com/siimon/prom-client)
 * [Perl](https://metacpan.org/pod/Net::Prometheus)
-* [PHP](https://github.com/Jimdo/prometheus_client_php)
+* [PHP](https://github.com/endclothing/prometheus_client_php)
 * [Rust](https://github.com/pingcap/rust-prometheus)
 
 When Prometheus scrapes your instance's HTTP endpoint, the client library


### PR DESCRIPTION
Jimdo/prometheus_client_php is not maintained anymore from more than two years. 

We can see most of community effort on fork https://github.com/endclothing/prometheus_client_php  (i'm not connected ;) )