### PR TITLE
Add redirect for "Disabled Features" page

### DIFF
--- a/content/_redirects
+++ b/content/_redirects
@@ -23,6 +23,9 @@
 # Redirect for HTTP SD docs, which briefly lived in the wrong category / repo.
 /docs/instrumenting/http_sd/ /docs/prometheus/latest/http_sd/
 
+# Redirect for "disabled_features", which is now called "feature_flags".
+/docs/prometheus/latest/disabled_features/ /docs/prometheus/latest/feature_flags/
+
 # Redirects for sections.
 # TODO(ts): Auto-generate from menu.
 /docs/                      /docs/introduction/overview/                302!


### PR DESCRIPTION
<!--
    Please sign CNCF's Developer Certificate of Origin and sign-off your commits by adding the -s / --sign-off flag to `git commit`

    More information on both of those can be found at https://github.com/apps/dco

    If you are proposing a new integration, exporter, or client library, please include representative sample output.
 -->

In https://github.com/prometheus/prometheus/pull/9073 the "Disabled Features" page was renamed to "Feature Flags", but there still may be links pointing to the old page.
