### PR TITLE
Show .zip archive only for Windows

### DIFF
--- a/lib/helpers/download.rb
+++ b/lib/helpers/download.rb
@@ -125,10 +125,15 @@ module Downloads
       @data['assets']
     end
 
+    # binaries returns a list of release archives in the .tar.gz or .zip format.
+    # If both formats are available, only .zip is returned (covers Windows use case).
     def binaries
       assets.
         select { |d| d['name'] && %w[.tar.gz .zip].any? { |ext| d['name'].end_with?(ext) } }.
-        map { |d| Binary.new(d) }
+        map { |d| Binary.new(d) }.
+        group_by { |b| [b.os, b.arch] }.
+        map { |_, binaries| binaries.sort_by(&:name).last }.
+        sort_by(&:name)
     end
 
     def tag

--- a/specs/download_spec.rb
+++ b/specs/download_spec.rb
@@ -47,6 +47,20 @@ describe Downloads::Release do
       expect([bugfix, regular, rc1, rc0].sort).to eql([bugfix, regular, rc0, rc1])
     end
   end
+
+  describe '#binaries' do
+    let(:release) do
+      Downloads::Release.new({ 'assets' => [
+        { 'name' => 'prometheus-1.2.0.linux-amd64.tar.gz' },
+        { 'name' => 'prometheus-1.2.0.windows-amd64.tar.gz' },
+        { 'name' => 'prometheus-1.2.0.windows-amd64.zip' },
+      ]})
+    end
+
+    it 'prefers .zip format over .tar.gz' do
+      expect(release.binaries.map(&:name)).to eql(['prometheus-1.2.0.linux-amd64.tar.gz', 'prometheus-1.2.0.windows-amd64.zip'])
+    end
+  end
 end
 
 describe Downloads::Repository do


### PR DESCRIPTION
If a release archive is available in both .tar.gz and .zip format, only
show the .zip archive in the download list.