### PR TITLE
Replace ClickHouse Intergration link to native exporter

### DIFF
--- a/content/docs/instrumenting/exporters.md
+++ b/content/docs/instrumenting/exporters.md
@@ -31,7 +31,7 @@ wide variety of JVM-based applications, for example [Kafka](http://kafka.apache.
 
 ### Databases
    * [Aerospike exporter](https://github.com/alicebob/asprom)
-   * [ClickHouse exporter](https://github.com/f1yegor/clickhouse_exporter)
+   * [ClickHouse](https://github.com/ClickHouse/ClickHouse)
    * [Consul exporter](https://github.com/prometheus/consul_exporter) (**official**)
    * [Couchbase exporter](https://github.com/blakelead/couchbase_exporter)
    * [CouchDB exporter](https://github.com/gesellix/couchdb-exporter)


### PR DESCRIPTION
ClickHouse database supports exporting metrics to Prometheus natively (see [issue](https://github.com/ClickHouse/ClickHouse/issues/7369), [PR](https://github.com/ClickHouse/ClickHouse/pull/7900) ).
Current link points to abandoned exporter.

