### PR TITLE
Add reference to the ServiceNow Webhook

### DIFF
--- a/content/docs/operating/integrations.md
+++ b/content/docs/operating/integrations.md
@@ -68,6 +68,7 @@ For notification mechanisms not natively supported by the Alertmanager, the
   * [JIRAlert](https://github.com/free/jiralert)
   * [Phabricator / Maniphest](https://github.com/knyar/phalerts)
   * [prom2teams](https://github.com/idealista/prom2teams): forwards notifications to Microsoft Teams
+  * [ServiceNow](https://github.com/FXinnovation/alertmanager-webhook-servicenow)
   * [SMS](https://github.com/messagebird/sachet): supports [multiple providers](https://github.com/messagebird/sachet/blob/master/examples/config.yaml)
   * [SNMP traps](https://github.com/maxwo/snmp_notifier)
   * [Telegram bot](https://github.com/inCaller/prometheus_bot)


### PR DESCRIPTION
Hi!

As discussed with @simonpasquier in [this issue](https://github.com/prometheus/alertmanager/issues/931), this PR add a reference to the ServiceNow Webhook.

It supports alerts grouping in one incident, updating an existing incident based on the group key, dynamic fields configurations and GO templating on fields values (from alert's annotations and labels).

Thanks!