### PR TITLE
Add Vector to tools that export Prometheus metrics

### DIFF
--- a/content/docs/instrumenting/exporters.md
+++ b/content/docs/instrumenting/exporters.md
@@ -287,6 +287,7 @@ separate exporters are needed:
    * [SkyDNS](https://github.com/skynetservices/skydns) (**direct**)
    * [Telegraf](https://github.com/influxdata/telegraf/tree/master/plugins/outputs/prometheus_client)
    * [Traefik](https://github.com/containous/traefik)
+   * [Vector](https://vector.dev)
    * [VerneMQ](https://github.com/vernemq/vernemq)
    * [Weave Flux](https://github.com/weaveworks/flux)
    * [Xandikos](https://www.xandikos.org/) (**direct**)


### PR DESCRIPTION
Vector has both a Prometheus source and sink and a `remote_write` source and sink.

@brian-brazil

Signed-off-by: James Turnbull <james@lovedthanlost.net>