### PR TITLE
Add IoTDB exporter link

### DIFF
--- a/content/docs/instrumenting/exporters.md
+++ b/content/docs/instrumenting/exporters.md
@@ -57,6 +57,7 @@ wide variety of JVM-based applications, for example [Kafka](http://kafka.apache.
    * [SQL exporter](https://github.com/free/sql_exporter)
    * [Tarantool metric library](https://github.com/tarantool/metrics)
    * [Twemproxy](https://github.com/stuartnelson3/twemproxy_exporter)
+   * [IoTDB exporter](https://github.com/fagnercarvalho/prometheus-iotdb-exporter)
 
 ### Hardware related
    * [apcupsd exporter](https://github.com/mdlayher/apcupsd_exporter)


### PR DESCRIPTION
I created an exporter for the IoTDB database and I wanted to add to the exporters page.

Let me know what you think.

Thanks!