### PR TITLE
Add discuss.prometheus.io to community

### DIFF
--- a/content/community.html
+++ b/content/community.html
@@ -27,6 +27,10 @@ title: Community
       </ul>
     </p>
     <p>
+      <strong>Discourse forum:</strong>
+        Web-based discussion forum at <a href="https://discuss.prometheus.io/">discuss.prometheus.io</a> hosted by <a href="https://www.discourse.org/">Discourse</a>.
+    </p>
+    <p>
       <strong>Calendar for public events:</strong>
       We have a public calendar for events, which you can use to join us.
       <p>


### PR DESCRIPTION
Add the new Discourse forum to the community page.

Signed-off-by: Ben Kochie <superq@gmail.com>