### PR TITLE
Training & Support page fixups / remove marketing blurbs

### DIFF
--- a/content/css/docs.css
+++ b/content/css/docs.css
@@ -455,9 +455,13 @@ article {
   margin: 10px 0 60px 0;
 }
 
-.training .row {
+.training > .row {
   padding-bottom: 20px;
   margin-bottom: 40px;
+}
+
+.training h2 {
+  margin-bottom: 20px;
 }
 
 .gray-bg {
@@ -479,11 +483,6 @@ article {
 .equal {
   display: flex;
   flex-wrap: wrap;
-}
-
-.row.display-flex > [class*='col-'] {
-  display: flex;
-  flex-direction: column;
 }
 
 .panel-col {

--- a/content/support-training.html
+++ b/content/support-training.html
@@ -4,129 +4,122 @@ layout: jumbotron
 ---
 
 <div class="container-fluid training">
-  
+
   <div class="row gray-bg">
-    <div class="container">
-    <div class="col-md-12 doc-content">
-      <h1>Support & Training</h1>
-      <p>This list is provided in alphabetical order. If you'd like to add your training resource, see <a href="#add">Add a resource</a>.
-    </div>
+    <div class="col-md-12">
+      <div class="container doc-content">
+        <h1>Support & Training</h1>
+        <p>This list is provided in alphabetical order. If you'd like to add your training resource, see <a href="#add">Add a resource</a>.
+      </div>
     </div>
   </div>
 
 
   <div class="row">
-    <div class="container">
-      <div class="col-md-12 doc-content training-team">
+    <div class="col-md-12">
+      <div class="container doc-content">
         <h2>Courses</h2>
-      </div>
-    </div>
-    <div class="container equal">
-      <div class="col-sm-12 col-md-6 doc-content panel-col">
-          <div class="panel panel-default">
-            <div class="panel-body">
-              <a href="https://training.robustperception.io/" target="_blank">
-                <h3>Learn how to Monitor with Prometheus</h3>
-              </a>
-              <p>Delivered by <a href="https://training.robustperception.io/" target="_blank">Robust Perception Training</a>.
-            </div>
+        <div class="row equal">
+          <div class="col-md-3 col-sm-6 doc-content tc-col">
+            <a href="https://training.robustperception.io/" class="btn btn-training btn-default btn-large" target="_blank">
+              <img src="../assets/commercial-support-logos/robust-perception.png" alt="Robust Perception">
+            </a>
           </div>
-      </div>
-      <div class="col-sm-12 col-md-6 doc-content panel-col">
-          <div class="panel panel-default">
-            <div class="panel-body">
-              <a href="https://training.linuxfoundation.org/training/monitoring-systems-and-services-with-prometheus-lfs241/" target="_blank">
-                <h3>Monitoring Systems and Services with Prometheus</h3>
-              </a>
-                <p>Delivered by <a href="https://training.linuxfoundation.org/" target="_blank">Linux Foundation Training</a></p>
 
-            </div>
+          <div class="col-md-3 col-sm-6 doc-content tc-col">
+            <a href="https://training.linuxfoundation.org/training/monitoring-systems-and-services-with-prometheus-lfs241/" class="btn btn-training btn-default btn-large" target="_blank">
+              <img src="../assets/commercial-support-logos/linux-foundation.png" alt="Linux Foundation">
+            </a>
           </div>
+        </div>
       </div>
     </div>
   </div>
 
   <div class="row gray-bg">
-    <div class="container">
-      <div class="col-md-12 doc-content training-community">
+    <div class="col-md-12">
+      <div class="container doc-content">
         <h2>Commercial support</h2>
-      </div>
-    </div>
-    <div class="container equal">
-      <div class="col-md-3 col-sm-6 doc-content tc-col">
-          <a href="https://www.container-solutions.com/" class="btn btn-training btn-default darkgray-bg btn-large" target="_blank">
-            <img src="../assets/commercial-support-logos/container-solutions.svg" alt="Container Solutions">
-          </a>
-      </div>
-      
-      <div class="col-md-3 col-sm-6 doc-content tc-col">
-          <a href="https://www.credativ.com/" class="btn btn-training btn-default btn-large" target="_blank">
-            <img src="../assets/commercial-support-logos/credativ.png" alt="Credativ">
-          </a>
-      </div>
-      
-      <div class="col-md-3 col-sm-6 doc-content tc-col">
-          <a href="https://grafana.com/" class="btn btn-training btn-default btn-large" target="_blank">
-            <img src="../assets/commercial-support-logos/grafana-labs.svg" alt="Grafana Labs">
-          </a>
-      </div>
-      
-      <div class="col-md-3 col-sm-6 doc-content tc-col">
-          
-          <a href="https://juliusv.com/" class="btn btn-training btn-default btn-large" target="_blank">
-            Julius Volz <br/> 
-            (Independent Contractor)
-          </a>
-      </div>
-      
-      <div class="col-md-3 col-sm-6 doc-content tc-col">
-          <a href="https://tina.tincho.org" class="btn btn-training btn-default btn-large" target="_blank">
-            Martina Ferrari <br/> 
-            (Independent Contractor)
-          </a>
-      </div>
-      
-      <div class="col-md-3 col-sm-6 doc-content tc-col">
-          <a href="https://www.metricfire.com/hosted-prometheus" class="btn btn-training btn-default darkgray-bg btn-large" target="_blank">
-            <img src="../assets/commercial-support-logos/metricfire.png" alt="MetricFire">
-          </a>
-      </div>
-      
-      <div class="col-md-3 col-sm-6 doc-content tc-col">
-          <a href="https://www.robustperception.io/" class="btn btn-training btn-default btn-large" target="_blank">
-            <img src="../assets/commercial-support-logos/robust-perception.png" alt="Robust Perception">
-          </a>
-      </div>
-      
-      <div class="col-md-3 col-sm-6 doc-content tc-col">
-          
-          <a href="https://sysdig.com/" class="btn btn-training btn-default btn-large" target="_blank">
-            <img src="../assets/commercial-support-logos/sysdig.svg" alt="Sysdig">
-          </a>
-      </div>
-      
-      <div class="col-md-3 col-sm-6 doc-content tc-col">
-          <a href="https://www.weave.works/features/prometheus-monitoring/" class="btn btn-training btn-default btn-large" target="_blank">
-            <img src="../assets/commercial-support-logos/weaveworks.svg" alt="Weaveworks">
-          </a>
+        <div class="row equal">
+          <div class="col-md-3 col-sm-6 doc-content tc-col">
+            <a href="https://www.container-solutions.com/" class="btn btn-training btn-default darkgray-bg btn-large" target="_blank">
+              <img src="../assets/commercial-support-logos/container-solutions.svg" alt="Container Solutions">
+            </a>
+          </div>
+
+          <div class="col-md-3 col-sm-6 doc-content tc-col">
+              <a href="https://www.credativ.com/" class="btn btn-training btn-default btn-large" target="_blank">
+                <img src="../assets/commercial-support-logos/credativ.png" alt="Credativ">
+              </a>
+          </div>
+
+          <div class="col-md-3 col-sm-6 doc-content tc-col">
+              <a href="https://grafana.com/" class="btn btn-training btn-default btn-large" target="_blank">
+                <img src="../assets/commercial-support-logos/grafana-labs.svg" alt="Grafana Labs">
+              </a>
+          </div>
+
+          <div class="col-md-3 col-sm-6 doc-content tc-col">
+
+              <a href="https://juliusv.com/" class="btn btn-training btn-default btn-large" target="_blank">
+                Julius Volz <br/>
+                (Independent Contractor)
+              </a>
+          </div>
+
+          <div class="col-md-3 col-sm-6 doc-content tc-col">
+              <a href="https://tina.tincho.org" class="btn btn-training btn-default btn-large" target="_blank">
+                Martina Ferrari <br/>
+                (Independent Contractor)
+              </a>
+          </div>
+
+          <div class="col-md-3 col-sm-6 doc-content tc-col">
+              <a href="https://www.metricfire.com/hosted-prometheus" class="btn btn-training btn-default darkgray-bg btn-large" target="_blank">
+                <img src="../assets/commercial-support-logos/metricfire.png" alt="MetricFire">
+              </a>
+          </div>
+
+          <div class="col-md-3 col-sm-6 doc-content tc-col">
+              <a href="https://www.robustperception.io/" class="btn btn-training btn-default btn-large" target="_blank">
+                <img src="../assets/commercial-support-logos/robust-perception.png" alt="Robust Perception">
+              </a>
+          </div>
+
+          <div class="col-md-3 col-sm-6 doc-content tc-col">
+
+              <a href="https://sysdig.com/" class="btn btn-training btn-default btn-large" target="_blank">
+                <img src="../assets/commercial-support-logos/sysdig.svg" alt="Sysdig">
+              </a>
+          </div>
+
+          <div class="col-md-3 col-sm-6 doc-content tc-col">
+            <a href="https://www.weave.works/features/prometheus-monitoring/" class="btn btn-training btn-default btn-large" target="_blank">
+              <img src="../assets/commercial-support-logos/weaveworks.svg" alt="Weaveworks">
+            </a>
+          </div>
+        </div>
       </div>
     </div>
   </div>
 
   <div class="row">
-    <div class="container">
-      <div class="col-md-12 doc-content">
+    <div class="col-md-12">
+      <div class="container doc-content">
         <a name="add"></a><h2>Add a resource</h2>
         <p>
           Anyone who has developed a Prometheus training program or offers related services
           can add themselves to this page by opening a pull request against it.
         </p>
 
-        <div class="col-md-12 doc-content training-cta">
-          <a href="https://github.com/prometheus/docs" target="_blank" class="btn btn-primary orange-bg btn-lg">Add your company</a> 
+        <div class="doc-content training-cta">
+          <a href="https://github.com/prometheus/docs" target="_blank" class="btn btn-primary orange-bg btn-lg">Add your company</a>
         </div>
       </div>
-    </div>  
+    </div>
   </div>
-  <%= render 'container_footer' %>
+
+  <div class="container">
+    <%= render 'container_footer' %>
+  </div>
 </div>

--- a/content/support-training.html
+++ b/content/support-training.html
@@ -21,17 +21,16 @@ layout: jumbotron
         <h2>Courses</h2>
         <div class="row equal">
           <div class="col-md-3 col-sm-6 doc-content tc-col">
-            <a href="https://training.robustperception.io/" class="btn btn-training btn-default btn-large" target="_blank">
-              <img src="../assets/commercial-support-logos/robust-perception.png" alt="Robust Perception">
-            </a>
-          </div>
-
-          <div class="col-md-3 col-sm-6 doc-content tc-col">
             <a href="https://training.linuxfoundation.org/training/monitoring-systems-and-services-with-prometheus-lfs241/" class="btn btn-training btn-default btn-large" target="_blank">
               <img src="../assets/commercial-support-logos/linux-foundation.png" alt="Linux Foundation">
             </a>
           </div>
-        </div>
+
+          <div class="col-md-3 col-sm-6 doc-content tc-col">
+            <a href="https://training.robustperception.io/" class="btn btn-training btn-default btn-large" target="_blank">
+              <img src="../assets/commercial-support-logos/robust-perception.png" alt="Robust Perception">
+            </a>
+          </div>        </div>
       </div>
     </div>
   </div>


### PR DESCRIPTION
I just wanted to remove the marketing blurbs as requested in
https://github.com/prometheus/docs/pull/1604, but while doing that I
noticed that the current HTML wasn't using Bootstrap validly (the only
valid children of rows are cols, not containers), so I changed that
around everywhere as well, and also fixed the footer, which wasn't
captured in its usual non-fluid container.

![training_page](https://user-images.githubusercontent.com/538008/81866834-120dee00-9570-11ea-835c-0248a2f61ef4.png)


Signed-off-by: Julius Volz <julius.volz@gmail.com>