### PR TITLE
Fix method name

### DIFF
--- a/content/docs/instrumenting/writing_exporters.md
+++ b/content/docs/instrumenting/writing_exporters.md
@@ -345,7 +345,7 @@ each scrape.
 
 Rather create new metrics each time. In Go this is done with
 [MustNewConstMetric](https://godoc.org/github.com/prometheus/client_golang/prometheus#MustNewConstMetric)
-in your `Update()` method. For Python see
+in your `Collect()` method. For Python see
 [https://github.com/prometheus/client_python#custom-collectors](https://github.com/prometheus/client_python#custom-collectors)
 and for Java generate a `List<MetricFamilySamples>` in your collect
 method, see


### PR DESCRIPTION
I believe this is meant to say `Collect()`, as it's the method in the `Collector` interface.