### PR TITLE
Change the integration link for PostgreSQL

### DIFF
--- a/content/docs/operating/integrations.md
+++ b/content/docs/operating/integrations.md
@@ -53,7 +53,7 @@ data volumes.
   * [MetricFire](https://www.hostedgraphite.com/docs/prometheus/prometheus.html): read and write
   * [New Relic](https://docs.newrelic.com/docs/set-or-remove-your-prometheus-remote-write-integration): write
   * [OpenTSDB](https://github.com/prometheus/prometheus/tree/master/documentation/examples/remote_storage/remote_storage_adapter): write
-  * [PostgreSQL/TimescaleDB](https://github.com/timescale/prometheus-postgresql-adapter): read and write
+  * [PostgreSQL/TimescaleDB](https://github.com/timescale/promscale): read and write
   * [QuasarDB](https://doc.quasardb.net/master/user-guide/integration/prometheus.html): read and write
   * [SignalFx](https://github.com/signalfx/metricproxy#prometheus): write
   * [Splunk](https://github.com/kebe7jun/ropee): read and write


### PR DESCRIPTION
Promscale is the v2 version of the prometheus-postgresql-adapter
project. It uses a much more efficient schema and is compatible
with vanilla PostgreSQL without additional extensions.

Previous discussion in #1722.