### PR TITLE
Update prometheus-net URL

### DIFF
--- a/content/docs/instrumenting/clientlibs.md
+++ b/content/docs/instrumenting/clientlibs.md
@@ -29,7 +29,7 @@ Unofficial third-party client libraries:
 * [Haskell](https://github.com/fimad/prometheus-haskell)
 * [Lua](https://github.com/knyar/nginx-lua-prometheus) for Nginx
 * [Lua](https://github.com/tarantool/prometheus) for Tarantool
-* [.NET / C#](https://github.com/andrasm/prometheus-net)
+* [.NET / C#](https://github.com/prometheus-net/prometheus-net)
 * [Node.js](https://github.com/siimon/prom-client)
 * [Perl](https://metacpan.org/pod/Net::Prometheus)
 * [PHP](https://github.com/Jimdo/prometheus_client_php)


### PR DESCRIPTION
The prometheus-net library was migrated from a user repository to a GitHub organization some time ago. There's an automatic redirect in place so the link still works but just to be on the safe side, here's the updated link.