### PR TITLE
Add 'Better Uptime' to list of webhook receivers

### DIFF
--- a/content/docs/operating/integrations.md
+++ b/content/docs/operating/integrations.md
@@ -70,6 +70,7 @@ For notification mechanisms not natively supported by the Alertmanager, the
   * [alertmanager-webhook-logger](https://github.com/tomtom-international/alertmanager-webhook-logger): logs alerts
   * [Alertsnitch](https://gitlab.com/yakshaving.art/alertsnitch): saves alerts to a MySQL database
   * [AWS SNS](https://github.com/DataReply/alertmanager-sns-forwarder)
+  * [Better Uptime](https://docs.betteruptime.com/integrations/prometheus)
   * [Canopsis](https://git.canopsis.net/canopsis-connectors/connector-prometheus2canopsis)
   * [DingTalk](https://github.com/timonwong/prometheus-webhook-dingtalk)
   * [Discord](https://github.com/benjojo/alertmanager-discord)


### PR DESCRIPTION
Documents the fact that Better Uptime has Prometheus webhook support.