### PR TITLE
Add Cilium to list of software exposing metrics

### DIFF
--- a/content/docs/instrumenting/exporters.md
+++ b/content/docs/instrumenting/exporters.md
@@ -241,6 +241,7 @@ separate exporters are needed:
    * [Ballerina](https://ballerina.io/)
    * [BFE](https://github.com/baidu/bfe)
    * [Ceph](http://docs.ceph.com/docs/master/mgr/prometheus/)
+   * [Cilium](https://docs.cilium.io/en/stable/configuration/metrics/) (**direct**)
    * [CockroachDB](https://www.cockroachlabs.com/docs/stable/monitoring-and-alerting.html#prometheus-endpoint)
    * [Collectd](https://collectd.org/wiki/index.php/Plugin:Write_Prometheus)
    * [Concourse](https://concourse-ci.org/)


### PR DESCRIPTION
Add Cilium (https://cilium.io) to the list of software exposing Prometheus metrics.

Signed-off-by: Tobias Klauser <tklauser@distanz.ch>