### PR TITLE
Remove Docker Swarm external integration

### DIFF
--- a/content/docs/operating/integrations.md
+++ b/content/docs/operating/integrations.md
@@ -22,7 +22,6 @@ these categories.
 For service discovery mechanisms not natively supported by Prometheus,
 [file-based service discovery](/docs/operating/configuration/#%3Cfile_sd_config%3E) provides an interface for integrating.
 
- * [Docker Swarm](https://github.com/ContainerSolutions/prometheus-swarm-discovery)
  * [Kuma](https://github.com/Kong/kuma/tree/master/app/kuma-prometheus-sd)
  * [Lightsail](https://github.com/n888/prometheus-lightsail-sd)
  * [Packet](https://github.com/packethost/prometheus-packet-sd)


### PR DESCRIPTION
Now Prometheus has native Swarm support and that is what we should
promote.

I have also engaged with the community:

https://github.com/ContainerSolutions/prometheus-swarm-discovery/issues/11
https://github.com/function61/promswarmconnect/issues/14
https://github.com/cuigh/prometheus/issues/8

Signed-off-by: Julien Pivotto <roidelapluie@inuits.eu>