### PR TITLE
Adding exporter for Citrix ADC (formerly Citrix NetScaler)

### DIFF
--- a/content/docs/instrumenting/exporters.md
+++ b/content/docs/instrumenting/exporters.md
@@ -108,6 +108,7 @@ wide variety of JVM-based applications, for example [Kafka](http://kafka.apache.
 
 ### HTTP
    * [Apache exporter](https://github.com/Lusitaniae/apache_exporter)
+   * [Citrix ADC Observability exporter (COE)](https://github.com/citrix/citrix-observability-exporter/)
    * [HAProxy exporter](https://github.com/prometheus/haproxy_exporter) (**official**)
    * [Nginx metric library](https://github.com/knyar/nginx-lua-prometheus)
    * [Nginx VTS exporter](https://github.com/hnlq715/nginx-vts-exporter)
@@ -116,6 +117,7 @@ wide variety of JVM-based applications, for example [Kafka](http://kafka.apache.
    * [Tinyproxy exporter](https://github.com/igzivkov/tinyproxy_exporter)
    * [Varnish exporter](https://github.com/jonnenauha/prometheus_varnish_exporter)
    * [WebDriver exporter](https://github.com/mattbostock/webdriver_exporter)
+   
 
 ### APIs
    * [AWS ECS exporter](https://github.com/slok/ecs-exporter)


### PR DESCRIPTION
Signed-Off-By: Komal Bhardwaj <komal.bhardwaj@citrix.com>
