### PR TITLE
Update first steps page to better describe the content of the page

### DIFF
--- a/content/docs/introduction/first_steps.md
+++ b/content/docs/introduction/first_steps.md
@@ -5,7 +5,7 @@ sort_rank: 3
 
 # First steps with Prometheus
 
-Welcome to Prometheus! Prometheus is a monitoring platform that collects metrics from monitored targets by scraping metrics HTTP endpoints on these targets. This guide will show you how to install, configure and monitor our first resource with Prometheus. You'll download, install and run Prometheus. You'll also download and install an exporter, tools that expose time series data on hosts and services. Our first exporter will be Prometheus itself, which provides a wide variety of host-level metrics about memory usage, garbage collection, and more.
+Welcome to Prometheus! Prometheus is a monitoring platform that collects metrics from monitored targets by scraping metrics HTTP endpoints on these targets. This guide will show you how to install, configure and monitor our first resource with Prometheus. You'll download, install and run Prometheus. We also recommend exploring documentation about other exporters. For example, in the [Monitoring Linux or macOS host metrics using a node exporter](/docs/guides/node-exporter) guide, you'll download and install an exporter, tools that expose time series data on hosts and services. This exporter will be Prometheus itself, which provides a wide variety of host-level metrics about memory usage, garbage collection, and more.
 
 ## Downloading Prometheus
 


### PR DESCRIPTION
Before my fix, the description of the first steps page said (https://prometheus.io/docs/introduction/first_steps/)
> You'll also download and install an exporter, tools that expose time series data on hosts and services. Our first exporter will be Prometheus itself, which provides a wide variety of host-level metrics about memory usage, garbage collection, and more.

But after reading this **first step**, we didn't download and install any exporter. All we did is just recommend exploring documentation about other exporters, and provide a link for a start point. So, I rephrased this sentence to:

> We also recommend exploring documentation about other exporters. For example, in the Monitoring Linux or macOS host metrics using a node exporter guide, you'll download and install an exporter, tools that expose time series data on hosts and services. This exporter will be Prometheus itself, which provides a wide variety of host-level metrics about memory usage, garbage collection, and more.

This will better describe what the following content is.

Signed-off-by: Luke Chen <showuon@gmail.com>