### PR TITLE
Extend wording about the dev-summit

### DIFF
--- a/content/community.html
+++ b/content/community.html
@@ -112,7 +112,17 @@ title: Community
 
     <h1>Developer summits</h1>
     <p>
-    We strive to be as open and public as possible. Technical discussions happen on the development list, our meetings are public. As of 2021, we carry a public, <a href="https://docs.google.com/document/d/11LC3wJcVk00l8w5P3oLQ-m3Y37iom6INAMEu2ZAGIIE">rolling meeting notes document</a>. You can find our historic meeting notes below.
+      Developer summits are public meetings to discuss more involved
+      development topics. They currently happen monthly as an online
+      meeting. (For details, check out the public events calendar
+      linked in the Community section above.) The Prometheus team
+      curates the agenda based on recent discussions via other
+      channels. To propose a topic, please send a mail to the
+      <a href="https://groups.google.com/forum/#!forum/prometheus-developers">development mailing list</a>
+      at least 24 hours prior to the summit.
+    </p>
+    <p>
+      As of 2021, we carry a public, <a href="https://docs.google.com/document/d/11LC3wJcVk00l8w5P3oLQ-m3Y37iom6INAMEu2ZAGIIE">rolling meeting notes document</a>. You can find our historic meeting notes below.
     </p>
     <p>
       <a href="https://docs.google.com/document/d/1DaHFao0saZ3MDt9yuuxLaCQg8WGadO8s44i3cxSARcM">2017 developer summit notes</a>


### PR DESCRIPTION
This now includes a way to propose topics, as discussed recently.

