### PR TITLE
Remove discontinued Hipchat link

### DIFF
--- a/content/docs/introduction/faq.md
+++ b/content/docs/introduction/faq.md
@@ -114,7 +114,6 @@ Currently, the following external systems are supported:
 
 * Email
 * Generic Webhooks
-* [HipChat](https://www.hipchat.com/)
 * [OpsGenie](https://www.opsgenie.com/)
 * [PagerDuty](http://www.pagerduty.com/)
 * [Pushover](https://pushover.net/)


### PR DESCRIPTION
Hipchat has been discontinued, this commit removes the link.

https://www.atlassian.com/partnerships/slack/faq#faq-e812d374-fc30-4eda-855a-ac4756450d6f

@brian-brazil 