### PR TITLE
Add prometheus_client package as an unofficial Dart client

### DIFF
--- a/content/docs/instrumenting/clientlibs.md
+++ b/content/docs/instrumenting/clientlibs.md
@@ -24,6 +24,7 @@ Unofficial third-party client libraries:
 * [C](https://github.com/digitalocean/prometheus-client-c)
 * [C++](https://github.com/jupp0r/prometheus-cpp)
 * [Common Lisp](https://github.com/deadtrickster/prometheus.cl)
+* [Dart](https://github.com/tentaclelabs/prometheus_client)
 * [Elixir](https://github.com/deadtrickster/prometheus.ex)
 * [Erlang](https://github.com/deadtrickster/prometheus.erl)
 * [Haskell](https://github.com/fimad/prometheus-haskell)


### PR DESCRIPTION
Signed-off-by: Oliver Sand <oliver.sand@tentaclelabs.com>