### PR TITLE
Add Algolia Docsearch

### DIFF
--- a/content/css/docs.css
+++ b/content/css/docs.css
@@ -8,7 +8,7 @@ body {
 }
 
 .navbar-brand {
-  margin-top: 4px;
+  margin-top: 1px;
   font-family: Lato, sans-serif;
   font-size: 26px;
   font-weight: 300;
@@ -31,19 +31,51 @@ body {
 }
 
 .navbar-jumbotron .navbar-brand {
-  margin-top: 14px;
+  margin-top: 12px;
 }
 
 .navbar-jumbotron .main-nav {
-  margin-top: 17px;
+  margin-top: 15px;
 }
 
 .main-nav {
-  margin-top: 4px;
+  margin-top: 3px;
   letter-spacing: 1px;
   font-family: 'Lato', sans-serif;
-  font-size: 16px;
+  font-size: 15px;
+}
+
+.main-nav > li > a {
   text-transform: uppercase;
+}
+
+.algolia-autocomplete {
+  margin-top: 8px;
+  padding-left: 15px;
+  padding-right: 15px;
+}
+
+.algolia-autocomplete .algolia-docsearch-suggestion--highlight {
+  color: #e6522c;
+  background: #e6522c20;
+}
+
+.algolia-autocomplete .algolia-docsearch-suggestion--category-header .algolia-docsearch-suggestion--category-header-lvl0
+.algolia-docsearch-suggestion--highlight,
+.algolia-autocomplete .algolia-docsearch-suggestion--category-header .algolia-docsearch-suggestion--category-header-lvl1
+.algolia-docsearch-suggestion--highlight {
+  box-shadow: inset 0 -2px 0 0 #e6522cc0;
+}
+
+.algolia-autocomplete .algolia-docsearch-suggestion--text .algolia-docsearch-suggestion--highlight {
+  box-shadow: inset 0 -2px 0 0 #e6522cc0;
+}
+
+.searchbox {
+  border: none;
+  border-radius: 5px;
+  background-color: rgb(75, 75, 75);
+  color: white;
 }
 
 .jumbotron {
@@ -300,6 +332,8 @@ footer {
   padding: 5px 15px 5px 40px;
 }
 
+/* NOTE: When updating this class name, the search box configuration at
+  https://github.com/algolia/docsearch-configs/blob/master/configs/prometheus.json needs to be updated as well! */
 .doc-content {
   font-size: 16px;
 }

--- a/layouts/footer.html
+++ b/layouts/footer.html
@@ -16,5 +16,20 @@
       ga('create', 'UA-58468480-1', 'auto');
       ga('send', 'pageview');
     </script>
+
+    <!-- Algolia Docsearch -->
+    <script type="text/javascript" src="https://cdn.jsdelivr.net/npm/docsearch.js@2/dist/cdn/docsearch.min.js"></script>
+    <script type="text/javascript">
+      docsearch({
+        apiKey: '48ac0b7924908a1fd40b1cb18b402ba1',
+        indexName: 'prometheus',
+        inputSelector: '.searchbox',
+        // Search all pages that either are the latest (2.18) or are not part of the versioned Prometheus docs subtree.
+        // TODO: This requires updating for every new Prometheus version. Switch to a general "search:true|false" attribute instead,
+        // and omit it for non-latest Prometheus versions?
+        algoliaOptions: { 'facetFilters': [["prometheus-version:2.18", "prometheus-version:none"]] },
+        debug: false // Set debug to true if you want to inspect the dropdown
+      });
+    </script>
   </body>
 </html>

--- a/layouts/footer.html
+++ b/layouts/footer.html
@@ -25,8 +25,8 @@
         indexName: 'prometheus',
         inputSelector: '.searchbox',
         // Search all pages that either are the latest (2.18) or are not part of the versioned Prometheus docs subtree.
-        // TODO: This requires updating for every new Prometheus version. Switch to a general "search:true|false" attribute instead,
-        // and omit it for non-latest Prometheus versions?
+        // TODO: This requires updating for every new Prometheus version. Switch to the more general "include:true|false"
+        // attribute instead, once it's indexed by Algolia.
         algoliaOptions: { 'facetFilters': [["prometheus-version:2.18", "prometheus-version:none"]] },
         debug: false // Set debug to true if you want to inspect the dropdown
       });

--- a/layouts/header.html
+++ b/layouts/header.html
@@ -42,6 +42,9 @@
     <!-- Bootstrap core CSS -->
     <link href="/assets/bootstrap-3.3.1/css/bootstrap.min.css" rel="stylesheet">
 
+    <!-- Algolia site search, see https://www.algolia.com/solutions/site-search/ -->
+    <link rel="stylesheet" href="https://cdn.jsdelivr.net/npm/docsearch.js@2/dist/cdn/docsearch.min.css" />
+
     <!-- Custom styles for this template -->
     <link href="/css/docs.css" rel="stylesheet">
     <link href="/css/routing-tree-editor.css" rel="stylesheet">
@@ -50,7 +53,6 @@
     <link href="/assets/font-awesome-4.7.0/css/font-awesome.min.css" rel="stylesheet" type="text/css">
     <link href='https://fonts.googleapis.com/css?family=Open+Sans' rel='stylesheet' type='text/css'>
     <link href='https://fonts.googleapis.com/css?family=Lato:300,300italic,400' rel='stylesheet' type='text/css'>
-
   </head>
 
   <body>
@@ -74,6 +76,7 @@
             <li><a href="/community/">Community</a></li>
             <li><a href="/support-training/">Support & Training</a></li>
             <li><a href="/blog/">Blog</a></li>
+            <li><input class="searchbox form-control" type="search" placeholder="Search" aria-label="Search"></li>
             <li><a href="https://github.com/prometheus"><i class="fa fa-github"></i></a></li>
             <li><a href="https://twitter.com/PrometheusIO"><i class="fa fa-twitter"></i></a></li>
           </ul>

--- a/layouts/header.html
+++ b/layouts/header.html
@@ -29,6 +29,7 @@
     <!-- Meta tag for indexing that enables faceted search in Algolia,
       see https://docsearch.algolia.com/docs/required-configuration/#introduce-global-information-as-meta-tags -->
     <meta name="docsearch:prometheus-version" content="<%= @item[:repo_docs] && @item[:repo_docs][:name] || 'none' %>" />
+    <meta name="docsearch:include" content="<%= (@item[:repo_docs].nil? || @item[:repo_docs][:name].include?('latest')) && 'true' || 'false' %>" />
     <meta name="msapplication-TileColor" content="#da532c">
     <meta name="msapplication-TileImage" content="/assets/favicons/mstile-144x144.png">
     <meta name="theme-color" content="#ffffff">

--- a/nanoc.yaml
+++ b/nanoc.yaml
@@ -73,7 +73,7 @@ data_sources:
     identifier_type: legacy
     items_root: /docs/prometheus/latest/
     config:
-      name: 'latest (2.18)'
+      name: 'latest (2.18)' # NOTE! Update the "prometheus-version:2.18" filter in footer.html when changing this.
       repository: https://github.com/prometheus/prometheus.git
       refspec: release-2.18
     encoding: utf-8


### PR DESCRIPTION
This adds a search box to the top of the document that uses Algolia's
Docsearch (https://docsearch.algolia.com/). Indexing settings for our site
are configured in:

https://github.com/algolia/docsearch-configs/blob/master/configs/prometheus.json

Signed-off-by: Julius Volz <julius.volz@gmail.com>

![docsearch](https://user-images.githubusercontent.com/538008/82360754-1facf300-9a0a-11ea-910e-f76fe72a83a2.gif)