### PR TITLE
tarantool/metrics instead of tarantool/prometheus

### DIFF
--- a/content/docs/instrumenting/clientlibs.md
+++ b/content/docs/instrumenting/clientlibs.md
@@ -29,7 +29,7 @@ Unofficial third-party client libraries:
 * [Erlang](https://github.com/deadtrickster/prometheus.erl)
 * [Haskell](https://github.com/fimad/prometheus-haskell)
 * [Lua](https://github.com/knyar/nginx-lua-prometheus) for Nginx
-* [Lua](https://github.com/tarantool/prometheus) for Tarantool
+* [Lua](https://github.com/tarantool/metrics) for Tarantool
 * [.NET / C#](https://github.com/prometheus-net/prometheus-net)
 * [Node.js](https://github.com/siimon/prom-client)
 * [Perl](https://metacpan.org/pod/Net::Prometheus)

--- a/content/docs/instrumenting/exporters.md
+++ b/content/docs/instrumenting/exporters.md
@@ -54,7 +54,7 @@ wide variety of JVM-based applications, for example [Kafka](http://kafka.apache.
    * [Redis exporter](https://github.com/oliver006/redis_exporter)
    * [RethinkDB exporter](https://github.com/oliver006/rethinkdb_exporter)
    * [SQL exporter](https://github.com/free/sql_exporter)
-   * [Tarantool metric library](https://github.com/tarantool/prometheus)
+   * [Tarantool metric library](https://github.com/tarantool/metrics)
    * [Twemproxy](https://github.com/stuartnelson3/twemproxy_exporter)
 
 ### Hardware related


### PR DESCRIPTION
https://github.com/tarantool/prometheus is deprecated. tarantool/metrics contains an actual version of Prometheus plugin.