### PR TITLE
Add link to Nagios section like others in this page for consistency

### DIFF
--- a/content/docs/introduction/comparison.md
+++ b/content/docs/introduction/comparison.md
@@ -250,7 +250,7 @@ environment, then Prometheus is a good choice.
 
 ### Scope
 
-The same general scope differences as in the case of Nagios apply here.
+The same general scope differences as in the case of [Nagios](/docs/introduction/comparison/#prometheus-vs-nagios) apply here.
 
 There is also a [client socket](https://docs.sensu.io/sensu-core/latest/reference/clients/#what-is-the-sensu-client-socket) permitting ad-hoc check results to be pushed into Sensu. 
 


### PR DESCRIPTION
In the comparison page, each time, we mentioned an previously described scope, we'll put a link there for reference. Just like this:
![image](https://user-images.githubusercontent.com/43372967/90369448-601a1c80-e09e-11ea-97e0-32fbc7654293.png)

But we didn't add the link in the Sensu's scope section, which should link to Nagios section. 

Signed-off-by: Luke Chen <showuon@gmail.com>