### PR TITLE
Add InfiniBand exporter

### DIFF
--- a/content/docs/instrumenting/exporters.md
+++ b/content/docs/instrumenting/exporters.md
@@ -68,6 +68,7 @@ wide variety of JVM-based applications, for example [Kafka](http://kafka.apache.
    * [Fortigate exporter](https://github.com/bluecmd/fortigate_exporter)
    * [IBM Z HMC exporter](https://github.com/zhmcclient/zhmc-prometheus-exporter)
    * [IoT Edison exporter](https://github.com/roman-vynar/edison_exporter)
+   * [InfiniBand exporter](https://github.com/treydock/infiniband_exporter)
    * [IPMI exporter](https://github.com/soundcloud/ipmi_exporter)
    * [knxd exporter](https://github.com/RichiH/knxd_exporter)
    * [Modbus exporter](https://github.com/RichiH/modbus_exporter)


### PR DESCRIPTION
The main purpose is to collect InfiniBand counters from switches that may not support SNMP.  Our IB fabric switches are all "dumb" so they can only expose counters via `perfquery` or other methods that talk to them over IB protocols.  The opt-in collection of HCA metrics is to collect metrics from HCAs in the event a site doesn't want to install node_exporter on their IB hosts.

@RichiH