### PR TITLE
fixed layout of the routing-tree-editor to avoid stripping bottom of the canvas

### DIFF
--- a/content/webtools/alerting/routing-tree-editor.html
+++ b/content/webtools/alerting/routing-tree-editor.html
@@ -1,23 +1,25 @@
 ---
 title: Routing tree editor
 ---
-<h1 id="routing-tree-editor" class="page-header">
-  Routing tree editor
-  <a class="header-anchor" href="#routing-tree-editor" name="routing-tree-editor"></a>
-</h1>
+<div id="routing-tree-container">
+  <h1 id="routing-tree-editor" class="page-header">
+    Routing tree editor
+    <a class="header-anchor" href="#routing-tree-editor" name="routing-tree-editor"></a>
+  </h1>
 
-<div class="form-group">
-  <p class="block">Copy and paste your Alertmanager config.yml:</p>
   <div class="form-group">
-    <textarea class="js-config-yml form-control" cols="50" rows="10"></textarea>
-  </div>
-  <button type="button" class="js-parse-and-draw btn btn-default">Draw Routing Tree</button>
-</div>
-<div class="form-inline">
-  <div class="form-group">
+    <p class="block">Copy and paste your Alertmanager config.yml:</p>
     <div class="form-group">
-      <input class="js-label-set-input label-input form-control" type="text" placeholder='{service="foo-service", severity="critical"}' \>
-      <button type="button" class="js-find-match btn btn-default">Match Label Set</button>
+      <textarea class="js-config-yml form-control" cols="50" rows="10"></textarea>
+    </div>
+    <button type="button" class="js-parse-and-draw btn btn-default">Draw Routing Tree</button>
+  </div>
+  <div class="form-inline">
+    <div class="form-group">
+      <div class="form-group">
+        <input class="js-label-set-input label-input form-control" type="text" placeholder='{service="foo-service", severity="critical"}' \>
+        <button type="button" class="js-find-match btn btn-default">Match Label Set</button>
+      </div>
     </div>
   </div>
 </div>

--- a/static/routing-tree.js
+++ b/static/routing-tree.js
@@ -1,7 +1,7 @@
 // Setup
 
 // Modify the diameter to expand/contract space between nodes.
-var anchor = document.querySelector(".page-header").parentElement;
+var anchor = document.querySelector("#routing-tree-container");
 var diameter = anchor.clientWidth;
 
 var color = "#e6522c";
@@ -40,7 +40,7 @@ function resetSVG() {
   svg = d3.select(anchor).append("svg")
     .classed("routing-table", true)
     .attr("width", diameter)
-    .attr("height", diameter - 150)
+    .attr("height", diameter)
     .append("g")
     .attr("transform", "translate(" + diameter / 2 + "," + (diameter / 2) + ")");
 }


### PR DESCRIPTION
Fixes https://github.com/prometheus/alertmanager/issues/2159

The routing tree editor has stripped bottom of the canvas when having odd number of routes and one going straight down. This should fix the stripping and also make sure the footer is below the tree.

