### PR TITLE
Added link to iLert webhook receiver documentation

### DIFF
--- a/content/docs/operating/integrations.md
+++ b/content/docs/operating/integrations.md
@@ -83,6 +83,7 @@ For notification mechanisms not natively supported by the Alertmanager, the
   * [Gotify](https://github.com/DRuggeri/alertmanager_gotify_bridge)
   * [GELF](https://github.com/b-com-software-basis/alertmanager2gelf)
   * [Icinga2](https://github.com/vshn/signalilo)
+  * [iLert](https://docs.ilert.com/integrations/prometheus)
   * [IRC Bot](https://github.com/multimfi/bot)
   * [JIRAlert](https://github.com/free/jiralert)
   * [Matrix](https://github.com/matrix-org/go-neb)


### PR DESCRIPTION
Hey @simonpasquier and @w0rm,

I've added a link to iLert webhook receiver docs. iLert is a SaaS for alerting and on-call management that integrates with the Alertmanager.

Thanks,
Birol