### PR TITLE
Add mongodb-query-exporter

### DIFF
--- a/content/docs/instrumenting/exporters.md
+++ b/content/docs/instrumenting/exporters.md
@@ -41,6 +41,7 @@ wide variety of JVM-based applications, for example [Kafka](http://kafka.apache.
    * [KDB+ exporter](https://github.com/KxSystems/prometheus-kdb-exporter)
    * [Memcached exporter](https://github.com/prometheus/memcached_exporter) (**official**)
    * [MongoDB exporter](https://github.com/dcu/mongodb_exporter)
+   * [MongoDB query exporter](https://github.com/raffis/mongodb-query-exporter)
    * [MSSQL server exporter](https://github.com/awaragi/prometheus-mssql-exporter)
    * [MySQL router exporter](https://github.com/rluisr/mysqlrouter_exporter)
    * [MySQL server exporter](https://github.com/prometheus/mysqld_exporter) (**official**)


### PR DESCRIPTION
Add mongodb-query-exporter to the list of exporters.
The mongodb-query-exporter creates prometheus metrics out of MongoDB aggregations.