### PR TITLE
Add trailing slash to location of proxy config in basic auth guide

### DIFF
--- a/content/docs/guides/basic-auth.md
+++ b/content/docs/guides/basic-auth.md
@@ -36,7 +36,7 @@ http {
     server {
         listen 12321;
 
-        location /prometheus {
+        location /prometheus/ {
             auth_basic           "Prometheus";
             auth_basic_user_file /etc/nginx/.htpasswd;
 


### PR DESCRIPTION
This PR adds a trailing slash to the location parameter of the proxy configuration in the [basic auth guide](https://prometheus.io/docs/guides/basic-auth/). The configuration, that is currently documented in this guide, is wrong and thus the proxy doesn't actually work. The configuration is correct in other places, such as the [TLS encryption guide](https://prometheus.io/docs/guides/tls-encryption/#nginx-configuration).
Maintainer: @brian-brazil 