### PR TITLE
Add spacing to first row

### DIFF
--- a/content/index.html
+++ b/content/index.html
@@ -13,7 +13,7 @@ layout: jumbotron
 </div>
 
 <div class="container">
-  <div class="row">
+  <div class="row top-tr">
     <div class="col-md-3 col-sm-6 col-xs-12 feature-item">
       <a href="/docs/concepts/data_model/">
         <h2><i class="fa fa-flask"></i> Dimensional data</h2>


### PR DESCRIPTION
Re-use the existing `top-hr` class which applies a margin to the first row.  

```css
.top-hr {
    margin-top: 30px;
}
```

### Before / After

![prom](https://user-images.githubusercontent.com/2972876/81617194-d3bed600-9399-11ea-978a-05e97508239c.png)
