### PR TITLE
Add artifactory_exportter to misc exporters

### DIFF
--- a/content/docs/instrumenting/exporters.md
+++ b/content/docs/instrumenting/exporters.md
@@ -176,6 +176,7 @@ wide variety of JVM-based applications, for example [Kafka](http://kafka.apache.
    * [Dnsmasq exporter](https://github.com/google/dnsmasq_exporter)
    * [eBPF exporter](https://github.com/cloudflare/ebpf_exporter)
    * [Ethereum Client exporter](https://github.com/31z4/ethereum-prometheus-exporter)
+   * [JFrog Artifactory Exporter](https://github.com/peimanja/artifactory_exporter)
    * [Hostapd Exporter](https://bitbucket.i2cat.net/users/miguel_catalan/repos/hostapd_prometheus_exporter)
    * [JMeter plugin](https://github.com/johrstrom/jmeter-prometheus-plugin)
    * [Kannel exporter](https://github.com/apostvav/kannel_exporter)


### PR DESCRIPTION
Here I want to add our [JFrog Artifactory Exporter](https://github.com/peimanja/artifactory_exporter) to list of Miscellaneous exporters.

Here are example of exported metrics and we are planning to work on extending this exporter in the future:
```
# HELP arti_artifacts_total_count Total artifacts count stored in Artifactory
# TYPE arti_artifacts_total_count gauge
arti_artifacts_total_count 24648
# HELP arti_artifacts_total_size_bytes Total artifacts Size stored in Artifactory in bytes
# TYPE arti_artifacts_total_size_bytes gauge
arti_artifacts_total_size_bytes 2.455647551488e+11
# HELP arti_binaries_total_count Total binaries count stored in Artifactory
# TYPE arti_binaries_total_count gauge
arti_binaries_total_count 19887
# HELP arti_binaries_total_size_bytes Total binaries Size stored in Artifactory in bytes
# TYPE arti_binaries_total_size_bytes gauge
arti_binaries_total_size_bytes 1.588064157696e+11
# HELP arti_filestore_bytes Total space in the file store in bytes
# TYPE arti_filestore_bytes gauge
arti_filestore_bytes{storage_dir="/var/opt/jfrog/artifactory-ha/cache",storage_type="cluster-s3"} 9.223372036854776e+18
# HELP arti_filestore_free_bytes Space free in the file store in bytes
# TYPE arti_filestore_free_bytes gauge
arti_filestore_free_bytes{storage_dir="/var/opt/jfrog/artifactory-ha/cache",storage_type="cluster-s3"} 9.223371708100799e+18
# HELP arti_filestore_used_bytes Space used in the file store in bytes
# TYPE arti_filestore_used_bytes gauge
arti_filestore_used_bytes{storage_dir="/var/opt/jfrog/artifactory-ha/cache",storage_type="cluster-s3"} 3.3236604420096e+11
# HELP arti_repo_files_count Number files in an Artifactory repository
# TYPE arti_repo_files_count gauge
arti_repo_files_count{name="artifactory-build-info",package_type="buildinfo",type="local"} 5623
# HELP arti_repo_folder_count Number of folders in an Artifactory repository
# TYPE arti_repo_folder_count gauge
arti_repo_folder_count{name="artifactory-build-info",package_type="buildinfo",type="local"} 301
# HELP arti_repo_items_count Number Items in an Artifactory repository
# TYPE arti_repo_items_count gauge
arti_repo_items_count{name="artifactory-build-info",package_type="buildinfo",type="local"} 5924
# HELP arti_repo_percentage Percentage of space used by an Artifactory repository
# TYPE arti_repo_percentage gauge
arti_repo_percentage{name="artifactory-build-info",package_type="buildinfo",type="local"} 0.01
# HELP arti_repo_used_bytes Space used by an Artifactory repository in bytes
# TYPE arti_repo_used_bytes gauge
arti_repo_used_bytes{name="artifactory-build-info",package_type="buildinfo",type="local"} 1.938817024e+07
# HELP arti_security_users Number of artifactory users
# TYPE arti_security_users gauge
arti_security_users{realm="internal"} 36
arti_security_users{realm="saml"} 56
# HELP arti_up Current health status of the server (1 = UP, 0 = DOWN)
# TYPE arti_up gauge
arti_up 1
```