### PR TITLE
Alerting: Update configuration.md and notification_examples.md docs

### DIFF
--- a/content/blog/2016-03-03-custom-alertmanager-templates.md
+++ b/content/blog/2016-03-03-custom-alertmanager-templates.md
@@ -125,4 +125,4 @@ templates:
 We reload our Alertmanager by sending a `SIGHUP` or restart it to load the
 changed configuration and the new template file. Done.
 
-To test and iterate on your Prometheus Alertmanager notification templates for Slack you can use following [tool](https://juliusv.com/promslack/).
+To test and iterate on your Prometheus Alertmanager notification templates for Slack you can use the following [tool](https://juliusv.com/promslack/).

--- a/content/blog/2016-03-03-custom-alertmanager-templates.md
+++ b/content/blog/2016-03-03-custom-alertmanager-templates.md
@@ -124,3 +124,5 @@ templates:
 
 We reload our Alertmanager by sending a `SIGHUP` or restart it to load the
 changed configuration and the new template file. Done.
+
+To test and iterate on your Prometheus Alertmanager notification templates for Slack you can use following [tool](https://juliusv.com/promslack/).

--- a/content/docs/alerting/configuration.md
+++ b/content/docs/alerting/configuration.md
@@ -27,7 +27,7 @@ sending a HTTP POST request to the `/-/reload` endpoint.
 To specify which configuration file to load, use the `--config.file` flag.
 
 ```bash
-./alertmanager --config.file=simple.yml
+./alertmanager --config.file= alertmanager.yml
 ```
 
 The file is written in the [YAML format](http://en.wikipedia.org/wiki/YAML),

--- a/content/docs/alerting/notification_examples.md
+++ b/content/docs/alerting/notification_examples.md
@@ -100,4 +100,4 @@ templates:
 - '/etc/alertmanager/templates/myorg.tmpl'
 ```
 
-This example is explained in further detail in this [blogpost](https://prometheus.io/blog/2016/03/03/custom-alertmanager-templates/). To test and iterate on your Prometheus Alertmanager notification for Slack you can use following [tool](https://juliusv.com/promslack/).
+This example is explained in further detail in this [blogpost](https://prometheus.io/blog/2016/03/03/custom-alertmanager-templates/). To test and iterate on your Prometheus Alertmanager notification templates for Slack you can use following [tool](https://juliusv.com/promslack/).

--- a/content/docs/alerting/notification_examples.md
+++ b/content/docs/alerting/notification_examples.md
@@ -100,4 +100,4 @@ templates:
 - '/etc/alertmanager/templates/myorg.tmpl'
 ```
 
-This example is explained in further detail in this [blogpost](https://prometheus.io/blog/2016/03/03/custom-alertmanager-templates/).
+This example is explained in further detail in this [blogpost](https://prometheus.io/blog/2016/03/03/custom-alertmanager-templates/). To test and iterate on your Prometheus Alertmanager notification for Slack you can use following [tool](https://juliusv.com/promslack/).

--- a/content/docs/alerting/notification_examples.md
+++ b/content/docs/alerting/notification_examples.md
@@ -100,4 +100,4 @@ templates:
 - '/etc/alertmanager/templates/myorg.tmpl'
 ```
 
-This example is explained in further detail in this [blogpost](https://prometheus.io/blog/2016/03/03/custom-alertmanager-templates/). To test and iterate on your Prometheus Alertmanager notification templates for Slack you can use following [tool](https://juliusv.com/promslack/).
+This example is explained in further detail in this [blogpost](https://prometheus.io/blog/2016/03/03/custom-alertmanager-templates/).


### PR DESCRIPTION
**content/docs/alerting/configuration.md**
- When downloading Alertmanager, it contains `alertmanager.yml` file and not `simple.yml`.

**content/docs/alerting/notification_examples.md**
- Listing very useful resource that I have found accidentally. I think that slack notification exmaples is a perfect place for this kind of resource. 
