### PR TITLE
Support download list for community repositories

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,6 +1,6 @@
-NANOC      = bundle exec nanoc
-GUARD      = bundle exec guard
-DOWNLOADS := prometheus alertmanager blackbox_exporter consul_exporter graphite_exporter haproxy_exporter memcached_exporter mysqld_exporter node_exporter pushgateway statsd_exporter
+NANOC     ?= bundle exec nanoc
+GUARD     ?= bundle exec guard
+DOWNLOADS := $(shell cat downloads.cfg)
 
 build: clean downloads compile
 
@@ -18,13 +18,13 @@ downloads: $(DOWNLOADS:%=downloads/%/repo.json) $(DOWNLOADS:%=downloads/%/releas
 
 downloads/%/repo.json:
 	@mkdir -p $(dir $@)
-	@echo "curl -sf -H 'Accept: application/vnd.github.v3+json' <GITHUB_AUTHENTICATION> https://api.github.com/repos/prometheus/$* > $@"
-	@curl -sf -H 'Accept: application/vnd.github.v3+json' $(GITHUB_AUTHENTICATION) https://api.github.com/repos/prometheus/$* > $@
+	@echo "curl -sf -H 'Accept: application/vnd.github.v3+json' <GITHUB_AUTHENTICATION> https://api.github.com/repos/$* > $@"
+	@curl -sf -H 'Accept: application/vnd.github.v3+json' $(GITHUB_AUTHENTICATION) https://api.github.com/repos/$* > $@
 
 downloads/%/releases.json:
 	@mkdir -p $(dir $@)
-	@echo "curl -sf -H 'Accept: application/vnd.github.v3+json' <GITHUB_AUTHENTICATION> https://api.github.com/repos/prometheus/$*/releases > $@"
-	@curl -sf -H 'Accept: application/vnd.github.v3+json' $(GITHUB_AUTHENTICATION) https://api.github.com/repos/prometheus/$*/releases > $@
+	@echo "curl -sf -H 'Accept: application/vnd.github.v3+json' <GITHUB_AUTHENTICATION> https://api.github.com/repos/$*/releases > $@"
+	@curl -sf -H 'Accept: application/vnd.github.v3+json' $(GITHUB_AUTHENTICATION) https://api.github.com/repos/$*/releases > $@
 
 guard:
 	$(GUARD)

--- a/downloads.cfg
+++ b/downloads.cfg
@@ -1,0 +1,12 @@
+prometheus/alertmanager
+prometheus/blackbox_exporter
+prometheus/consul_exporter
+prometheus/graphite_exporter
+prometheus/haproxy_exporter
+prometheus/memcached_exporter
+prometheus/mysqld_exporter
+prometheus/node_exporter
+prometheus/prometheus
+prometheus/pushgateway
+prometheus/statsd_exporter
+prometheus-community/windows_exporter

--- a/specs/download_spec.rb
+++ b/specs/download_spec.rb
@@ -14,10 +14,17 @@ describe Downloads::Binary do
     })
   end
 
+  let(:windows) do
+    Downloads::Binary.new({
+      'name' => 'windows_exporter-0.15.0-386.msi',
+    })
+  end
+
   describe '#os' do
     it 'extracts the operating system name' do
       expect(asset.os).to eql('freebsd')
       expect(beta.os).to eql('darwin')
+      expect(windows.os).to eql('windows')
     end
   end
 
@@ -25,6 +32,7 @@ describe Downloads::Binary do
     it 'extracts the architecture' do
       expect(asset.arch).to eql('armv5')
       expect(beta.arch).to eql('amd64')
+      expect(windows.arch).to eql('386')
     end
   end
 end
@@ -54,11 +62,16 @@ describe Downloads::Release do
         { 'name' => 'prometheus-1.2.0.linux-amd64.tar.gz' },
         { 'name' => 'prometheus-1.2.0.windows-amd64.tar.gz' },
         { 'name' => 'prometheus-1.2.0.windows-amd64.zip' },
+        { 'name' => 'prometheus-1.2.0.windows-amd64.msi' },
       ]})
     end
 
     it 'prefers .zip format over .tar.gz' do
-      expect(release.binaries.map(&:name)).to eql(['prometheus-1.2.0.linux-amd64.tar.gz', 'prometheus-1.2.0.windows-amd64.zip'])
+      expect(release.binaries.map(&:name)).to eql([
+        'prometheus-1.2.0.linux-amd64.tar.gz',
+        'prometheus-1.2.0.windows-amd64.msi',
+        'prometheus-1.2.0.windows-amd64.zip',
+      ])
     end
   end
 end


### PR DESCRIPTION
In order to display windows_exporter releases and the available
artifacts on the downloads page, this change adds the option to fetch
release information for all organizations on Github. As the
windows_exporter artifact naming doesn't follow the established format
unfortunately, a few additional special format options were added.

Signed-off-by: Tobias Schmidt <tobidt@gmail.com>

---

Solves #1799. FYI @carlpett @roidelapluie 