### PR TITLE
Add Getting started tutorials.

### DIFF
--- a/content/docs/tutorials/getting_started.md
+++ b/content/docs/tutorials/getting_started.md
@@ -1,0 +1,106 @@
+---
+title: Getting Started with Prometheus
+sort_rank: 1
+---
+
+# What is Prometheus ?
+
+Prometheus is a system monitoring and alerting system. It was opensourced by SoundCloud in 2012 and is the second project both to join and to to graduate within Cloud Native Computing Foundation after Kubernetes. Prometheus stores all metrics data as time series, i.e metrics information is stored along with the timestamp at which it was recorded, optional key-value pairs called as labels can also be stored along with metrics.
+# What are metrics and why is it important?
+
+Metrics in layperson terms is a standard for measurement. What we want to measure depends from application to application. For a web server it can be request times, for a database it can be CPU usage or number of active connections etc.
+
+Metrics play an important role in understanding why your application is working in a certain way. If you run a web application and someone comes up to you and says that the application is slow. You will need some information to find out what is happening with your application. For example the application can become slow when the number of requests are high. If you have the request count metric you can spot the reason and increase the number of servers to handle the heavy load. Whenever you are defining the metrics for your application you must put on your detective hat and ask this question **what all information will be important for me to debug if any issue occurs in my application?**
+
+# Basic Architecture of Prometheus
+
+The basic components of a Prometheus setup are:
+
+- Prometheus Server (The server which scrapes and stores the metrics data).
+- Targets to be scraped, for example: Instrumented Application that exposes its metrics or an Exporter that exposes metrics of another application.
+- Alertmanager to raise alerts based on preset rules.
+
+(Note: Apart from this Prometheus has push_gateway which is not covered here).
+
+[![Architecture](/assets/tutorial/architecture.png)](/assets/tutorial/architecture.png)
+
+Let's consider web server as an example application and we want to extract a certain metric like the number of API calls processed by the web server. So we add certain instrumentation code using the Prometheus client library and expose the metrics information. Now that our web server exposes its metrics we can configure Prometheus to scrape it. Now Prometheus is configured to fetch the metrics from the web server which is listening on xyz IP address port 7500 at a specific time interval, say, every minute.
+
+At 11:00:00 when I make the server public for consumption, the application calculates the request count and exposes it, Prometheus simultaneously scrapes the count metric and stores the value as 0.
+
+By 11:01:00 one request is processed. The instrumentation logic in the server increments the count to 1. When Prometheus scrapes the metric the value of count is 1 now.
+
+By 11:02:00 two more requests are processed and the request count is 1+2 = 3 now. Similarly metrics are scraped and stored.
+
+The user can control the frequency at which metrics are scraped by Prometheus.
+
+| Time Stamp | Request Count (metric) |
+| ---------- | ---------------------- |
+| 11:00:00   | 0                      |
+| 11:01:00   | 1                      |
+| 11:02:00   | 3                      |
+
+(Note: This table is just a representation for understanding purposes. Prometheus doesn’t store the values in this exact format)
+
+Prometheus also has an API which allows to query metrics which have been stored by scraping. This API is used to query the metrics, create dashboards/charts on it etc. PromQL is used to query these metrics.
+
+A simple Line chart created on the Request Count metric will look like this
+
+[![Graph](/assets/tutorial/sample_graph.png)](/assets/tutorial/sample_graph.png)
+
+One can scrape multiple useful metrics to understand what is happening in the application and create multiple charts on them. Group the charts into a dashboard and use it to get an overview of the application.
+
+# Show me how it is done.
+
+Let’s get our hands dirty and setup Prometheus. Prometheus is written using [Go](https://golang.org/) and all you need is the binary compiled for your operating system. Download the binary corresponding to your operating system from [here](https://prometheus.io/download/) and add the binary to your path.
+
+Prometheus exposes its own metrics which can be consumed by itself or another Prometheus server.
+
+Now that we have Prometheus installed, the next step is to run it. All that we need is just the binary and a configuration file. Prometheus uses yaml files for configuration.
+
+
+```yaml
+global:
+  scrape_interval: 15s
+
+scrape_configs:
+  - job_name: prometheus
+    static_configs:
+      - targets: ["localhost:9090"]
+```
+
+In the above configuration file we have mentioned the scrape_interval i.e how frequently we want Prometheus to scrape the metrics. We have added scrape_configs which has a name and target to scrape the metrics from. Prometheus by default listens on port 9090. So add it to targets.
+
+> prometheus --config.file=prometheus.yml
+
+<iframe width="560" height="315" src="https://www.youtube.com/embed/ioa0eISf1Q0" frameborder="0" allowfullscreen></iframe>
+
+Now we have Prometheus up and running and scraping its own metrics every 15s. Prometheus has standard exporters available to export metrics. Next we will run a node exporter which is an exporter for machine metrics and scrape the same using Prometheus. Download node metrics exporter from [here](https://prometheus.io/download/#node_exporter)
+
+
+Run the node exporter in a terminal.
+
+<code>./node_exporter</code>
+
+[![Node exporter](/assets/tutorial/node_exporter.png)](/assets/tutorial/node_exporter.png)
+
+
+Next Add node exporter to the list of scrape_configs
+
+```yaml
+global:
+  scrape_interval: 15s
+
+scrape_configs:
+  - job_name: prometheus
+    static_configs:
+      - targets: ["localhost:9090"]
+  - job_name: node_exporter
+    static_configs:
+      - targets: ["localhost:9100"]
+```
+
+<iframe width="560" height="315" src="https://www.youtube.com/embed/hM5bp53C7Y8" frameborder="0" allowfullscreen></iframe>
+
+In this tutorial we discussed what are metrics and why they are important, basic architecture of Prometheus and how to
+run Prometheus.

--- a/content/docs/tutorials/index.md
+++ b/content/docs/tutorials/index.md
@@ -1,0 +1,5 @@
+---
+title: Tutorials
+sort_rank: 10
+nav_icon: book
+---

--- a/content/docs/tutorials/instrumenting_http_server_in_go.md
+++ b/content/docs/tutorials/instrumenting_http_server_in_go.md
@@ -1,0 +1,145 @@
+---
+title: Instrumenting HTTP server written in Go  
+sort_rank: 3
+---
+
+In this tutorial we will create a simple Go HTTP server and instrumentation it by adding a counter
+metric to keep count of the total number of requests processed by the server.
+
+Here we have a simple HTTP server with `/ping` endpoint which returns `pong` as response.
+
+```go
+package main
+
+import (
+   "fmt"
+   "net/http"
+)
+
+func ping(w http.ResponseWriter, req *http.Request){
+   fmt.Fprintf(w,"pong")
+}
+
+func main() {
+   http.HandleFunc("/ping",ping)
+
+   http.ListenAndServe(":8090", nil)
+}
+```
+
+Compile and run the server
+
+```bash
+go build server.go
+./server.go
+```
+
+Now open `http://localhost:8090/ping` in your browser and you must see `pong`.
+
+[![Server](/assets/tutorial/server.png)](/assets/tutorial/server.png)
+
+
+Now lets add a metric to the server which will instrument the number of requests made to the ping endpoint,the counter metric type is suitable for this as we know the request count doesn’t go down and only increases.
+
+Create a Prometheus counter
+
+```go
+var pingCounter = prometheus.NewCounter(
+   prometheus.CounterOpts{
+       Name: "ping_request_count",
+       Help: "No of request handled by Ping handler",
+   },
+)
+```
+
+Next lets update the ping Handler to increase the count of the counter using `pingCounter.Inc()`.
+
+```go
+func ping(w http.ResponseWriter, req *http.Request) {
+   pingCounter.Inc()
+   fmt.Fprintf(w, "pong")
+}
+```
+
+Then register the counter to the Default Register and expose the metrics.
+
+```go
+func main() {
+   prometheus.MustRegister(pingCounter)
+   http.HandleFunc("/ping", ping)
+   http.Handle("/metrics", promhttp.Handler())
+   http.ListenAndServe(":8090", nil)
+}
+```
+
+The `prometheus.MustRegister` function registers the pingCounter to the default Register.
+To expose the metrics the Go Prometheus client library provides the promhttp package.
+`promhttp.Handler()` provides a `http.Handler` which exposes the metrics registered in the Default Register.
+
+The sample code depends on the  
+
+```go
+package main
+
+import (
+   "fmt"
+   "net/http"
+
+   "github.com/prometheus/client_golang/prometheus"
+   "github.com/prometheus/client_golang/prometheus/promhttp"
+)
+
+var pingCounter = prometheus.NewCounter(
+   prometheus.CounterOpts{
+       Name: "ping_request_count",
+       Help: "No of request handled by Ping handler",
+   },
+)
+
+func ping(w http.ResponseWriter, req *http.Request) {
+   pingCounter.Inc()
+   fmt.Fprintf(w, "pong")
+}
+
+func main() {
+   prometheus.MustRegister(pingCounter)
+
+   http.HandleFunc("/ping", ping)
+   http.Handle("/metrics", promhttp.Handler())
+   http.ListenAndServe(":8090", nil)
+}
+```
+
+Run the example 
+```bash
+go mod init prom_example
+go mod tidy
+go run main.go
+```
+
+Now hit the localhost:8090/ping endpoint a couple of times and sending a request to localhost:8090 will provide the metrics.
+
+[![Ping Metric](/assets/tutorial/ping_metric.png)](/assets/tutorial/ping_metric.png)
+
+Here the ping_request_count shows that `/ping` endpoint was called 3 times.
+
+The DefaultRegister comes with a collector for go runtime metrics and that is why we see other metrics like go_threads, go_goroutines etc.
+
+We have built our first metric exporter. Let’s update our Prometheus config to scrape the metrics from our server.
+
+```yaml
+global:
+  scrape_interval: 15s
+
+scrape_configs:
+  - job_name: prometheus
+    static_configs:
+      - targets: ["localhost:9090"]
+  - job_name: simple_server
+    static_configs:
+      - targets: ["localhost:8090"]
+```
+
+<code>prometheus --config.file=prometheus.yml</code>
+
+<iframe width="560" height="315" src="https://www.youtube.com/embed/yQIWgZoiW0o" frameborder="0" allowfullscreen></iframe>

--- a/content/docs/tutorials/understanding_metric_types.md
+++ b/content/docs/tutorials/understanding_metric_types.md
@@ -1,0 +1,100 @@
+---
+title: Understanding metric types  
+sort_rank: 2
+---
+
+# Types of metrics.
+
+Prometheus supports four types of metrics, they are
+    - Counter
+    - Gauge
+    - Histogram
+    - Summary 
+
+## Counter
+
+Counter is a metric value which can only increase or reset i.e the value cannot reduce than the previous value. It can be used for metrics like number of requests, no of errors etc.
+
+Type the below query in the query bar and click execute.
+
+<code>go\_gc\_duration\_seconds\_count</code>
+
+
+[![Counter](/assets/tutorial/counter_example.png)](/assets/tutorial/counter_example.png)
+
+The rate() function in PromQL takes the history of metrics over a time frame and calculates how fast value is increasing per second. Rate is applicable on counter values only.
+
+<code> rate(go\_gc\_duration\_seconds\_count[5m])</code>
+[![Rate Counter](/assets/tutorial/rate_example.png)](/assets/tutorial/rate_example.png)
+
+## Gauge
+
+Gauge is a number which can either go up or down. It can be used for metrics like number of pods in a cluster, number of events in an queue etc.
+
+<code> go\_memstats\_heap\_alloc\_bytes</code>
+[![Gauge](/assets/tutorial/gauge_example.png)](/assets/tutorial/gauge_example.png)
+
+PromQL functions like `max_over_time`, `min_over_time` and `avg_over_time` can be used on gauge metrics
+
+## Histogram
+
+Histogram is a more complex metric type when compared to the previous two. Histogram can be used for any calculated value which is counted based on bucket values. Bucket boundaries can be configured by the developer. A common example would the time it takes to reply to a request, called latency.
+
+Example: Lets assume we want to observe the time taken to process API requests. Instead of storing the request time for each request, histograms allow us to store them in buckets. We define buckets for time taken, for example `lower or equal 0.3` , `le 0.5`, `le 0.7`, `le 1`, and `le 1.2`. So these are our buckets and once the time taken for a request is calculated it is added to the count of all the buckets whose bucket boundaries are higher than the measured value.
+
+Lets say Request 1 for endpoint “/ping” takes 0.25 s. The count values for the buckets will be.
+
+> /ping
+
+| Bucket    | Count |
+| --------- | ----- |
+| 0 - 0.3   | 1     |
+| 0 - 0.5   | 1     |
+| 0 - 0.7   | 1     |
+| 0 - 1     | 1     |
+| 0 - 1.2   | 1     |
+| 0 - +Inf  | 1     |
+
+Note: +Inf bucket is added by default.
+
+(Since histogram is a cumulative frequency 1 is added to all the buckets which are greater than the value)
+
+Request 2 for endpoint “/ping” takes 0.4s The count values for the buckets will be this.
+
+> /ping
+
+| Bucket    | Count |
+| --------- | ----- |
+| 0 - 0.3   | 1     |
+| 0 - 0.5   | 2     |
+| 0 - 0.7   | 2     |
+| 0 - 1     | 2     |
+| 0 - 1.2   | 2     |
+| 0 - +Inf  | 2     |
+
+Since 0.4 is below 0.5, all buckets up to that boundary increase their counts.
+
+Let's explore a histogram metric from the Prometheus UI and apply few functions.
+
+<code>prometheus\_http\_request\_duration\_seconds\_bucket{handler="/graph"}</code>
+
+[![Histogram](/assets/tutorial/histogram_example.png)](/assets/tutorial/histogram_example.png)
+
+`histogram_quantile()` function can be used to calculate calculate quantiles from histogram
+
+<code>histogram\_quantile(0.9,prometheus\_http\_request\_duration\_seconds\_bucket{handler="/graph"})</code>
+
+[![Histogram Quantile](/assets/tutorial/histogram_quantile_example.png)](/assets/tutorial/histogram_quantile_example.png)
+
+The graph shows that the 90th percentile is 0.09, To find the histogram_quantile over last 5m you can use the rate() and time frame
+
+<code>histogram_quantile(0.9, rate(prometheus\_http\_request\_duration\_seconds\_bucket{handler="/graph"}[5m]))</code>
+
+[![Histogram Quantile Rate](/assets/tutorial/histogram_rate_example.png)](/assets/tutorial/histogram_rate_example.png)
+
+
+## Summary
+
+Summaries also measure events and are an alternative to histograms. They are cheaper, but lose more data. They are calculated on the application level hence aggregation of metrics from multiple instances of the same process is not possible. They are used when the buckets of a metric is not known beforehand, but it is highly recommended to use histograms over summaries whenever possible.
+
+In this tutorial we covered the types of metrics in detail and few PromQL operations like rate, histogram_quantile etc.


### PR DESCRIPTION
I have created a new menu option `tutorial` and split the work from [Prometheus-Basics](https://github.com/yolossn/Prometheus-Basics) into three parts. I am skeptical if these should be added to the `Guides`, would like to get others inputs on this.

<!--
    Please sign CNCF's Developer Certificate of Origin and sign-off your commits by adding the -s / --sign-off flag to `git commit`

    More information on both of those can be found at https://github.com/apps/dco

    If you are proposing a new integration, exporter, or client library, please include representative sample output.
 -->
