### PR TITLE
Add nftables exporter to the monitoring list

### DIFF
--- a/content/docs/instrumenting/exporters.md
+++ b/content/docs/instrumenting/exporters.md
@@ -194,6 +194,7 @@ wide variety of JVM-based applications, for example [Kafka](http://kafka.apache.
    * [Locust Exporter](https://github.com/ContainerSolutions/locust_exporter)
    * [Meteor JS web framework exporter](https://atmospherejs.com/sevki/prometheus-exporter)
    * [Minecraft exporter module](https://github.com/Baughn/PrometheusIntegration)
+   * [nftables exporter](https://github.com/Intrinsec/nftables_exporter)
    * [OpenStack exporter](https://github.com/openstack-exporter/openstack-exporter)
    * [OpenStack blackbox exporter](https://github.com/infraly/openstack_client_exporter)
    * [oVirt exporter](https://github.com/czerwonk/ovirt_exporter)


### PR DESCRIPTION
Hello,

I propose to add this exporter to the monitoring list.

It uses only pure go (no external lib or binary) to create metrics with the number of netfilter rules loaded, labeled with the domain, table and chain.

It is useful to trigger alerts on firewall changes.

Signed-off-by: Stany MARCEL <stanypub@gmail.com>