### PR TITLE
Add Honeypot exporter to the misc list

### DIFF
--- a/content/docs/instrumenting/exporters.md
+++ b/content/docs/instrumenting/exporters.md
@@ -183,6 +183,7 @@ wide variety of JVM-based applications, for example [Kafka](http://kafka.apache.
    * [eBPF exporter](https://github.com/cloudflare/ebpf_exporter)
    * [Ethereum Client exporter](https://github.com/31z4/ethereum-prometheus-exporter)
    * [JFrog Artifactory Exporter](https://github.com/peimanja/artifactory_exporter)
+   * [Honeypot exporter](https://github.com/Intrinsec/honeypot_exporter)
    * [Hostapd Exporter](https://bitbucket.i2cat.net/users/miguel_catalan/repos/hostapd_prometheus_exporter)
    * [IRCd exporter](https://github.com/dgl/ircd_exporter)
    * [Linux HA ClusterLabs exporter](https://github.com/ClusterLabs/ha_cluster_exporter)


### PR DESCRIPTION
Hello,

I propose to add this exporter to the misc list.

It is a small honeypot that exports the total number of connections (or packets for udp) in a configured list of proto/port. The metric is labeled with proto, src, dst, and port.

We use it to combined with a firewall to detect anomalies on our scan activities.

Signed-off-by: Stany MARCEL <stanypub@gmail.com>