### PR TITLE
Add missing slash in nginx example.

### DIFF
--- a/content/docs/guides/tls-encryption.md
+++ b/content/docs/guides/tls-encryption.md
@@ -51,7 +51,7 @@ http {
         ssl_certificate     /root/certs/example.com/example.com.crt;
         ssl_certificate_key /root/certs/example.com/example.com.key;
 
-        location /prometheus {
+        location /prometheus/ {
             proxy_pass http://localhost:9090/;
         }
     }


### PR DESCRIPTION
Fixes #1650

Signed-off-by: Brian Brazil <brian.brazil@robustperception.io>