### PR TITLE
Add prometheus-version docsearch meta tag to pages

### DIFF
--- a/layouts/header.html
+++ b/layouts/header.html
@@ -28,7 +28,7 @@
     <% if (c = @item[:repo_docs]) && c[:canonical] %><link rel="canonical" href="<%= @item.path.sub(c[:items_root], c[:canonical]) %>" /><% end %>
     <!-- Meta tag for indexing that enables faceted search in Algolia,
       see https://docsearch.algolia.com/docs/required-configuration/#introduce-global-information-as-meta-tags -->
-    <meta name="docsearch:prometheus-version" content="<%= @item[:repo_docs] && @item[:repo_docs][:name] || 'unversioned' %>" />
+    <meta name="docsearch:prometheus-version" content="<%= @item[:repo_docs] && @item[:repo_docs][:name] || 'none' %>" />
     <meta name="msapplication-TileColor" content="#da532c">
     <meta name="msapplication-TileImage" content="/assets/favicons/mstile-144x144.png">
     <meta name="theme-color" content="#ffffff">

--- a/layouts/header.html
+++ b/layouts/header.html
@@ -26,6 +26,9 @@
     <link rel="icon" type="image/png" href="/assets/favicons/favicon-16x16.png" sizes="16x16">
     <link rel="manifest" href="/assets/favicons/android-chrome-manifest.json">
     <% if (c = @item[:repo_docs]) && c[:canonical] %><link rel="canonical" href="<%= @item.path.sub(c[:items_root], c[:canonical]) %>" /><% end %>
+    <!-- Meta tag for indexing that enables faceted search in Algolia,
+      see https://docsearch.algolia.com/docs/required-configuration/#introduce-global-information-as-meta-tags -->
+    <meta name="docsearch:prometheus-version" content="<%= @item[:repo_docs] && @item[:repo_docs][:name] || 'unversioned' %>" />
     <meta name="msapplication-TileColor" content="#da532c">
     <meta name="msapplication-TileImage" content="/assets/favicons/mstile-144x144.png">
     <meta name="theme-color" content="#ffffff">


### PR DESCRIPTION
I hope this will cause the Aloglia indexing engine to add a
"prometheus-version" indexing facet to our pages, so that when adding
Algolia search to the site in a subsequent step (I can already test it
locally), we can use this to search only for pages that are either the
latest Prometheus version (otherwise we get 10x the same-looking
result), or have no Prometheus version at all (the doc pages outside of
the versioned Prometheus sub-tree). I need to explicitly add "none" as a
version for the non-versioned pages, as Algolia search doesn't allow
facet filtering on null / undefined values.

Signed-off-by: Julius Volz <julius.volz@gmail.com>