### PR TITLE
docs(guides): add windows exporter guide

### DIFF
--- a/content/docs/guides/windows-exporter.md
+++ b/content/docs/guides/windows-exporter.md
@@ -1,0 +1,68 @@
+---
+title: Monitoring Windows host metrics with Windows Exporter
+---
+
+# Monitoring Windows host metrics with Windows Exporter
+
+The Prometheus [**Windows Exporter**](https://github.com/prometheus-community/windows_exporter) exposes a wide variety of hardware- and kernel-related metrics.
+
+In this guide, you will:
+
+* Start up a Windows Exporter on Windows host.
+* Start up a Prometheus instance on `localhost` that's configured to scrape metrics from the running Windows Exporter
+
+NOTE: While the Prometheus Windows Exporter is for *windows systems, there is the [Node exporter](https://github.com/prometheus/node_exporter) for Linux that serves an analogous purpose.
+
+## Installing and running the Windows Exporter
+
+The Prometheus Windows Exporter is availabe in various formats [via github](https://github.com/prometheus-community/windows_exporter/releases). Once you've downloaded it from Github releases, then run it:
+
+```bash
+wget https://github.com/prometheus-community/windows_exporter/releases/download/v0.15.0/windows_exporter-0.15.0-386.msi
+./windows_exporter-0.15.0-386.msi
+```
+
+You should get prompted so accept all questions so Windows Exporter is now running and exposing metrics on port 9182:
+
+
+## Windows Exporter metrics
+
+Once the Windows Exporter is installed and running, you can verify that metrics are being exported by cURLing the `/metrics` endpoint:
+
+```bash
+curl http://localhost:9182/metrics
+```
+
+You should see output like this:
+
+```
+# HELP go_gc_duration_seconds A summary of the GC invocation durations.
+# TYPE go_gc_duration_seconds summary
+go_gc_duration_seconds{quantile="0"} 0
+go_gc_duration_seconds{quantile="0.25"} 0
+# etc.
+```
+
+Success! The Windows Exporter is now exposing metrics that Prometheus can scrape, including a wide variety of system metrics further down in the output (prefixed with `wmi_`). To view those metrics (along with help and type information):
+
+```bash
+curl http://localhost:9182/metrics | grep "^wmi_"
+```
+
+## Configuring your Prometheus instances
+
+Your Prometheus instance needs to be properly configured in order to access Windows Exporter metrics. The following [`prometheus.yml`](../../prometheus/latest/configuration/configuration/) example configuration file will tell the Prometheus instance to scrape, and how frequently, from the Windows Exporter via (say) `192.168.1.4:9182`:
+
+<a id="config"></a>
+
+```yaml
+global:
+  scrape_interval: 15s
+
+scrape_configs:
+- job_name: windows clients
+  static_configs:
+  - targets: ['192.168.1.4:9182']   # windowshost ipaddress goes here
+```
+
+Continue with [next steps here](node-exporter/#configuring-your-prometheus-instances).

--- a/content/docs/instrumenting/writing_exporters.md
+++ b/content/docs/instrumenting/writing_exporters.md
@@ -41,7 +41,7 @@ mix of these, with complexity varying by module. For example, the
 specifically for that collector, so we may as well get the metrics
 right. For the `meminfo` collector the results vary across kernel
 versions so we end up doing just enough of a transform to create valid
-metrics.
+metrics. See also [windows_exporter](https://github.com/prometheus-community/windows_exporter).
 
 ## Configuration
 

--- a/content/docs/introduction/faq.md
+++ b/content/docs/introduction/faq.md
@@ -152,7 +152,7 @@ the [exposition formats](/docs/instrumenting/exposition_formats/).
 Yes, the [Node Exporter](https://github.com/prometheus/node_exporter) exposes
 an extensive set of machine-level metrics on Linux and other Unix systems such
 as CPU usage, memory, disk utilization, filesystem fullness, and network
-bandwidth.
+bandwidth. See also [Windows Exporter](https://github.com/prometheus-community/windows_exporter).
 
 ### Can I monitor network devices?
 


### PR DESCRIPTION
This PR introduces a Windows Exporter Guide (mirrors node_exporter) so people can find the procedure here.  

Otherwise, you need to search the internet for Blog on Windows and prometheus .