### PR TITLE
Add nvme_exporter to the list

### DIFF
--- a/content/docs/instrumenting/exporters.md
+++ b/content/docs/instrumenting/exporters.md
@@ -107,6 +107,7 @@ wide variety of JVM-based applications, for example [Kafka](http://kafka.apache.
    * [Hadoop HDFS FSImage exporter](https://github.com/marcelmay/hadoop-hdfs-fsimage-exporter)
    * [Lustre exporter](https://github.com/HewlettPackard/lustre_exporter)
    * [ScaleIO exporter](https://github.com/syepes/sio2prom)
+   * [NVMe SSD exporter](https://github.com/yongseokoh/nvme_exporter)
 
 ### HTTP
    * [Apache exporter](https://github.com/Lusitaniae/apache_exporter)


### PR DESCRIPTION
Hi maintainers,

I would like to add the nvme_export (https://github.com/yongseokoh/nvme_exporter) link to the page. Please, have it included in the project.

Thanks