### PR TITLE
Fix link to best practices for writing exporters

### DIFF
--- a/content/docs/instrumenting/exporters.md
+++ b/content/docs/instrumenting/exporters.md
@@ -16,7 +16,7 @@ Some of these exporters are maintained as part of the official [Prometheus GitHu
 those are marked as *official*, others are externally contributed and maintained.
 
 We encourage the creation of more exporters but cannot vet all of them for
-[best practices](/docs/instrumenting/writing_exporters/).
+[best practices](/docs/blob/master/content/docs/instrumenting/writing_exporters.md).
 Commonly, those exporters are hosted outside of the Prometheus GitHub
 organization.
 


### PR DESCRIPTION
The old link to https://github.com/prometheus/docs/blob/master/content/docs/instrumenting/writing_exporters.md 404's and this fixes it.