### PR TITLE
Add Prom-migrator to list of integrations

### DIFF
--- a/content/docs/operating/integrations.md
+++ b/content/docs/operating/integrations.md
@@ -63,6 +63,8 @@ data volumes.
   * [VictoriaMetrics](https://github.com/VictoriaMetrics/VictoriaMetrics): write
   * [Wavefront](https://github.com/wavefrontHQ/prometheus-storage-adapter): write
 
+[Prom-migrator](https://github.com/timescale/promscale/tree/master/cmd/prom-migrator) is a tool for migrating data between remote storage systems.
+
 ## Alertmanager Webhook Receiver
 
 For notification mechanisms not natively supported by the Alertmanager, the


### PR DESCRIPTION
Prom-migrator allows users to migrate existing data between various long-term storage systems. In particular it can migrate data from any system that support remote_read to any system that supports remote_write. I think it would be useful to users and this seems like a natural place to mention this.