### PR TITLE
Cleanup practices docs a bit.

### DIFF
--- a/content/docs/instrumenting/writing_clientlibs.md
+++ b/content/docs/instrumenting/writing_clientlibs.md
@@ -246,7 +246,7 @@ aspects](/docs/practices/instrumentation/#use-labels) of Prometheus, but
 Accordingly client libraries must be very careful in how labels are offered to
 users.
 
-Client libraries MUST NOT under any circumstances allow users to have different
+Client libraries MUST NOT allow users to have different
 label names for the same metric for Gauge/Counter/Summary/Histogram or any
 other Collector offered by the library.
 

--- a/content/docs/practices/instrumentation.md
+++ b/content/docs/practices/instrumentation.md
@@ -259,10 +259,9 @@ benchmarks are the best way to determine the impact of any given change.
 ### Avoid missing metrics
 
 Time series that are not present until something happens are difficult
-to deal with, as the usual simple operations are no longer sufficient
-to correctly handle them. To avoid this, export `0` (or `NaN`, if `0`
-would be misleading) for any time series you know may exist in
-advance.
+to deal with, as the usual simple operations are no longer sufficient to
+correctly handle them. To avoid this, export a default value such as `0` for
+any time series you know may exist in advance.
 
 Most Prometheus client libraries (including Go, Java, and Python) will
 automatically export a `0` for you for metrics with no labels.


### PR DESCRIPTION
NaN does not make sense as a missing value, and given
that enum/info metrics are a thing now 0 isn't always the
default value so hedge a little.

Tone down the language around mismatch label names, this
hasn't been an issue in a long time.

Signed-off-by: Brian Brazil <brian.brazil@robustperception.io>