### PR TITLE
Update Julius' affiliation in the governance

### DIFF
--- a/content/governance.md
+++ b/content/governance.md
@@ -58,7 +58,7 @@ The current team members are:
 * Ganesh Vernekar ([Grafana Labs](https://grafana.com/))
 * Goutham Veeramachaneni ([Grafana Labs](https://grafana.com/))
 * Johannes Ziemke (independent)
-* Julius Volz (independent)
+* Julius Volz ([PromLabs](https://promlabs.com/))
 * Julien Pivotto ([Inuits](https://inuits.eu/))
 * Krasi Georgiev ([Red Hat](https://www.redhat.com/))
 * Matt Layher ([Fastly](https://www.fastly.com/))


### PR DESCRIPTION
I'll edit the service provider info in a later PR after we merge the one
that currently restructures that bit.

Signed-off-by: Julius Volz <julius.volz@gmail.com>