### PR TITLE
Add scrape_interval to node_exporter guide

### DIFF
--- a/content/docs/guides/node-exporter.md
+++ b/content/docs/guides/node-exporter.md
@@ -62,13 +62,16 @@ curl http://localhost:9100/metrics | grep "node_"
 
 ## Configuring your Prometheus instances
 
-Your locally running Prometheus instance needs to be properly configured in order to access Node Exporter metrics. The following [`scrape_config`](../../prometheus/latest/configuration/configuration/#scrape_config) block (in a `prometheus.yml` configuration file) will tell the Prometheus instance to scrape from the Node Exporter via `localhost:9100`:
+Your locally running Prometheus instance needs to be properly configured in order to access Node Exporter metrics. The following [`prometheus.yml`](../../prometheus/latest/configuration/configuration/) example configuration file will tell the Prometheus instance to scrape, and how frequently, from the Node Exporter via `localhost:9100`:
 
 <a id="config"></a>
 
 ```yaml
+global:
+  scrape_interval: 15s
+
 scrape_configs:
-- job_name: 'node'
+- job_name: node
   static_configs:
   - targets: ['localhost:9100']
 ```


### PR DESCRIPTION
Document the use of scrape_interval in the node_exporter guide.

Signed-off-by: Ben Kochie <superq@gmail.com>