### PR TITLE
Add MongoDB Atlas exporter to the list of exporters

### DIFF
--- a/content/docs/instrumenting/exporters.md
+++ b/content/docs/instrumenting/exporters.md
@@ -41,6 +41,7 @@ wide variety of JVM-based applications, for example [Kafka](http://kafka.apache.
    * [IoTDB exporter](https://github.com/fagnercarvalho/prometheus-iotdb-exporter)
    * [KDB+ exporter](https://github.com/KxSystems/prometheus-kdb-exporter)
    * [Memcached exporter](https://github.com/prometheus/memcached_exporter) (**official**)
+   * [MongoDB Atlas exporter](https://github.com/commercetools/mongodbatlas_exporter)
    * [MongoDB exporter](https://github.com/dcu/mongodb_exporter)
    * [MongoDB query exporter](https://github.com/raffis/mongodb-query-exporter)
    * [MSSQL server exporter](https://github.com/awaragi/prometheus-mssql-exporter)


### PR DESCRIPTION
Signed-off-by: Tetiana Kravchenko <tetiana.kravchenko@commercetools.com>

@RichiH, please take a look

Output:
```
# HELP mongodbatlas_disks_stats_measurement_transformation_failures_total Number of errors during transformation of scraped MongoDB Atlas measurements into Prometheus metrics.
# TYPE mongodbatlas_disks_stats_measurement_transformation_failures_total counter
mongodbatlas_disks_stats_measurement_transformation_failures_total 60
# HELP mongodbatlas_disks_stats_scrape_failures_total Number of unsuccessful measurement scrapes from MongoDB Atlas API.
# TYPE mongodbatlas_disks_stats_scrape_failures_total counter
mongodbatlas_disks_stats_scrape_failures_total 0
# HELP mongodbatlas_disks_stats_scrapes_total Current total MongoDB Atlas scrapes.
# TYPE mongodbatlas_disks_stats_scrapes_total counter
mongodbatlas_disks_stats_scrapes_total 1
# HELP mongodbatlas_disks_stats_up Was the last communication with MongoDB Atlas API successful.
# TYPE mongodbatlas_disks_stats_up gauge
mongodbatlas_disks_stats_up 1
# HELP mongodbatlas_exporter_build_info A metric with a constant '1' value labeled by version, revision, branch, and goversion from which mongodbatlas_exporter was built.
# TYPE mongodbatlas_exporter_build_info gauge
mongodbatlas_exporter_build_info{branch="",goversion="go1.16.7",revision="",version=""} 1
# HELP mongodbatlas_processes_stats_connections Original measurements.name: 'CONNECTIONS'. Please see MongoDB Atlas documentation for details about the measurement
# TYPE mongodbatlas_processes_stats_connections gauge
mongodbatlas_processes_stats_connections{project_id="PROJECT_ID",rs_name="atlas-salt-shard-0",user_alias="atlas-test-project-clus-shard-00-00.salt.mongodb.net:27017"} 0
mongodbatlas_processes_stats_connections{project_id="PROJECT_ID",rs_name="atlas-salt-shard-0",user_alias="atlas-test-project-clus-shard-00-01.salt.mongodb.net:27017"} 0
mongodbatlas_processes_stats_connections{project_id="PROJECT_ID",rs_name="atlas-salt-shard-0",user_alias="atlas-test-project-clus-shard-00-02.salt.mongodb.net:27017"} 0
# HELP mongodbatlas_processes_stats_info Process info metric
# TYPE mongodbatlas_processes_stats_info gauge
mongodbatlas_processes_stats_info{project_id="PROJECT_ID",rs_name="atlas-salt-shard-0",type="REPLICA_PRIMARY",user_alias="atlas-test-project-clus-shard-00-02.salt.mongodb.net:27017",version="4.4.8"} 1
mongodbatlas_processes_stats_info{project_id="PROJECT_ID",rs_name="atlas-salt-shard-0",type="REPLICA_SECONDARY",user_alias="atlas-test-project-clus-shard-00-00.salt.mongodb.net:27017",version="4.4.8"} 1
mongodbatlas_processes_stats_info{project_id="PROJECT_ID",rs_name="atlas-salt-shard-0",type="REPLICA_SECONDARY",user_alias="atlas-test-project-clus-shard-00-01.salt.mongodb.net:27017",version="4.4.8"} 1
# HELP mongodbatlas_processes_stats_logical_size_bytes Original measurements.name: 'LOGICAL_SIZE'. Please see MongoDB Atlas documentation for details about the measurement
# TYPE mongodbatlas_processes_stats_logical_size_bytes gauge
mongodbatlas_processes_stats_logical_size_bytes{project_id="PROJECT_ID",rs_name="atlas-salt-shard-0",user_alias="atlas-test-project-clus-shard-00-00.salt.mongodb.net:27017"} 0
mongodbatlas_processes_stats_logical_size_bytes{project_id="PROJECT_ID",rs_name="atlas-salt-shard-0",user_alias="atlas-test-project-clus-shard-00-01.salt.mongodb.net:27017"} 0
mongodbatlas_processes_stats_logical_size_bytes{project_id="PROJECT_ID",rs_name="atlas-salt-shard-0",user_alias="atlas-test-project-clus-shard-00-02.salt.mongodb.net:27017"} 0
# HELP mongodbatlas_processes_stats_measurement_transformation_failures_total Number of errors during transformation of scraped MongoDB Atlas measurements into Prometheus metrics.
# TYPE mongodbatlas_processes_stats_measurement_transformation_failures_total counter
mongodbatlas_processes_stats_measurement_transformation_failures_total 72
# HELP mongodbatlas_processes_stats_network_bytes_in_bytes_ratio Original measurements.name: 'NETWORK_BYTES_IN'. Please see MongoDB Atlas documentation for details about the measurement
# TYPE mongodbatlas_processes_stats_network_bytes_in_bytes_ratio gauge
mongodbatlas_processes_stats_network_bytes_in_bytes_ratio{project_id="PROJECT_ID",rs_name="atlas-salt-shard-0",user_alias="atlas-test-project-clus-shard-00-00.salt.mongodb.net:27017"} 0
mongodbatlas_processes_stats_network_bytes_in_bytes_ratio{project_id="PROJECT_ID",rs_name="atlas-salt-shard-0",user_alias="atlas-test-project-clus-shard-00-01.salt.mongodb.net:27017"} 0
mongodbatlas_processes_stats_network_bytes_in_bytes_ratio{project_id="PROJECT_ID",rs_name="atlas-salt-shard-0",user_alias="atlas-test-project-clus-shard-00-02.salt.mongodb.net:27017"} 0
# HELP mongodbatlas_processes_stats_network_bytes_out_bytes_ratio Original measurements.name: 'NETWORK_BYTES_OUT'. Please see MongoDB Atlas documentation for details about the measurement
# TYPE mongodbatlas_processes_stats_network_bytes_out_bytes_ratio gauge
mongodbatlas_processes_stats_network_bytes_out_bytes_ratio{project_id="PROJECT_ID",rs_name="atlas-salt-shard-0",user_alias="atlas-test-project-clus-shard-00-00.salt.mongodb.net:27017"} 0
mongodbatlas_processes_stats_network_bytes_out_bytes_ratio{project_id="PROJECT_ID",rs_name="atlas-salt-shard-0",user_alias="atlas-test-project-clus-shard-00-01.salt.mongodb.net:27017"} 0
mongodbatlas_processes_stats_network_bytes_out_bytes_ratio{project_id="PROJECT_ID",rs_name="atlas-salt-shard-0",user_alias="atlas-test-project-clus-shard-00-02.salt.mongodb.net:27017"} 0
# HELP mongodbatlas_processes_stats_network_num_requests_ratio Original measurements.name: 'NETWORK_NUM_REQUESTS'. Please see MongoDB Atlas documentation for details about the measurement
# TYPE mongodbatlas_processes_stats_network_num_requests_ratio gauge
mongodbatlas_processes_stats_network_num_requests_ratio{project_id="PROJECT_ID",rs_name="atlas-salt-shard-0",user_alias="atlas-test-project-clus-shard-00-00.salt.mongodb.net:27017"} 0
mongodbatlas_processes_stats_network_num_requests_ratio{project_id="PROJECT_ID",rs_name="atlas-salt-shard-0",user_alias="atlas-test-project-clus-shard-00-01.salt.mongodb.net:27017"} 0
mongodbatlas_processes_stats_network_num_requests_ratio{project_id="PROJECT_ID",rs_name="atlas-salt-shard-0",user_alias="atlas-test-project-clus-shard-00-02.salt.mongodb.net:27017"} 0
# HELP mongodbatlas_processes_stats_opcounter_cmd_ratio Original measurements.name: 'OPCOUNTER_CMD'. Please see MongoDB Atlas documentation for details about the measurement
# TYPE mongodbatlas_processes_stats_opcounter_cmd_ratio gauge
mongodbatlas_processes_stats_opcounter_cmd_ratio{project_id="PROJECT_ID",rs_name="atlas-salt-shard-0",user_alias="atlas-test-project-clus-shard-00-00.salt.mongodb.net:27017"} 0
mongodbatlas_processes_stats_opcounter_cmd_ratio{project_id="PROJECT_ID",rs_name="atlas-salt-shard-0",user_alias="atlas-test-project-clus-shard-00-01.salt.mongodb.net:27017"} 0
mongodbatlas_processes_stats_opcounter_cmd_ratio{project_id="PROJECT_ID",rs_name="atlas-salt-shard-0",user_alias="atlas-test-project-clus-shard-00-02.salt.mongodb.net:27017"} 0
# HELP mongodbatlas_processes_stats_opcounter_delete_ratio Original measurements.name: 'OPCOUNTER_DELETE'. Please see MongoDB Atlas documentation for details about the measurement
# TYPE mongodbatlas_processes_stats_opcounter_delete_ratio gauge
mongodbatlas_processes_stats_opcounter_delete_ratio{project_id="PROJECT_ID",rs_name="atlas-salt-shard-0",user_alias="atlas-test-project-clus-shard-00-00.salt.mongodb.net:27017"} 0
mongodbatlas_processes_stats_opcounter_delete_ratio{project_id="PROJECT_ID",rs_name="atlas-salt-shard-0",user_alias="atlas-test-project-clus-shard-00-01.salt.mongodb.net:27017"} 0
mongodbatlas_processes_stats_opcounter_delete_ratio{project_id="PROJECT_ID",rs_name="atlas-salt-shard-0",user_alias="atlas-test-project-clus-shard-00-02.salt.mongodb.net:27017"} 0
# HELP mongodbatlas_processes_stats_opcounter_getmore_ratio Original measurements.name: 'OPCOUNTER_GETMORE'. Please see MongoDB Atlas documentation for details about the measurement
# TYPE mongodbatlas_processes_stats_opcounter_getmore_ratio gauge
mongodbatlas_processes_stats_opcounter_getmore_ratio{project_id="PROJECT_ID",rs_name="atlas-salt-shard-0",user_alias="atlas-test-project-clus-shard-00-00.salt.mongodb.net:27017"} 0
mongodbatlas_processes_stats_opcounter_getmore_ratio{project_id="PROJECT_ID",rs_name="atlas-salt-shard-0",user_alias="atlas-test-project-clus-shard-00-01.salt.mongodb.net:27017"} 0
mongodbatlas_processes_stats_opcounter_getmore_ratio{project_id="PROJECT_ID",rs_name="atlas-salt-shard-0",user_alias="atlas-test-project-clus-shard-00-02.salt.mongodb.net:27017"} 0
# HELP mongodbatlas_processes_stats_opcounter_insert_ratio Original measurements.name: 'OPCOUNTER_INSERT'. Please see MongoDB Atlas documentation for details about the measurement
# TYPE mongodbatlas_processes_stats_opcounter_insert_ratio gauge
mongodbatlas_processes_stats_opcounter_insert_ratio{project_id="PROJECT_ID",rs_name="atlas-salt-shard-0",user_alias="atlas-test-project-clus-shard-00-00.salt.mongodb.net:27017"} 0
mongodbatlas_processes_stats_opcounter_insert_ratio{project_id="PROJECT_ID",rs_name="atlas-salt-shard-0",user_alias="atlas-test-project-clus-shard-00-01.salt.mongodb.net:27017"} 0
mongodbatlas_processes_stats_opcounter_insert_ratio{project_id="PROJECT_ID",rs_name="atlas-salt-shard-0",user_alias="atlas-test-project-clus-shard-00-02.salt.mongodb.net:27017"} 0
# HELP mongodbatlas_processes_stats_opcounter_query_ratio Original measurements.name: 'OPCOUNTER_QUERY'. Please see MongoDB Atlas documentation for details about the measurement
# TYPE mongodbatlas_processes_stats_opcounter_query_ratio gauge
mongodbatlas_processes_stats_opcounter_query_ratio{project_id="PROJECT_ID",rs_name="atlas-salt-shard-0",user_alias="atlas-test-project-clus-shard-00-00.salt.mongodb.net:27017"} 0
mongodbatlas_processes_stats_opcounter_query_ratio{project_id="PROJECT_ID",rs_name="atlas-salt-shard-0",user_alias="atlas-test-project-clus-shard-00-01.salt.mongodb.net:27017"} 0
mongodbatlas_processes_stats_opcounter_query_ratio{project_id="PROJECT_ID",rs_name="atlas-salt-shard-0",user_alias="atlas-test-project-clus-shard-00-02.salt.mongodb.net:27017"} 0
# HELP mongodbatlas_processes_stats_opcounter_update_ratio Original measurements.name: 'OPCOUNTER_UPDATE'. Please see MongoDB Atlas documentation for details about the measurement
# TYPE mongodbatlas_processes_stats_opcounter_update_ratio gauge
mongodbatlas_processes_stats_opcounter_update_ratio{project_id="PROJECT_ID",rs_name="atlas-salt-shard-0",user_alias="atlas-test-project-clus-shard-00-00.salt.mongodb.net:27017"} 0
mongodbatlas_processes_stats_opcounter_update_ratio{project_id="PROJECT_ID",rs_name="atlas-salt-shard-0",user_alias="atlas-test-project-clus-shard-00-01.salt.mongodb.net:27017"} 0
mongodbatlas_processes_stats_opcounter_update_ratio{project_id="PROJECT_ID",rs_name="atlas-salt-shard-0",user_alias="atlas-test-project-clus-shard-00-02.salt.mongodb.net:27017"} 0
# HELP mongodbatlas_processes_stats_scrape_failures_total Number of unsuccessful measurement scrapes from MongoDB Atlas API.
# TYPE mongodbatlas_processes_stats_scrape_failures_total counter
mongodbatlas_processes_stats_scrape_failures_total 0
# HELP mongodbatlas_processes_stats_scrapes_total Current total MongoDB Atlas scrapes.
# TYPE mongodbatlas_processes_stats_scrapes_total counter
mongodbatlas_processes_stats_scrapes_total 1
# HELP mongodbatlas_processes_stats_up Was the last communication with MongoDB Atlas API successful.
# TYPE mongodbatlas_processes_stats_up gauge
mongodbatlas_processes_stats_up 1
```
