### PR TITLE
Add bungeecord prometheus exporter

### DIFF
--- a/content/docs/instrumenting/exporters.md
+++ b/content/docs/instrumenting/exporters.md
@@ -193,6 +193,7 @@ wide variety of JVM-based applications, for example [Kafka](http://kafka.apache.
    * [BIND query exporter](https://github.com/DRuggeri/bind_query_exporter)
    * [Bitcoind exporter](https://github.com/LePetitBloc/bitcoind-exporter)
    * [Blackbox exporter](https://github.com/prometheus/blackbox_exporter) (**official**)
+   * [Bungeecord exporter](https://github.com/weihao/bungeecord-prometheus-exporter)
    * [BOSH exporter](https://github.com/cloudfoundry-community/bosh_exporter)
    * [cAdvisor](https://github.com/google/cadvisor)
    * [Cachet exporter](https://github.com/ContaAzul/cachet_exporter)


### PR DESCRIPTION
Example output
```
# HELP bungeecord_online_players the number of online players in BungeeCord
# TYPE bungeecord_online_players gauge
bungeecord_online_players{server="smp",} 0.0
# HELP bungeecord_player_disconnects_total the number of player disconnects in Velocity
# TYPE bungeecord_player_disconnects_total counter
bungeecord_player_disconnects_total 0.0
# HELP bungeecord_server_list_pings_total the number of server list pings in Velocity
# TYPE bungeecord_server_list_pings_total counter
bungeecord_server_list_pings_total 0.0
# HELP bungeecord_player_connects_total the number of player logins in Velocity
# TYPE bungeecord_player_connects_total counter
bungeecord_player_connects_total 0.0
# HELP bungeecord_jvm_gc_collection_seconds Time spent in a given JVM garbage collector in seconds.
# TYPE bungeecord_jvm_gc_collection_seconds summary
bungeecord_jvm_gc_collection_seconds_count{gc="G1 Young Generation",} 8.0
bungeecord_jvm_gc_collection_seconds_sum{gc="G1 Young Generation",} 0.122
bungeecord_jvm_gc_collection_seconds_count{gc="G1 Old Generation",} 0.0
bungeecord_jvm_gc_collection_seconds_sum{gc="G1 Old Generation",} 0.0
# HELP bungeecord_jvm_memory JVM memory usage
# TYPE bungeecord_jvm_memory gauge
bungeecord_jvm_memory{type="max",} 2.68435456E8
bungeecord_jvm_memory{type="used",} 4.6992464E7
bungeecord_jvm_memory{type="free",} 2.21442992E8
bungeecord_jvm_memory{type="allocated",} 2.68435456E8
# HELP bungeecord_managed_servers the number of managed servers in Velocity
# TYPE bungeecord_managed_servers gauge
bungeecord_managed_servers 1.0
# HELP bungeecord_jvm_threads_current Current thread count of a JVM
# TYPE bungeecord_jvm_threads_current gauge
bungeecord_jvm_threads_current 35.0
# HELP bungeecord_jvm_threads_daemon Daemon thread count of a JVM
# TYPE bungeecord_jvm_threads_daemon gauge
bungeecord_jvm_threads_daemon 22.0
# HELP bungeecord_jvm_threads_peak Peak thread count of a JVM
# TYPE bungeecord_jvm_threads_peak gauge
bungeecord_jvm_threads_peak 37.0
# HELP bungeecord_jvm_threads_started_total Started thread count of a JVM
# TYPE bungeecord_jvm_threads_started_total counter
bungeecord_jvm_threads_started_total 40.0
# HELP bungeecord_jvm_threads_deadlocked Cycles of JVM-threads that are in deadlock waiting to acquire object monitors or ownable synchronizers
# TYPE bungeecord_jvm_threads_deadlocked gauge
bungeecord_jvm_threads_deadlocked 0.0
# HELP bungeecord_jvm_threads_deadlocked_monitor Cycles of JVM-threads that are in deadlock waiting to acquire object monitors
# TYPE bungeecord_jvm_threads_deadlocked_monitor gauge
bungeecord_jvm_threads_deadlocked_monitor 0.0
# HELP bungeecord_jvm_threads_state Current count of threads by state
# TYPE bungeecord_jvm_threads_state gauge
bungeecord_jvm_threads_state{state="RUNNABLE",} 9.0
bungeecord_jvm_threads_state{state="TIMED_WAITING",} 19.0
bungeecord_jvm_threads_state{state="BLOCKED",} 0.0
bungeecord_jvm_threads_state{state="WAITING",} 7.0
bungeecord_jvm_threads_state{state="TERMINATED",} 0.0
bungeecord_jvm_threads_state{state="NEW",} 0.0
# HELP bungeecord_player_connects_created the number of player logins in Velocity
# TYPE bungeecord_player_connects_created gauge
bungeecord_player_connects_created 1.637479024887E9
# HELP bungeecord_player_disconnects_created the number of player disconnects in Velocity
# TYPE bungeecord_player_disconnects_created gauge
bungeecord_player_disconnects_created 1.637479024896E9
# HELP bungeecord_server_list_pings_created the number of server list pings in Velocity
# TYPE bungeecord_server_list_pings_created gauge
bungeecord_server_list_pings_created 1.6374790249E9
```