### PR TITLE
Add GPFS exporter

### DIFF
--- a/content/docs/instrumenting/exporters.md
+++ b/content/docs/instrumenting/exporters.md
@@ -108,6 +108,7 @@ wide variety of JVM-based applications, for example [Kafka](http://kafka.apache.
    * [Ceph exporter](https://github.com/digitalocean/ceph_exporter)
    * [Ceph RADOSGW exporter](https://github.com/blemmenes/radosgw_usage_exporter)
    * [Gluster exporter](https://github.com/ofesseler/gluster_exporter)
+   * [GPFS exporter](https://github.com/treydock/gpfs_exporter)
    * [Hadoop HDFS FSImage exporter](https://github.com/marcelmay/hadoop-hdfs-fsimage-exporter)
    * [Lustre exporter](https://github.com/HewlettPackard/lustre_exporter)
    * [ScaleIO exporter](https://github.com/syepes/sio2prom)


### PR DESCRIPTION
Adds link to GPFS exporter.  This filesystem is now called IBM Spectrum Scale though the actual filesystem type is GPFS, and is commonly found at HPC centers.