### PR TITLE
Update integrations.md to point to official Elasticsearch implementation

### DIFF
--- a/content/docs/operating/integrations.md
+++ b/content/docs/operating/integrations.md
@@ -42,7 +42,7 @@ data volumes.
   * [Chronix](https://github.com/ChronixDB/chronix.ingester): write
   * [Cortex](https://github.com/cortexproject/cortex): read and write
   * [CrateDB](https://github.com/crate/crate_adapter): read and write
-  * [Elasticsearch](https://github.com/infonova/prometheusbeat): write
+  * [Elasticsearch](https://www.elastic.co/guide/en/beats/metricbeat/master/metricbeat-metricset-prometheus-remote_write.html): write
   * [Gnocchi](https://gnocchi.xyz/prometheus.html): write
   * [Graphite](https://github.com/prometheus/prometheus/tree/master/documentation/examples/remote_storage/remote_storage_adapter): write
   * [InfluxDB](https://docs.influxdata.com/influxdb/latest/supported_protocols/prometheus): read and write


### PR DESCRIPTION
This PR updates the docs to point to the official integration for Elasticsearch which uses an official module of Beats upstream project instead of a custom community Beat.

Integration implementation issue: https://github.com/elastic/beats/issues/14983