### PR TITLE
Add Rediseen as one option for Redis exporter

### DIFF
--- a/content/docs/instrumenting/exporters.md
+++ b/content/docs/instrumenting/exporters.md
@@ -52,6 +52,7 @@ wide variety of JVM-based applications, for example [Kafka](http://kafka.apache.
    * [ProxySQL exporter](https://github.com/percona/proxysql_exporter)
    * [RavenDB exporter](https://github.com/marcinbudny/ravendb_exporter)
    * [Redis exporter](https://github.com/oliver006/redis_exporter)
+   * [Rediseen as Redis exporter](https://github.com/XD-DENG/rediseen)
    * [RethinkDB exporter](https://github.com/oliver006/rethinkdb_exporter)
    * [SQL exporter](https://github.com/free/sql_exporter)
    * [Tarantool metric library](https://github.com/tarantool/metrics)


### PR DESCRIPTION
Starting from 2.4.0, [Rediseen](https://github.com/XD-DENG/rediseen) starts to support exposing Redis INFO command output in Prometheus-compatible format. This provides an easy way for Redis users to use Prometheus with the metrics they are familiar with.

@brian-brazil  Hope you can consider merging this. Please let me know if any clarification is needed. Thanks!

