### PR TITLE
Add c-lightning exporter to exporters.md

### DIFF
--- a/content/docs/instrumenting/exporters.md
+++ b/content/docs/instrumenting/exporters.md
@@ -187,6 +187,7 @@ wide variety of JVM-based applications, for example [Kafka](http://kafka.apache.
    * [cAdvisor](https://github.com/google/cadvisor)
    * [Cachet exporter](https://github.com/ContaAzul/cachet_exporter)
    * [ccache exporter](https://github.com/virtualtam/ccache_exporter)
+   * [c-lightning exporter](https://github.com/lightningd/plugins/tree/master/prometheus)
    * [DHCPD leases exporter](https://github.com/DRuggeri/dhcpd_leases_exporter)
    * [Dovecot exporter](https://github.com/kumina/dovecot_exporter)
    * [Dnsmasq exporter](https://github.com/google/dnsmasq_exporter)


### PR DESCRIPTION
The exporter was already added to the port-reservations list, and exports a variety of metrics from the Lightning Network client.