### PR TITLE
Replace third-party client PHP

### DIFF
--- a/content/docs/instrumenting/clientlibs.md
+++ b/content/docs/instrumenting/clientlibs.md
@@ -33,7 +33,7 @@ Unofficial third-party client libraries:
 * [.NET / C#](https://github.com/prometheus-net/prometheus-net)
 * [Node.js](https://github.com/siimon/prom-client)
 * [Perl](https://metacpan.org/pod/Net::Prometheus)
-* [PHP](https://github.com/endclothing/prometheus_client_php)
+* [PHP](https://github.com/promphp/prometheus_client_php)
 * [R](https://github.com/cfmack/pRometheus)
 * [Rust](https://github.com/tikv/rust-prometheus)
 


### PR DESCRIPTION
This commit replaces https://github.com/endclothing/prometheus_client_php, as it seems to be without active development anymore, so I forked it and took over the maintaining in https://github.com/lkaemmerling/prometheus_client_php

This client is already widely used (~800 downloads in 1oneweek)