### PR TITLE
Add Power == watts base unit to naming.md

### DIFF
--- a/content/docs/practices/naming.md
+++ b/content/docs/practices/naming.md
@@ -83,5 +83,5 @@ The list is not exhaustive.
 | Voltage | volts | |
 | Electric current | amperes | |
 | Energy | joules | |
+| Power  | | Prefer exporting a counter of joules, then `rate(joules[5m])` gives you power in Watts. |
 | Mass   | grams | _grams_ is preferred over _kilograms_ to avoid issues with the _kilo_ prefix. |
- 


### PR DESCRIPTION
I'm just making an IoT power device and I thought this might be nice to standardize in the docs.