### PR TITLE
Remove bolding from h4

### DIFF
--- a/content/css/docs.css
+++ b/content/css/docs.css
@@ -346,7 +346,6 @@ footer {
 }
 
 .doc-content > h4 {
-  font-weight: bold;
   font-size: 18px;
   margin-top: 20px;
 }


### PR DESCRIPTION
@juliusv

I can't discern the 2px difference between h3 and h4 on https://prometheus.io/docs/prometheus/latest/configuration/configuration/ . Removing bold makes it much easier to see where a new h3 section begins.

Thanks for your review!

Signed-Off-By: Tony Laidig < laidig@google.com >