### PR TITLE
Update PgBouncer exporter link

### DIFF
--- a/content/docs/instrumenting/exporters.md
+++ b/content/docs/instrumenting/exporters.md
@@ -46,7 +46,7 @@ wide variety of JVM-based applications, for example [Kafka](http://kafka.apache.
    * [MySQL server exporter](https://github.com/prometheus/mysqld_exporter) (**official**)
    * [OpenTSDB Exporter](https://github.com/cloudflare/opentsdb_exporter)
    * [Oracle DB Exporter](https://github.com/iamseth/oracledb_exporter)
-   * [PgBouncer exporter](http://git.cbaines.net/prometheus-pgbouncer-exporter/about)
+   * [PgBouncer exporter](https://github.com/prometheus-community/pgbouncer_exporter)
    * [PostgreSQL exporter](https://github.com/wrouesnel/postgres_exporter)
    * [Presto exporter](https://github.com/yahoojapan/presto_exporter)
    * [ProxySQL exporter](https://github.com/percona/proxysql_exporter)


### PR DESCRIPTION
Replace link to original Python PgBouncer exporter.
* The Python exporter hasn't been updated since 2017.
* The new Go exporter has many more metrics available.
* The new Go exporter is in the Prometheus Community.

Signed-off-by: Ben Kochie <superq@gmail.com>