### PR TITLE
instrumenting/clientlibs: add process_threads

### DIFF
--- a/content/docs/instrumenting/writing_clientlibs.md
+++ b/content/docs/instrumenting/writing_clientlibs.md
@@ -345,6 +345,7 @@ all times in unixtime/seconds.
 | `process_resident_memory_bytes`    | Resident memory size in bytes.                         | bytes            |
 | `process_heap_bytes`               | Process heap size in bytes.                            | bytes            |
 | `process_start_time_seconds`       | Start time of the process since unix epoch in seconds. | seconds          |
+| `process_threads`                  | Number of OS threads in the process.             | threads          |
 
 ### Runtime metrics
 


### PR DESCRIPTION
This reserves a new well-known `process_threads` gauge for client
libraries, in order to expose OS threads count on all instrumented
processes.
As this metrics is language/runtime independent, it makes sense to
be under the `process_` namespace so that libraries can align on
the name (if/when they start exposing this).

For reference, this is coming from an enhancement request on the Rust library: https://github.com/tikv/rust-prometheus/pull/401.