### PR TITLE
content/docs/alerting: document the new template function stringSlice

### DIFF
--- a/content/docs/alerting/notifications.md
+++ b/content/docs/alerting/notifications.md
@@ -91,3 +91,4 @@ templating.
 | reReplaceAll | pattern, replacement, text | [Regexp.ReplaceAllString](http://golang.org/pkg/regexp/#Regexp.ReplaceAllString) Regexp substitution, unanchored. |
 | join | sep string, s []string | [strings.Join](http://golang.org/pkg/strings/#Join), concatenates the elements of s to create a single string. The separator string sep is placed between elements in the resulting string. (note: argument order inverted for easier pipelining in templates.) |
 | safeHtml | text string | [html/template.HTML](https://golang.org/pkg/html/template/#HTML), Marks string as HTML not requiring auto-escaping. |
+| stringSlice | ...string | Returns the passed strings as a slice of strings. |


### PR DESCRIPTION
This documents the `stringSlice` function introduced with https://github.com/prometheus/alertmanager/commit/66a0ed21bdb0720b4ba083d35acd6ae77fa7b0b5