### PR TITLE
Add SSH exporter

### DIFF
--- a/content/docs/instrumenting/exporters.md
+++ b/content/docs/instrumenting/exporters.md
@@ -226,6 +226,7 @@ wide variety of JVM-based applications, for example [Kafka](http://kafka.apache.
    * [Smokeping prober](https://github.com/SuperQ/smokeping_prober)
    * [SMTP/Maildir MDA blackbox prober](https://github.com/cherti/mailexporter)
    * [SoftEther exporter](https://github.com/dalance/softether_exporter)
+   * [SSH exporter](https://github.com/treydock/ssh_exporter)
    * [Teamspeak3 exporter](https://github.com/hikhvar/ts3exporter)
    * [Transmission exporter](https://github.com/metalmatze/transmission-exporter)
    * [Unbound exporter](https://github.com/kumina/unbound_exporter)


### PR DESCRIPTION
Adds SSH exporter that is mostly used for monitoring purposes in testing that SSH is healthy but does produce some timing data.