### PR TITLE
Improve wording around former team membership

### DIFF
--- a/content/governance.md
+++ b/content/governance.md
@@ -72,6 +72,7 @@ The current team members are:
 
 Previous members:
 
+* Conor Broderick
 * Max Inden
 * Stuart Nelson
 

--- a/content/governance.md
+++ b/content/governance.md
@@ -70,10 +70,12 @@ The current team members are:
 * Tobias Schmidt ([SoundCloud](https://soundcloud.com/))
 * Tom Wilkie ([Grafana Labs](https://grafana.com/))
 
-The ex-members who are publicly listed are:
+Previous members:
 
 * Max Inden
 * Stuart Nelson
+
+_Note that Prometheus has received significant contributions from a number of unlisted individuals before this governance document and thus formal team membership was created._
 
 ### Maintainers
 


### PR DESCRIPTION
- Use "Previous members" rather than "Ex-members" in agreement with
  the wording in the offboarding list.

- Add a paragraph noting that there were significant contributors
  before prometheus-team existed.

Signed-off-by: beorn7 <beorn@grafana.com>