### PR TITLE
Aerospike official Prometheus exporter

### DIFF
--- a/content/docs/instrumenting/exporters.md
+++ b/content/docs/instrumenting/exporters.md
@@ -30,7 +30,7 @@ wide variety of JVM-based applications, for example [Kafka](http://kafka.apache.
 [Cassandra](http://cassandra.apache.org/).
 
 ### Databases
-   * [Aerospike exporter](https://github.com/alicebob/asprom)
+   * [Aerospike exporter](https://github.com/aerospike/aerospike-prometheus-exporter)
    * [ClickHouse exporter](https://github.com/f1yegor/clickhouse_exporter)
    * [Consul exporter](https://github.com/prometheus/consul_exporter) (**official**)
    * [Couchbase exporter](https://github.com/blakelead/couchbase_exporter)


### PR DESCRIPTION
This is a link to the official Aerospike Official Prometheus Exporter maintained by Aerospike engineering team