### PR TITLE
Add vmware vcenter/esx exporter

### DIFF
--- a/content/docs/instrumenting/exporters.md
+++ b/content/docs/instrumenting/exporters.md
@@ -177,6 +177,7 @@ wide variety of JVM-based applications, for example [Kafka](http://kafka.apache.
    * [StatsD exporter](https://github.com/prometheus/statsd_exporter) (**official**)
    * [TencentCloud monitor exporter](https://github.com/tencentyun/tencentcloud-exporter)
    * [ThousandEyes exporter](https://github.com/sapcc/1000eyes_exporter)
+   * [vmware vcenter / esx exporter](https://github.com/Intrinsec/govc_exporter)
 
 ### Miscellaneous
    * [ACT Fibernet Exporter](https://git.captnemo.in/nemo/prometheus-act-exporter)


### PR DESCRIPTION
Hello,

I made a prometheus stand alone exporter for VCenter metrics. Metrics are fetched by govmomi api.

It also works with stand alone ESX without VCenter.

| Collectors          | Description |
| ------------------- | ----------- |
| `collector.ds`      | Datastore metrics collector |
| `collector.esx`     | ESX (HostSystem) metrics collector |
| `collector.respool` | ResourcePool metrics collector |
| `collector.spod`    | Datastore Cluster (StoragePod) metrics collector |
| `collector.vm`      | VirtualMachine metrics Collector |

It is functional but I still have some tests to perform in order to verify that all metrics units are correct as it is not very well documented in vmware api.

Regards,
