### PR TITLE
Update cadvisor repository

### DIFF
--- a/content/docs/guides/cadvisor.md
+++ b/content/docs/guides/cadvisor.md
@@ -43,7 +43,7 @@ services:
     depends_on:
     - cadvisor
   cadvisor:
-    image: gcr.io/google-containers/cadvisor:latest
+    image: gcr.io/cadvisor/cadvisor:latest
     container_name: cadvisor
     ports:
     - 8080:8080


### PR DESCRIPTION
cAdvisor registry has moved from GCP project `google_containers` to `cadvisor`, ref: https://github.com/google/cadvisor/pull/2590