### PR TITLE
Load all used weights and styles of the Open Sans font

### DIFF
--- a/layouts/header.html
+++ b/layouts/header.html
@@ -57,7 +57,7 @@
 
     <!-- Custom Fonts -->
     <link href="/assets/font-awesome-4.7.0/css/font-awesome.min.css" rel="stylesheet" type="text/css">
-    <link href='https://fonts.googleapis.com/css?family=Open+Sans' rel='stylesheet' type='text/css'>
+    <link href='https://fonts.googleapis.com/css?family=Open+Sans:400,400italic,700' rel='stylesheet' type='text/css'>
     <link href='https://fonts.googleapis.com/css?family=Lato:300,300italic,400' rel='stylesheet' type='text/css'>
   </head>
 


### PR DESCRIPTION
Currently the stylesheets are using regular (400) and bold (700) weights of the Open Sans font, plus regular italic, but only the regular-weight normal style is being loaded from Google Fonts. In addition to missing intended emphasis, this can cause "bold" text to appear blurry as the browser attempts to make do without an actual bold font, as seen here in "Between two scalars":

![blurry](https://user-images.githubusercontent.com/1084619/109884473-05679d00-7c4b-11eb-8273-39b9ca18a26f.png)

This PR adds the `400italic` and `700` variants to the Google Fonts request.

Before:

![before](https://user-images.githubusercontent.com/1084619/109884152-7fe3ed00-7c4a-11eb-8ce8-59f7d083550f.png)

After:

![after](https://user-images.githubusercontent.com/1084619/109884629-4f508300-7c4b-11eb-84b0-bbf28362b9e2.png)

Note that the "after" is pretty dramatically different and won't necessarily be what everyone wants, but it is allowing the styles to come through as they're currently written. If it's then desirable to adjust from there, the styles themselves should be revised.