### PR TITLE
Added link to MetricFire's Hosted Prometheus remote storage

### DIFF
--- a/content/docs/operating/integrations.md
+++ b/content/docs/operating/integrations.md
@@ -50,6 +50,7 @@ data volumes.
   * [IRONdb](https://github.com/circonus-labs/irondb-prometheus-adapter): read and write
   * [Kafka](https://github.com/Telefonica/prometheus-kafka-adapter): write
   * [M3DB](https://m3db.github.io/m3/integrations/prometheus): read and write
+  * [MetricFire](https://www.hostedgraphite.com/docs/prometheus/prometheus.html): read and write
   * [OpenTSDB](https://github.com/prometheus/prometheus/tree/master/documentation/examples/remote_storage/remote_storage_adapter): write
   * [PostgreSQL/TimescaleDB](https://github.com/timescale/prometheus-postgresql-adapter): read and write
   * [QuasarDB](https://doc.quasardb.net/master/user-guide/integration/prometheus.html): read and write


### PR DESCRIPTION
Signed-off-by: Jiro Mizuno <jiro@metricfire.com>

@brian-brazil 