### PR TITLE
Add note about details handling for Opsgenie

### DIFF
--- a/content/docs/alerting/configuration.md
+++ b/content/docs/alerting/configuration.md
@@ -607,6 +607,7 @@ OpsGenie notifications are sent via the [OpsGenie API](https://docs.opsgenie.com
 
 # A set of arbitrary key/value pairs that provide further detail
 # about the incident.
+# All common labels are included as details by default.
 [ details: { <string>: <tmpl_string>, ... } ]
 
 # List of responders responsible for notifications.


### PR DESCRIPTION
With the merge of https://github.com/prometheus/alertmanager/pull/2276 all common labels are included in the OpsGenie details by default.