### PR TITLE
Add pgBackrest exporter to the list.

### DIFF
--- a/content/docs/instrumenting/exporters.md
+++ b/content/docs/instrumenting/exporters.md
@@ -48,6 +48,7 @@ wide variety of JVM-based applications, for example [Kafka](http://kafka.apache.
    * [MySQL server exporter](https://github.com/prometheus/mysqld_exporter) (**official**)
    * [OpenTSDB Exporter](https://github.com/cloudflare/opentsdb_exporter)
    * [Oracle DB Exporter](https://github.com/iamseth/oracledb_exporter)
+   * [pgBackRest exporter](https://github.com/woblerr/pgbackrest_exporter)
    * [PgBouncer exporter](https://github.com/prometheus-community/pgbouncer_exporter)
    * [PostgreSQL exporter](https://github.com/prometheus-community/postgres_exporter)
    * [Presto exporter](https://github.com/yahoojapan/presto_exporter)


### PR DESCRIPTION
Signed-off-by: Anton Kurochkin <antkurochkin@gmail.com>

<!--
    Please sign CNCF's Developer Certificate of Origin and sign-off your commits by adding the -s / --sign-off flag to `git commit`

    More information on both of those can be found at https://github.com/apps/dco

    If you are proposing a new integration, exporter, or client library, please include representative sample output.
 -->

Output:
```
# HELP pgbackrest_backup_delta_bytes Amount of data in the database to actually backup.
# TYPE pgbackrest_backup_delta_bytes gauge
pgbackrest_backup_delta_bytes{backup_name="20211002-135040F",backup_type="full",database_id="1",repo_key="1",stanza="demo"} 2.4316343e+07
pgbackrest_backup_delta_bytes{backup_name="20211002-135040F_20211002-135044D",backup_type="diff",database_id="1",repo_key="1",stanza="demo"} 8457
pgbackrest_backup_delta_bytes{backup_name="20211002-135040F_20211002-135046I",backup_type="incr",database_id="1",repo_key="1",stanza="demo"} 8457
# HELP pgbackrest_backup_diff_since_last_completion_seconds Seconds since the last completed full or differential backup.
# TYPE pgbackrest_backup_diff_since_last_completion_seconds gauge
pgbackrest_backup_diff_since_last_completion_seconds{stanza="demo"} 31
# HELP pgbackrest_backup_duration_seconds Backup duration.
# TYPE pgbackrest_backup_duration_seconds gauge
pgbackrest_backup_duration_seconds{backup_name="20211002-135040F",backup_type="full",database_id="1",repo_key="1",stanza="demo",start_time="2021-10-02 13:50:40",stop_time="2021-10-02 13:50:43"} 3
pgbackrest_backup_duration_seconds{backup_name="20211002-135040F_20211002-135044D",backup_type="diff",database_id="1",repo_key="1",stanza="demo",start_time="2021-10-02 13:50:44",stop_time="2021-10-02 13:50:45"} 1
pgbackrest_backup_duration_seconds{backup_name="20211002-135040F_20211002-135046I",backup_type="incr",database_id="1",repo_key="1",stanza="demo",start_time="2021-10-02 13:50:46",stop_time="2021-10-02 13:50:47"} 1
# HELP pgbackrest_backup_full_since_last_completion_seconds Seconds since the last completed full backup.
# TYPE pgbackrest_backup_full_since_last_completion_seconds gauge
pgbackrest_backup_full_since_last_completion_seconds{stanza="demo"} 33
# HELP pgbackrest_backup_incr_since_last_completion_seconds Seconds since the last completed full, differential or incremental backup.
# TYPE pgbackrest_backup_incr_since_last_completion_seconds gauge
pgbackrest_backup_incr_since_last_completion_seconds{stanza="demo"} 29
# HELP pgbackrest_backup_info Backup info.
# TYPE pgbackrest_backup_info gauge
pgbackrest_backup_info{backrest_ver="2.35",backup_name="20211002-135040F",backup_type="full",database_id="1",pg_version="13",prior="",repo_key="1",stanza="demo",wal_start="000000010000000000000002",wal_stop="000000010000000000000002"} 1
pgbackrest_backup_info{backrest_ver="2.35",backup_name="20211002-135040F_20211002-135044D",backup_type="diff",database_id="1",pg_version="13",prior="20211002-135040F",repo_key="1",stanza="demo",wal_start="000000010000000000000003",wal_stop="000000010000000000000003"} 1
pgbackrest_backup_info{backrest_ver="2.35",backup_name="20211002-135040F_20211002-135046I",backup_type="incr",database_id="1",pg_version="13",prior="20211002-135040F_20211002-135044D",repo_key="1",stanza="demo",wal_start="000000010000000000000004",wal_stop="000000010000000000000004"} 1
# HELP pgbackrest_backup_repo_delta_bytes Compressed files size in backup.
# TYPE pgbackrest_backup_repo_delta_bytes gauge
pgbackrest_backup_repo_delta_bytes{backup_name="20211002-135040F",backup_type="full",database_id="1",repo_key="1",stanza="demo"} 2.969517e+06
pgbackrest_backup_repo_delta_bytes{backup_name="20211002-135040F_20211002-135044D",backup_type="diff",database_id="1",repo_key="1",stanza="demo"} 428
pgbackrest_backup_repo_delta_bytes{backup_name="20211002-135040F_20211002-135046I",backup_type="incr",database_id="1",repo_key="1",stanza="demo"} 427
# HELP pgbackrest_backup_repo_size_bytes Full compressed files size to restore the database from backup.
# TYPE pgbackrest_backup_repo_size_bytes gauge
pgbackrest_backup_repo_size_bytes{backup_name="20211002-135040F",backup_type="full",database_id="1",repo_key="1",stanza="demo"} 2.969517e+06
pgbackrest_backup_repo_size_bytes{backup_name="20211002-135040F_20211002-135044D",backup_type="diff",database_id="1",repo_key="1",stanza="demo"} 2.969518e+06
pgbackrest_backup_repo_size_bytes{backup_name="20211002-135040F_20211002-135046I",backup_type="incr",database_id="1",repo_key="1",stanza="demo"} 2.969517e+06
# HELP pgbackrest_backup_size_bytes Full uncompressed size of the database.
# TYPE pgbackrest_backup_size_bytes gauge
pgbackrest_backup_size_bytes{backup_name="20211002-135040F",backup_type="full",database_id="1",repo_key="1",stanza="demo"} 2.4316343e+07
pgbackrest_backup_size_bytes{backup_name="20211002-135040F_20211002-135044D",backup_type="diff",database_id="1",repo_key="1",stanza="demo"} 2.4316343e+07
pgbackrest_backup_size_bytes{backup_name="20211002-135040F_20211002-135046I",backup_type="incr",database_id="1",repo_key="1",stanza="demo"} 2.4316343e+07
# HELP pgbackrest_exporter_info Information about pgBackRest exporter.
# TYPE pgbackrest_exporter_info gauge
pgbackrest_exporter_info{version="0.8.1"} 1
# HELP pgbackrest_repo_status Current repository status.
# TYPE pgbackrest_repo_status gauge
pgbackrest_repo_status{cipher="none",repo_key="1",stanza="demo"} 0
# HELP pgbackrest_stanza_status Current stanza status.
# TYPE pgbackrest_stanza_status gauge
pgbackrest_stanza_status{stanza="demo"} 0
# HELP pgbackrest_wal_archive_status Current WAL archive status.
# TYPE pgbackrest_wal_archive_status gauge
pgbackrest_wal_archive_status{database_id="1",pg_version="13",repo_key="1",stanza="demo",wal_max="000000010000000000000004",wal_min="000000010000000000000001"} 1
```
