### PR TITLE
Fix Dockerfile

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,5 +1,5 @@
-FROM   ruby:2.1-onbuild
+FROM   ruby:2.4-onbuild
 EXPOSE 3000
 RUN    bundle exec nanoc
-CMD    bundle exec nanoc view
+CMD    bundle exec nanoc view --host 0.0.0.0
 VOLUME output

--- a/nanoc.yaml
+++ b/nanoc.yaml
@@ -70,15 +70,16 @@ data_sources:
     encoding: utf-8
   -
     type: repo_docs
+    encoding: utf-8
     identifier_type: legacy
     items_root: /docs/prometheus/latest/
     config:
       name: 'latest (2.18)' # NOTE! Update the "prometheus-version:2.18" filter in footer.html when changing this.
       repository: https://github.com/prometheus/prometheus.git
       refspec: release-2.18
-    encoding: utf-8
   -
     type: repo_docs
+    encoding: utf-8
     items_root: /docs/prometheus/2.18/
     identifier_type: legacy
     config:
@@ -88,6 +89,7 @@ data_sources:
       canonical: /docs/prometheus/latest/
   -
     type: repo_docs
+    encoding: utf-8
     identifier_type: legacy
     items_root: /docs/prometheus/2.17/
     config:
@@ -98,6 +100,7 @@ data_sources:
       outdated: /docs/prometheus/latest/
   -
     type: repo_docs
+    encoding: utf-8
     identifier_type: legacy
     items_root: /docs/prometheus/2.16/
     config:
@@ -108,6 +111,7 @@ data_sources:
       outdated: /docs/prometheus/latest/
   -
     type: repo_docs
+    encoding: utf-8
     identifier_type: legacy
     items_root: /docs/prometheus/2.15/
     config:
@@ -118,6 +122,7 @@ data_sources:
       outdated: /docs/prometheus/latest/
   -
     type: repo_docs
+    encoding: utf-8
     identifier_type: legacy
     items_root: /docs/prometheus/2.14/
     config:
@@ -128,6 +133,7 @@ data_sources:
       outdated: /docs/prometheus/latest/
   -
     type: repo_docs
+    encoding: utf-8
     identifier_type: legacy
     items_root: /docs/prometheus/2.13/
     config:
@@ -138,6 +144,7 @@ data_sources:
       outdated: /docs/prometheus/latest/
   -
     type: repo_docs
+    encoding: utf-8
     identifier_type: legacy
     items_root: /docs/prometheus/2.12/
     config:
@@ -146,9 +153,9 @@ data_sources:
       refspec: release-2.12
       canonical: /docs/prometheus/latest/
       outdated: /docs/prometheus/latest/
-    encoding: utf-8
   -
     type: repo_docs
+    encoding: utf-8
     identifier_type: legacy
     items_root: /docs/prometheus/2.11/
     config:
@@ -157,9 +164,9 @@ data_sources:
       refspec: release-2.11
       canonical: /docs/prometheus/latest/
       outdated: /docs/prometheus/latest/
-    encoding: utf-8
   -
     type: repo_docs
+    encoding: utf-8
     identifier_type: legacy
     items_root: /docs/prometheus/2.10/
     config:
@@ -168,9 +175,9 @@ data_sources:
       refspec: release-2.10
       canonical: /docs/prometheus/latest/
       outdated: /docs/prometheus/latest/
-    encoding: utf-8
   -
     type: repo_docs
+    encoding: utf-8
     identifier_type: legacy
     items_root: /docs/prometheus/2.9/
     config:
@@ -179,9 +186,9 @@ data_sources:
       refspec: release-2.9
       canonical: /docs/prometheus/latest/
       outdated: /docs/prometheus/latest/
-    encoding: utf-8
   -
     type: repo_docs
+    encoding: utf-8
     identifier_type: legacy
     items_root: /docs/prometheus/2.8/
     config:
@@ -190,9 +197,9 @@ data_sources:
       refspec: release-2.8
       canonical: /docs/prometheus/latest/
       outdated: /docs/prometheus/latest/
-    encoding: utf-8
   -
     type: repo_docs
+    encoding: utf-8
     identifier_type: legacy
     items_root: /docs/prometheus/1.8/
     config:
@@ -201,7 +208,6 @@ data_sources:
       refspec: release-1.8
       canonical: /docs/prometheus/latest/
       outdated: /docs/prometheus/latest/
-    encoding: utf-8
   -
     type: filesystem
     items_root: /assets


### PR DESCRIPTION
Ruby 2.4 is needed and the encoding is mising on some data sources.

I have moved encoding next to `type:`, so it will less likely be removed
accidentaly.

Signed-off-by: Julien Pivotto <roidelapluie@inuits.eu>