### PR TITLE
Add ITM exporter to the list

### DIFF
--- a/content/docs/instrumenting/exporters.md
+++ b/content/docs/instrumenting/exporters.md
@@ -153,6 +153,7 @@ wide variety of JVM-based applications, for example [Kafka](http://kafka.apache.
    * [Heka exporter](https://github.com/imgix/heka_exporter)
    * [Huawei Cloudeye exporter](https://github.com/huaweicloud/cloudeye-exporter)
    * [InfluxDB exporter](https://github.com/prometheus/influxdb_exporter) (**official**)
+   * [ITM exporter](https://github.com/rafal-szypulka/itm_exporter)
    * [JavaMelody exporter](https://github.com/fschlag/javamelody-prometheus-exporter)
    * [JMX exporter](https://github.com/prometheus/jmx_exporter) (**official**)
    * [Munin exporter](https://github.com/pvdh/munin_exporter)


### PR DESCRIPTION
@brian-brazil 
I would like to add an exporter that integrates a couple of IBM monitoring products with Prometheus:
- IBM Tivoli Monitoring
- IBM Application Performance Management (on-prem version)
- IBM Tivoli Composite Application Manager for Applications
- IBM Tivoli Composite Application Manager for Transactions
- IBM OMEGAMON (monitoring suite for IBM z/OS systems and middleware https://www.ibm.com/it-infrastructure/z/omegamon#2306732)

The exporter collects the last snapshot of selected metric values from ITM metric API and exposes them as Prometheus gauges.