### PR TITLE
Add Unit Modifier Section to Naming Best Practices

### DIFF
--- a/content/docs/practices/naming.md
+++ b/content/docs/practices/naming.md
@@ -42,7 +42,10 @@ A metric name...
  * request duration
  * bytes of data transfer
  * instantaneous resource usage as a percentage
-
+* ...should add the unit modifier, like `failed`, before the metric name if needed.
+ * <code>foobar\_<b>failed</b>\_requests_total</code>
+ * <code>prometheus\_target\_<b>failed</b>\_scrape\_pool\_total<code> (`target` being the Prometheus module the metric originates from).
+ 
 As a rule of thumb, either the `sum()` or the `avg()` over all dimensions of a
 given metric should be meaningful (though not necessarily useful). If it is not
 meaningful, split the data up into multiple metrics. For example, having the

--- a/content/docs/practices/naming.md
+++ b/content/docs/practices/naming.md
@@ -44,7 +44,7 @@ A metric name...
  * instantaneous resource usage as a percentage
 * ...should add the unit modifier, like `failed`, before the metric name if needed.
  * <code>foobar\_<b>failed</b>\_requests_total</code>
- * <code>prometheus\_target\_<b>failed</b>\_scrape\_pool\_total<code> (`target` being the Prometheus module the metric originates from).
+ * <code>prometheus\_target\_<b>failed</b>\_scrape\_pool\_total</code> (`target` being the Prometheus module the metric originates from).
  
 As a rule of thumb, either the `sum()` or the `avg()` over all dimensions of a
 given metric should be meaningful (though not necessarily useful). If it is not


### PR DESCRIPTION
This PR adds a section to the naming best practices for unit modifiers. Related to prometheus/prometheus#8754.

Fixes prometheus/prometheus#8718