### PR TITLE
Update bind_exporter URL

### DIFF
--- a/content/docs/instrumenting/exporters.md
+++ b/content/docs/instrumenting/exporters.md
@@ -165,7 +165,7 @@ wide variety of JVM-based applications, for example [Kafka](http://kafka.apache.
 
 ### Miscellaneous
    * [ACT Fibernet Exporter](https://git.captnemo.in/nemo/prometheus-act-exporter)
-   * [BIND exporter](https://github.com/digitalocean/bind_exporter)
+   * [BIND exporter](https://github.com/prometheus-community/bind_exporter)
    * [Bitcoind exporter](https://github.com/LePetitBloc/bitcoind-exporter)
    * [Blackbox exporter](https://github.com/prometheus/blackbox_exporter) (**official**)
    * [BOSH exporter](https://github.com/cloudfoundry-community/bosh_exporter)


### PR DESCRIPTION
Update github link to the bind_exporter now that it's in
prometheus-community.

Signed-off-by: Ben Kochie <superq@gmail.com>