### PR TITLE
Add GSuite to onboarding

### DIFF
--- a/content/governance.md
+++ b/content/governance.md
@@ -169,6 +169,7 @@ The new member is
 * added to the [GitHub organization][gh] as _Owner_.
 * optionally added to the community, junkyard, and related organizations and repositories.
 * added to the [team mailing list][team].
+* added to the prometheus.io GSuite account with a user name of the new member's choice. (Most importantly, this comes with a `<chosen-username>@prometheus.io` email address and provides access to the team's GDrive and calendar. The new member should add the latter to their own calendar list.)
 * announced to CNCF.
 * given access to the shared password storage.
 


### PR DESCRIPTION
_This is an informational change and therefore doesn't go through the
formal procedure of a governance change._

This also mentions the team's calendar. Note that those calendars are
notoriously difficult to find, so whoever onboards the new team member
should give them a direct link to it. (But I didn't want to get more
technical than I did in this PR.)

Signed-off-by: beorn7 <beorn@grafana.com>