### PR TITLE
Make MAINTAINERS.md more nuanced

### DIFF
--- a/MAINTAINERS.md
+++ b/MAINTAINERS.md
@@ -1,1 +1,17 @@
-* Brian Brazil <brian.brazil@robustperception.io>
+Documentation that refers to a specific project within the Prometheus ecosystem
+is maintained by the maintainers of the respective project. For example, refer
+to the maintainers specified in Alertmanager's
+[MAINTAINERS.md](https://github.com/prometheus/alertmanager/blob/master/MAINTAINERS.md)
+file for documentation about the Alertmanager.
+
+Note that the documentation for the Prometheus server is located in the
+[prometheus/prometheus
+repository](https://github.com/prometheus/prometheus/tree/master/docs) itself.
+
+For anything that is not documentation for a specific project, refer to the
+following maintainers with their focus areas:
+
+* Julius Volz <julius.volz@gmail.com> @juliusv: Web design, static site
+  generator.
+* Brian Brazil <brian.brazil@robustperception.io> @brian-brazil: Everything
+  else.


### PR DESCRIPTION
This is a first step to get away from a single person carrying all the
weight for the whole, quite involved repository.

I would envision that we define more focus areas with more maintainers
later. This change should already help by directing project-specific
tasks to the respective project maintainers. I also added Julius for
the "technical" part of the site generation.

Signed-off-by: beorn7 <beorn@grafana.com>