### PR TITLE
The solace exporter gots a new home

### DIFF
--- a/content/docs/instrumenting/exporters.md
+++ b/content/docs/instrumenting/exporters.md
@@ -104,7 +104,7 @@ wide variety of JVM-based applications, for example [Kafka](http://kafka.apache.
    * [RabbitMQ exporter](https://github.com/kbudde/rabbitmq_exporter)
    * [RabbitMQ Management Plugin exporter](https://github.com/deadtrickster/prometheus_rabbitmq_exporter)
    * [RocketMQ exporter](https://github.com/apache/rocketmq-exporter)
-   * [Solace exporter](https://github.com/dabgmx/solace_exporter)
+   * [Solace exporter](https://github.com/solacecommunity/solace-prometheus-exporter)
 
 ### Storage
    * [Ceph exporter](https://github.com/digitalocean/ceph_exporter)


### PR DESCRIPTION
We moved the solace exporter from a private githup repo to the official solace community software repo