### PR TITLE
Add link to docs about `up` metric

### DIFF
--- a/content/docs/instrumenting/writing_exporters.md
+++ b/content/docs/instrumenting/writing_exporters.md
@@ -497,7 +497,7 @@ that has a value of 0 or 1 depending on whether the scrape worked.
 The latter is better where there’s still some useful metrics you can get
 even with a failed scrape, such as the HAProxy exporter providing
 process stats. The former is a tad easier for users to deal with, as
-[`up` works in the usual way](https://prometheus.io/docs/concepts/jobs_instances/#automatically-generated-labels-and-time-series), although you can’t distinguish between the
+[`up` works in the usual way](/docs/concepts/jobs_instances/#automatically-generated-labels-and-time-series), although you can’t distinguish between the
 exporter being down and the application being down.
 
 ### Landing page

--- a/content/docs/instrumenting/writing_exporters.md
+++ b/content/docs/instrumenting/writing_exporters.md
@@ -497,7 +497,7 @@ that has a value of 0 or 1 depending on whether the scrape worked.
 The latter is better where there’s still some useful metrics you can get
 even with a failed scrape, such as the HAProxy exporter providing
 process stats. The former is a tad easier for users to deal with, as
-`up` works in the usual way, although you can’t distinguish between the
+[`up` works in the usual way](https://prometheus.io/docs/concepts/jobs_instances/#automatically-generated-labels-and-time-series), although you can’t distinguish between the
 exporter being down and the application being down.
 
 ### Landing page


### PR DESCRIPTION
I read this section a few times, but was still confused about how I'd alert or graph uptime if the app or exporter doesn't export a 1/0 metric. The missing piece of information is that there's a built-in `up` metric. This PR adds a link so the next guy or gal doesn't get confused like I did. :-)

<!--
    Please sign CNCF's Developer Certificate of Origin and sign-off your commits by adding the -s / --sign-off flag to `git commit`

    More information on both of those can be found at https://github.com/apps/dco

    If you are proposing a new integration, exporter, or client library, please include representative sample output.
 -->
