### PR TITLE
Dovecot 2.3.11+ can expose metrics natively

### DIFF
--- a/content/docs/instrumenting/exporters.md
+++ b/content/docs/instrumenting/exporters.md
@@ -254,6 +254,7 @@ separate exporters are needed:
    * [Diffusion](https://docs.pushtechnology.com/docs/latest/manual/html/administratorguide/systemmanagement/r_statistics.html)
    * [Docker Daemon](https://docs.docker.com/engine/reference/commandline/dockerd/#daemon-metrics)
    * [Doorman](https://github.com/youtube/doorman) (**direct**)
+   * [Dovecot](https://doc.dovecot.org/configuration_manual/stats/openmetrics/)
    * [Envoy](https://www.envoyproxy.io/docs/envoy/latest/operations/admin.html#get--stats?format=prometheus)
    * [Etcd](https://github.com/coreos/etcd) (**direct**)
    * [Flink](https://github.com/apache/flink)


### PR DESCRIPTION
https://doc.dovecot.org/configuration_manual/stats/openmetrics/
https://dovecot.org/doc/NEWS