### PR TITLE
Remove link to Unifi exporter from exporters.md

### DIFF
--- a/content/docs/instrumenting/exporters.md
+++ b/content/docs/instrumenting/exporters.md
@@ -70,7 +70,6 @@ wide variety of JVM-based applications, for example [Kafka](http://kafka.apache.
    * [Node/system metrics exporter](https://github.com/prometheus/node_exporter) (**official**)
    * [NVIDIA GPU exporter](https://github.com/mindprince/nvidia_gpu_prometheus_exporter)
    * [ProSAFE exporter](https://github.com/dalance/prosafe_exporter)
-   * [Ubiquiti UniFi exporter](https://github.com/mdlayher/unifi_exporter)
 
 ### Issue trackers and continuous integration
 


### PR DESCRIPTION
The Unifi exporter repo has been archived, no more development, and no nominated successor.