### PR TITLE
Change maintainer from @brian-brazil to @RichiH

### DIFF
--- a/MAINTAINERS.md
+++ b/MAINTAINERS.md
@@ -13,5 +13,5 @@ following maintainers with their focus areas:
 
 * Julius Volz <julius.volz@gmail.com> @juliusv: Web design, static site
   generator.
-* Brian Brazil <brian.brazil@robustperception.io> @brian-brazil: Everything
+* Richard Hartmann <richih@prometheus.io> @RichiH: Everything
   else.


### PR DESCRIPTION
Yesterday at the dev-summit, the Prometheus team has proposed @RichiH as the new maintainer for “everything else” in this repo after @brian-brazil's retirement from the project.

This change will only be merged after an announcement on the prometheus-developers mailing list and is subject to lazy consensus.

Thank you, @brian-brazil, for the incredible amount of work done in this repository and for the project in general.