### PR TITLE
Update PHP client lib repo link

### DIFF
--- a/content/docs/instrumenting/clientlibs.md
+++ b/content/docs/instrumenting/clientlibs.md
@@ -32,7 +32,7 @@ Unofficial third-party client libraries:
 * [.NET / C#](https://github.com/prometheus-net/prometheus-net)
 * [Node.js](https://github.com/siimon/prom-client)
 * [Perl](https://metacpan.org/pod/Net::Prometheus)
-* [PHP](https://github.com/Jimdo/prometheus_client_php)
+* [PHP](https://github.com/endclothing/prometheus_client_php)
 * [Rust](https://github.com/pingcap/rust-prometheus)
 
 When Prometheus scrapes your instance's HTTP endpoint, the client library


### PR DESCRIPTION
The current PHP client lib from Jimdo is no longer maintained, and the
repo is archived. The README of the archived repo points to the new
active repo maintained by END clothing accompanied with the following
message:

> This project is no longer maintained here. Please go to
> https://github.com/endclothing/prometheus_client_php.

This PR modifies the link to reflect that reality.

cc: @brian-brazil 

Signed-off-by: Mosab Ibrahim <mosab.a.ibrahim@gmail.com>