### PR TITLE
Add Open OnDemand exporter

### DIFF
--- a/content/docs/instrumenting/exporters.md
+++ b/content/docs/instrumenting/exporters.md
@@ -211,6 +211,7 @@ wide variety of JVM-based applications, for example [Kafka](http://kafka.apache.
    * [Minecraft exporter module](https://github.com/Baughn/PrometheusIntegration)
    * [Nomad exporter](https://gitlab.com/yakshaving.art/nomad-exporter)
    * [nftables exporter](https://github.com/Intrinsec/nftables_exporter)
+   * [Open OnDemand exporter](https://github.com/OSC/ondemand_exporter)
    * [OpenStack exporter](https://github.com/openstack-exporter/openstack-exporter)
    * [OpenStack blackbox exporter](https://github.com/infraly/openstack_client_exporter)
    * [oVirt exporter](https://github.com/czerwonk/ovirt_exporter)


### PR DESCRIPTION
Adds Open OnDemand (http://openondemand.org/) exporter that collects application specific metrics.  This is a NSF funded application typically deployed by HPC centers.