### PR TITLE
Update the supported list for alert manager

### DIFF
--- a/content/docs/introduction/faq.md
+++ b/content/docs/introduction/faq.md
@@ -114,11 +114,12 @@ Currently, the following external systems are supported:
 
 * Email
 * Generic Webhooks
-* [HipChat](https://www.hipchat.com/)
 * [OpsGenie](https://www.opsgenie.com/)
 * [PagerDuty](http://www.pagerduty.com/)
 * [Pushover](https://pushover.net/)
 * [Slack](https://slack.com/)
+* [VictorOps](https://victorops.com/)
+* [WeChat](https://www.wechat.com)
 
 ### Can I create dashboards?
 


### PR DESCRIPTION
1. Remove the unsupported HipChat
2. Add 2 more supported systems: VictorOps, WeChat
Ref: https://prometheus.io/docs/alerting/latest/configuration/