### PR TITLE
Fixed two typos in Sensu description on comparison page

### DIFF
--- a/content/docs/introduction/comparison.md
+++ b/content/docs/introduction/comparison.md
@@ -258,7 +258,7 @@ Sensu [Events](https://docs.sensu.io/sensu-go/latest/observability-pipeline/obse
 
 ### Storage
 
-Sensu stores current and recent event status information and real-time inventory data in an embedded database (etcd) or an external RDBMS (Postgres). 
+Sensu stores current and recent event status information and real-time inventory data in an embedded database (etcd) or an external RDBMS (PostgreSQL). 
 
 ### Architecture
 
@@ -271,7 +271,7 @@ Sensu and Prometheus have a few capabilities in common, but they take very diffe
 Where Sensu is better: 
 
 - If you're collecting and processing hybrid observability data (including metrics _and/or_ events)
-- If you're consolidating mulitple monitoring tools and need support for metrics _and_ Nagios-style plugins or check scripts
+- If you're consolidating multiple monitoring tools and need support for metrics _and_ Nagios-style plugins or check scripts
 - More powerful event-processing platform
 
 Where Prometheus is better: 


### PR DESCRIPTION
Fixing "multiple" and "PostgreSQL" typos in Sensu description on comparison page. 

Signed-off-by: bananabele <otherships@gmail.com>
