### PR TITLE
content/docs/instrumenting: Rust client moved to tikv org

### DIFF
--- a/content/docs/instrumenting/clientlibs.md
+++ b/content/docs/instrumenting/clientlibs.md
@@ -35,7 +35,7 @@ Unofficial third-party client libraries:
 * [Perl](https://metacpan.org/pod/Net::Prometheus)
 * [PHP](https://github.com/endclothing/prometheus_client_php)
 * [R](https://github.com/cfmack/pRometheus)
-* [Rust](https://github.com/pingcap/rust-prometheus)
+* [Rust](https://github.com/tikv/rust-prometheus)
 
 When Prometheus scrapes your instance's HTTP endpoint, the client library
 sends the current state of all tracked metrics to the server.


### PR DESCRIPTION
Signed-off-by: Max Inden <mail@max-inden.de>