### PR TITLE
Change external URL proto from "http" to "https"

### DIFF
--- a/content/docs/guides/tls-encryption.md
+++ b/content/docs/guides/tls-encryption.md
@@ -70,12 +70,12 @@ NOTE: This example uses `/usr/local/etc/nginx` as the location of the nginx conf
 
 ## Prometheus configuration
 
-When running Prometheus behind the nginx proxy, you'll need to set the external URL to `http://example.com/prometheus` and the route prefix to `/`:
+When running Prometheus behind the nginx proxy with TLS, you'll need to set the external URL to `https://example.com/prometheus` and the route prefix to `/`:
 
 ```bash
 prometheus \
   --config.file=/path/to/prometheus.yml \
-  --web.external-url=http://example.com/prometheus \
+  --web.external-url=https://example.com/prometheus \
   --web.route-prefix="/"
 ```
 


### PR DESCRIPTION
Ping @brian-brazil

According to the documentation, the "--web.external-url" option in used to specify a URL which Prometheus should advertise in links and similar. As the purpose of this guide is to configure a reverse proxy for TLS access, it seems reasonable to prefix the URL with "https" instead of "http".

Signed-off-by: Joel Rangsmo <joel@rangsmo.se>