### PR TITLE
Update shard memory usage after increase of default values

### DIFF
--- a/content/docs/practices/remote_write.md
+++ b/content/docs/practices/remote_write.md
@@ -44,9 +44,9 @@ In addition to the series cache, each shard and its queue increases memory
 usage. Shard memory is proportional to the `number of shards * (capacity +
 max_samples_per_send)`. When tuning, consider reducing `max_shards` alongside
 increases to `capacity` and `max_samples_per_send` to avoid inadvertantly
-running out of memory. The default values for `capacity` and
-`max_samples_per_send` will constrain shard memory usage to less than 100 kB per
-shard.
+running out of memory. The default values for `capacity: 2500` and
+`max_samples_per_send: 500` will constrain shard memory usage to less than 500
+kB per shard.
 
 ## Parameters
 


### PR DESCRIPTION
https://github.com/prometheus/prometheus/pull/5267 increased the defaults by 5 times for both `max_samples_per_send` and `capacity`.

I think this value needs to be increased, too. Not too sure how realistic is 5 times and how to get to the `< 100kb` in the first place.

@csmarchbanks @bboreham 