### PR TITLE
Add link to Signalilo in integrations page

### DIFF
--- a/content/docs/operating/integrations.md
+++ b/content/docs/operating/integrations.md
@@ -69,6 +69,7 @@ For notification mechanisms not natively supported by the Alertmanager, the
   * [AWS SNS](https://github.com/DataReply/alertmanager-sns-forwarder)
   * [DingTalk](https://github.com/timonwong/prometheus-webhook-dingtalk)
   * [GELF](https://github.com/b-com-software-basis/alertmanager2gelf)
+  * [Icinga2](https://github.com/vshn/signalilo)
   * [IRC Bot](https://github.com/multimfi/bot)
   * [JIRAlert](https://github.com/free/jiralert)
   * [Phabricator / Maniphest](https://github.com/knyar/phalerts)


### PR DESCRIPTION
This is just a small change adding our tool "Signalilo" which converts received notifications into Icinga2 services to the list of webhook-based integrations.