### PR TITLE
Add BMC exporter to list

### DIFF
--- a/content/docs/instrumenting/exporters.md
+++ b/content/docs/instrumenting/exporters.md
@@ -59,6 +59,7 @@ wide variety of JVM-based applications, for example [Kafka](http://kafka.apache.
 ### Hardware related
    * [apcupsd exporter](https://github.com/mdlayher/apcupsd_exporter)
    * [BIG-IP exporter](https://github.com/ExpressenAB/bigip_exporter)
+   * [BMC exporter](https://github.com/gebn/bmc_exporter)
    * [Collins exporter](https://github.com/soundcloud/collins_exporter)
    * [Dell Hardware OMSA exporter](https://github.com/galexrt/dellhw_exporter)
    * [IBM Z HMC exporter](https://github.com/zhmcclient/zhmc-prometheus-exporter)


### PR DESCRIPTION
This is a pure-Go alternative to the existing `ipmi_exporter`. It doesn't expose the entire SDR, but the metrics it does export follow Prometheus conventions and are normalised across BMC vendors, making it practical to aggregate them across a large estate. I hope to add more coverage over time. Any comments much appreciated!