### PR TITLE
Fix a broken link to the ceph website

### DIFF
--- a/content/docs/instrumenting/exporters.md
+++ b/content/docs/instrumenting/exporters.md
@@ -257,7 +257,7 @@ separate exporters are needed:
    * [Ballerina](https://ballerina.io/)
    * [BFE](https://github.com/baidu/bfe)
    * [Caddy](https://caddyserver.com/docs/metrics) (**direct**)
-   * [Ceph](http://docs.ceph.com/docs/master/mgr/prometheus/)
+   * [Ceph](https://docs.ceph.com/en/latest/mgr/prometheus/)
    * [CockroachDB](https://www.cockroachlabs.com/docs/stable/monitoring-and-alerting.html#prometheus-endpoint)
    * [Collectd](https://collectd.org/wiki/index.php/Plugin:Write_Prometheus)
    * [Concourse](https://concourse-ci.org/)


### PR DESCRIPTION
Hello, this is a tiny fix of a broken link to Ceph official documentation. Thank you.

**How to test the change**

1. Go to https://deploy-preview-1901--prometheus-docs.netlify.app/docs/instrumenting/exporters/#software-exposing-prometheus-metrics
2. Click Ceph
3. Ensure the link is not broken and the page is proper.