### PR TITLE
Add 2019 dev summit 2 and fix some links

### DIFF
--- a/content/community.html
+++ b/content/community.html
@@ -65,13 +65,16 @@ title: Community
       We strive to be as open and public as possible. Technical discussions happen on the development list, our in-person meeting notes are public, and we have public calls. Below, you can find links to our developer summits at PromCon 2017 & 2018, respectively. These developer summits are open to join upon request as long as we have capacity. Preference is given to friendly projects and companies, plus diversity. Attendees are free not to be listed in the public meeting notes.
     </p>
     <p>
-      <a href="https://docs.google.com/document/d/1DaHFao0saZ3MDt9yuuxLaCQg8WGadO8s44i3cxSARcM/edit#heading=h.bbvw42ndm0nb">2017 developer summit notes</a>
+      <a href="https://docs.google.com/document/d/1DaHFao0saZ3MDt9yuuxLaCQg8WGadO8s44i3cxSARcM">2017 developer summit notes</a>
     </p>
     <p>
-      <a href="https://docs.google.com/document/d/1-C5PycocOZEVIPrmM1hn8fBelShqtqiAmFptoG4yK70/edit">2018 developer summit notes</a>
+      <a href="https://docs.google.com/document/d/1-C5PycocOZEVIPrmM1hn8fBelShqtqiAmFptoG4yK70">2018 developer summit notes</a>
     </p>
     <p>
       <a href="https://docs.google.com/document/d/1NQIX78nwBhfLZD3pAb0PK-uBKYqnkzjjVhOQ-kIaEGU">2019 developer summit notes</a>
+    </p>
+    <p>
+      <a href="https://docs.google.com/document/d/1VVxx9DzpJPDgOZpZ5TtSHBRPuG5Fr3Vr6EFh8XuUpgs">2019 developer summit 2 notes</a>
     </p>
 
     <h1>Project Governance</h1>


### PR DESCRIPTION
Signed-off-by: Richard Hartmann <richih@richih.org>