### PR TITLE
Add some missing Pagerduty optional fields

### DIFF
--- a/content/docs/alerting/configuration.md
+++ b/content/docs/alerting/configuration.md
@@ -72,9 +72,9 @@ global:
   [ smtp_auth_password: <secret> ]
   # SMTP Auth using PLAIN.
   [ smtp_auth_identity: <string> ]
-  # SMTP Auth using CRAM-MD5. 
+  # SMTP Auth using CRAM-MD5.
   [ smtp_auth_secret: <secret> ]
-  # The default SMTP TLS requirement. 
+  # The default SMTP TLS requirement.
   # Note that Go does not support unencrypted connections to remote SMTP endpoints.
   [ smtp_require_tls: <bool> | default = true ]
 
@@ -137,10 +137,10 @@ current node.
 # be batched into a single group.
 #
 # To aggregate by all possible labels use the special value '...' as the sole label name, for example:
-# group_by: ['...'] 
-# This effectively disables aggregation entirely, passing through all 
-# alerts as-is. This is unlikely to be what you want, unless you have 
-# a very low alert volume or your upstream notification system performs 
+# group_by: ['...']
+# This effectively disables aggregation entirely, passing through all
+# alerts as-is. This is unlikely to be what you want, unless you have
+# a very low alert volume or your upstream notification system performs
 # its own grouping.
 [ group_by: '[' <labelname>, ... ']' ]
 
@@ -207,7 +207,7 @@ route:
 
 An inhibition rule mutes an alert (target) matching a set of matchers
 when an alert (source) exists that matches another set of matchers.
-Both target and source alerts must have the same label values 
+Both target and source alerts must have the same label values
 for the label names in the `equal` list.
 
 Semantically, a missing label and a label with an empty value are the same
@@ -439,6 +439,15 @@ images:
 # Links to attach to the incident.
 links:
   [ <link_config> ... ]
+
+# The part or component of the affected system that is broken.
+[ component: <tmpl_string> ]
+
+# A cluster or grouping of sources.
+[ group: <tmpl_string> ]
+
+# The class/type of the event.
+[ class: <tmpl_string> ]
 
 # The HTTP client's configuration.
 [ http_config: <http_config> | default = global.http_config ]


### PR DESCRIPTION
These fields are all available on the PagerdutyConfig type:
https://github.com/prometheus/alertmanager/blob/master/config/notifiers.go#L213..L215

I took the descriptions from the PagerDuty events-api-v2 docs:
https://developer.pagerduty.com/docs/events-api-v2/overview/