### PR TITLE
Add Ansible Tower (AWX)

### DIFF
--- a/content/docs/instrumenting/exporters.md
+++ b/content/docs/instrumenting/exporters.md
@@ -234,8 +234,8 @@ possible.
 Some third-party software exposes metrics in the Prometheus format, so no
 separate exporters are needed:
 
-   * [App Connect Enterprise](https://github.com/ot4i/ace-docker)
    * [Ansible Tower (AWX)](https://docs.ansible.com/ansible-tower/latest/html/administration/metrics.html)
+   * [App Connect Enterprise](https://github.com/ot4i/ace-docker)
    * [Ballerina](https://ballerina.io/)
    * [BFE](https://github.com/baidu/bfe)
    * [Ceph](http://docs.ceph.com/docs/master/mgr/prometheus/)

--- a/content/docs/instrumenting/exporters.md
+++ b/content/docs/instrumenting/exporters.md
@@ -235,6 +235,7 @@ Some third-party software exposes metrics in the Prometheus format, so no
 separate exporters are needed:
 
    * [App Connect Enterprise](https://github.com/ot4i/ace-docker)
+   * [Ansible Tower (AWX)](https://docs.ansible.com/ansible-tower/latest/html/administration/metrics.html)
    * [Ballerina](https://ballerina.io/)
    * [BFE](https://github.com/baidu/bfe)
    * [Ceph](http://docs.ceph.com/docs/master/mgr/prometheus/)


### PR DESCRIPTION
Include Ansible Tower (AWX) as a "Software exposing Prometheus metrics" with direct link to the documentation.