### PR TITLE
adding scaphandre to softwares exposing prometheus metrics

### DIFF
--- a/content/docs/instrumenting/exporters.md
+++ b/content/docs/instrumenting/exporters.md
@@ -293,6 +293,7 @@ separate exporters are needed:
    * [Quobyte](https://www.quobyte.com/) (**direct**)
    * [RabbitMQ](https://rabbitmq.com/prometheus.html)
    * [RobustIRC](http://robustirc.net/)
+   * [Scaphandre](https://github.com/hubblo-org/scaphandre)
    * [ScyllaDB](http://github.com/scylladb/scylla)
    * [Skipper](https://github.com/zalando/skipper)
    * [SkyDNS](https://github.com/skynetservices/skydns) (**direct**)


### PR DESCRIPTION
[scaphandre](https://github.com/hubblo-org/scaphandre) is a monitoring agent dedicated to power consumption metrics

Signed-off-by: Benoit Petit <bpetit@nce.re>

<!--
    Please sign CNCF's Developer Certificate of Origin and sign-off your commits by adding the -s / --sign-off flag to `git commit`

    More information on both of those can be found at https://github.com/apps/dco

    If you are proposing a new integration, exporter, or client library, please include representative sample output.
 -->
