### PR TITLE
Add TSM exporter

### DIFF
--- a/content/docs/instrumenting/exporters.md
+++ b/content/docs/instrumenting/exporters.md
@@ -111,6 +111,7 @@ wide variety of JVM-based applications, for example [Kafka](http://kafka.apache.
    * [Hadoop HDFS FSImage exporter](https://github.com/marcelmay/hadoop-hdfs-fsimage-exporter)
    * [Lustre exporter](https://github.com/HewlettPackard/lustre_exporter)
    * [ScaleIO exporter](https://github.com/syepes/sio2prom)
+   * [Tivoli Storage Manager/IBM Spectrum Protect exporter](https://github.com/treydock/tsm_exporter)
 
 ### HTTP
    * [Apache exporter](https://github.com/Lusitaniae/apache_exporter)


### PR DESCRIPTION
Adds link to TSM exporter (Tivoli Storage Manager) which is also called IBM Spectrum Protect.  This is a common enterprise backup and archival solution.