### PR TITLE
Add Google Cloud Spanner Adapter to Prometheus integration doc.

### DIFF
--- a/content/docs/operating/integrations.md
+++ b/content/docs/operating/integrations.md
@@ -44,6 +44,7 @@ data volumes.
   * [CrateDB](https://github.com/crate/crate_adapter): read and write
   * [Elasticsearch](https://github.com/infonova/prometheusbeat): write
   * [Gnocchi](https://gnocchi.xyz/prometheus.html): write
+  * [Google Cloud Spanner](https://github.com/google/truestreet): read and write
   * [Graphite](https://github.com/prometheus/prometheus/tree/master/documentation/examples/remote_storage/remote_storage_adapter): write
   * [InfluxDB](https://docs.influxdata.com/influxdb/latest/supported_protocols/prometheus): read and write
   * [IRONdb](https://github.com/circonus-labs/irondb-prometheus-adapter): read and write


### PR DESCRIPTION
Adds a remote read/write storage adapter for Google Cloud Spanner.