### PR TITLE
Added GitLab to webhook integrations list

### DIFF
--- a/content/docs/operating/integrations.md
+++ b/content/docs/operating/integrations.md
@@ -79,6 +79,7 @@ For notification mechanisms not natively supported by the Alertmanager, the
   * [Canopsis](https://git.canopsis.net/canopsis-connectors/connector-prometheus2canopsis)
   * [DingTalk](https://github.com/timonwong/prometheus-webhook-dingtalk)
   * [Discord](https://github.com/benjojo/alertmanager-discord)
+  * [GitLab](https://docs.gitlab.com/ee/operations/metrics/alerts.html#external-prometheus-instances)
   * [Gotify](https://github.com/DRuggeri/alertmanager_gotify_bridge)
   * [GELF](https://github.com/b-com-software-basis/alertmanager2gelf)
   * [Icinga2](https://github.com/vshn/signalilo)


### PR DESCRIPTION
@simonpasquier please, check and merge.

The PR adds GitLab as a webhook integration. Prometheus Alerts can be surfaced into GitLab and a corresponding alert is created within GitLab as per the linked docs.