### PR TITLE
Use current Docker registry

### DIFF
--- a/content/docs/guides/cadvisor.md
+++ b/content/docs/guides/cadvisor.md
@@ -43,7 +43,7 @@ services:
     depends_on:
     - cadvisor
   cadvisor:
-    image: google/cadvisor:latest
+    image: gcr.io/google-containers/cadvisor:latest
     container_name: cadvisor
     ports:
     - 8080:8080


### PR DESCRIPTION
The following Docker registry is obsolete and provides only version 0.33.0, while 0.35.0 is the last release. 