### PR TITLE
Change Kuma Link to go to proper repository

### DIFF
--- a/content/docs/operating/integrations.md
+++ b/content/docs/operating/integrations.md
@@ -22,7 +22,7 @@ these categories.
 For service discovery mechanisms not natively supported by Prometheus,
 [file-based service discovery](/docs/operating/configuration/#%3Cfile_sd_config%3E) provides an interface for integrating.
 
- * [Kuma](https://github.com/Kong/kuma/tree/master/app/kuma-prometheus-sd)
+ * [Kuma](https://github.com/kumahq/kuma/tree/master/app/kuma-prometheus-sd)
  * [Lightsail](https://github.com/n888/prometheus-lightsail-sd)
  * [Netbox](https://github.com/FlxPeters/netbox-prometheus-sd)
  * [Packet](https://github.com/packethost/prometheus-packet-sd)


### PR DESCRIPTION
The kuma link goes to an empty repository under the wrong organization, this fix changes the link to the proper repository.

<!--
    Please sign CNCF's Developer Certificate of Origin and sign-off your commits by adding the -s / --sign-off flag to `git commit`

    More information on both of those can be found at https://github.com/apps/dco

    If you are proposing a new integration, exporter, or client library, please include representative sample output.
 -->
