### PR TITLE
Added Intel Optane Persistent Memory Controller Exporter

### DIFF
--- a/content/docs/instrumenting/exporters.md
+++ b/content/docs/instrumenting/exporters.md
@@ -81,6 +81,7 @@ wide variety of JVM-based applications, for example [Kafka](http://kafka.apache.
    * [Waveplus Radon Sensor Exporter](https://github.com/jeremybz/waveplus_exporter)
    * [Weathergoose Climate Monitor Exporter](https://github.com/branttaylor/watchdog-prometheus-exporter)
    * [Windows exporter](https://github.com/prometheus-community/windows_exporter)
+   * [Intel® Optane™ Persistent Memory Controller Exporter](https://github.com/intel/ipmctl-exporter)
 
 ### Issue trackers and continuous integration
 


### PR DESCRIPTION
We have created internal exporter to monitor [Intel Optane Persistent Memories](https://github.com/intel/ipmctl-exporter) behavior at scale, and some time ago decide to open source it. It relays on library provided together with  https://github.com/intel/ipmctl. I will appreciate your feedback. Thanks in advance.