### PR TITLE
add bsbmp-exporter

### DIFF
--- a/content/docs/instrumenting/exporters.md
+++ b/content/docs/instrumenting/exporters.md
@@ -60,6 +60,7 @@ wide variety of JVM-based applications, for example [Kafka](http://kafka.apache.
 ### Hardware related
    * [apcupsd exporter](https://github.com/mdlayher/apcupsd_exporter)
    * [BIG-IP exporter](https://github.com/ExpressenAB/bigip_exporter)
+   * [Bosch Sensortec BMP/BME exporter](https://github.com/David-Igou/bsbmp-exporter)
    * [Collins exporter](https://github.com/soundcloud/collins_exporter)
    * [Dell Hardware OMSA exporter](https://github.com/galexrt/dellhw_exporter)
    * [Fortigate exporter](https://github.com/bluecmd/fortigate_exporter)


### PR DESCRIPTION
This exporter is for several models of Bosch Sensortec environmental sensors. Tested on Raspberry Pi Zero and 4, but should also work on Banana and Orange Pi's (I plan on verifying this)

Feedback is welcome. 