### PR TITLE
content/governance.md: Remove mxinden from team

### DIFF
--- a/content/governance.md
+++ b/content/governance.md
@@ -64,7 +64,6 @@ The current team members are:
 * Krasi Georgiev ([Red Hat](https://www.redhat.com/))
 * Matt Layher ([Fastly](https://www.fastly.com/))
 * Matthias Rampke ([SoundCloud](https://soundcloud.com/))
-* Max Inden ([Parity Technologies](https://www.parity.io/))
 * Richard Hartmann ([Grafana Labs](https://grafana.com/))
 * Simon Pasquier ([Red Hat](https://www.redhat.com/))
 * Steve Durrheimer ([Cycloid](https://www.cycloid.io/))


### PR DESCRIPTION
After stepping down as an Alertmanager maintainer in January, I think it
is time for me to resign as a Prometheus team member. I am doing so
because I am not very active on any core projects today, nor do I think
that I will become active again in the near future.

In no way should this imply that I am not a very big fan of Prometheus!
In fact I just pushed for introducing native instrumentation into our
main product, bugged people not to use a global registry, added 1000
comments on metric naming, pitched the power of metric-driven debugging
and educated everyone on the danger of a cardinality explosions.

I am very thankful for the last 2 years and 4 month! Thanks for
including me. Keep up this great work.