### PR TITLE
Add link to Canopsis integration in docs

### DIFF
--- a/content/docs/operating/integrations.md
+++ b/content/docs/operating/integrations.md
@@ -70,6 +70,7 @@ For notification mechanisms not natively supported by the Alertmanager, the
   * [alertmanager-webhook-logger](https://github.com/tomtom-international/alertmanager-webhook-logger): logs alerts
   * [Alertsnitch](https://gitlab.com/yakshaving.art/alertsnitch): saves alerts to a MySQL database
   * [AWS SNS](https://github.com/DataReply/alertmanager-sns-forwarder)
+  * [Canopsis](https://git.canopsis.net/canopsis-connectors/connector-prometheus2canopsis)
   * [DingTalk](https://github.com/timonwong/prometheus-webhook-dingtalk)
   * [GELF](https://github.com/b-com-software-basis/alertmanager2gelf)
   * [IRC Bot](https://github.com/multimfi/bot)


### PR DESCRIPTION
Hello,

Please find in this pull request some informations about Canopsis-Prometheus integration.

Canopsis is an Open Source ( french project https://github.com/capensis/canopsis ) Hypervisor Solution which collect information about several sources ( through AMQP bus or HTTP API ) and aggregate them into a single monitoring interface. This can be usefull to make some correlation rules, global alarm list or global weather of your IT.

Request you to please include a link to the Canopsis-Prometheus connector documentation in your Integrations page.

Thanks