### PR TITLE
Add Pomerium to Software List

### DIFF
--- a/content/docs/instrumenting/exporters.md
+++ b/content/docs/instrumenting/exporters.md
@@ -289,6 +289,7 @@ separate exporters are needed:
    * [MinIO](https://docs.minio.io/docs/how-to-monitor-minio-using-prometheus.html)
    * [PATROL with Monitoring Studio X](https://www.sentrysoftware.com/library/swsyx/prometheus/exposing-patrol-parameters-in-prometheus.html)
    * [Netdata](https://github.com/firehol/netdata)
+   * [Pomerium](https://pomerium.com/reference/#metrics-address) (**direct**)
    * [Pretix](https://pretix.eu/)
    * [Quobyte](https://www.quobyte.com/) (**direct**)
    * [RabbitMQ](https://rabbitmq.com/prometheus.html)

--- a/content/docs/instrumenting/exporters.md
+++ b/content/docs/instrumenting/exporters.md
@@ -289,7 +289,7 @@ separate exporters are needed:
    * [MinIO](https://docs.minio.io/docs/how-to-monitor-minio-using-prometheus.html)
    * [PATROL with Monitoring Studio X](https://www.sentrysoftware.com/library/swsyx/prometheus/exposing-patrol-parameters-in-prometheus.html)
    * [Netdata](https://github.com/firehol/netdata)
-   * [Pomerium](https://pomerium.com/reference/#metrics-address) (**direct**)
+   * [Pomerium](https://pomerium.com/reference/#metrics-address)
    * [Pretix](https://pretix.eu/)
    * [Quobyte](https://www.quobyte.com/) (**direct**)
    * [RabbitMQ](https://rabbitmq.com/prometheus.html)


### PR DESCRIPTION
Pomerium exposes data to Prometheus using the client_golang library.

<!--
    Please sign CNCF's Developer Certificate of Origin and sign-off your commits by adding the -s / --sign-off flag to `git commit`

    More information on both of those can be found at https://github.com/apps/dco

    If you are proposing a new integration, exporter, or client library, please include representative sample output.
 -->
