### PR TITLE
Added matcher syntax support for Routing tree editor.

### DIFF
--- a/static/routing-tree.js
+++ b/static/routing-tree.js
@@ -25,7 +25,7 @@ var tooltip = d3.select("body")
     .style("z-index", "10")
     .style("visibility", "hidden");
 
-const promQlRegExp = /\b(?<label>[a-z0-9_]\w*)(?<selector>=~?|![=~])"?(?<value>(?<=")(?:[^\\"]|\\.)*(?=")|\w+[^\s},]+)/gmi;
+const promQlRegExp = /\b(?<label>[a-z0-9_]\w*)\s?(?<selector>=~?|![=~])\s"?(?<value>(?<=")(?:[^\\"]|\\.)*(?=")|\w+[^\s},]+)/gmi;
 
 function parseSearch(searchString) {
   let o = {};

--- a/static/routing-tree.js
+++ b/static/routing-tree.js
@@ -25,7 +25,7 @@ var tooltip = d3.select("body")
     .style("z-index", "10")
     .style("visibility", "hidden");
 
-const promQlRegExp = /\b(?<label>[a-z0-9_]\w*)\s?(?<selector>=~?|![=~])\s"?(?<value>(?<=")(?:[^\\"]|\\.)*(?=")|\w+[^\s},]+)/gmi;
+const promQlRegExp = /\b(?<label>[a-z0-9_]\w*)\s?(?<selector>=~?|![=~])\s?"?(?<value>(?<=")(?:[^\\"]|\\.)*(?=")|\w+[^\s},]+)/gmi;
 
 function parseSearch(searchString) {
   let o = {};
@@ -114,6 +114,13 @@ function matchLabels(matchers, labelSet) {
   return true;
 }
 
+const Matcher = Object.freeze({
+  EQ: "MatchEqual",
+  NE: "MatchNotEqual",
+  RE: "MatchRegexp",
+  NRE: "MatchNotRegexp",
+})
+
 // Compare single matcher to labelSet
 function matchLabel(matcher, labelSet) {
   var v = "";
@@ -121,11 +128,30 @@ function matchLabel(matcher, labelSet) {
     v = labelSet[matcher.name];
   }
 
-  if (matcher.isRegex) {
-    return matcher.value.test(v)
+  if (matcher.op !== undefined) {
+    return matchNewSyntax(matcher, v);
+  } else {
+    // Deprecated matchers check
+    if (matcher.isRegex) {
+      return matcher.value.test(v)
+    }
+    return matcher.value === v;
   }
+}
 
-  return matcher.value === v;
+function matchNewSyntax(matcher, v) {
+  switch (matcher.op) {
+    case Matcher.EQ:
+      return matcher.value === v;
+    case Matcher.NE:
+      return matcher.value !== v;
+    case Matcher.RE:
+    case Matcher.NRE:
+      return matcher.value.test(v);
+    default:
+      console.log("Invalid matcher");
+      break;
+  }
 }
 
 // Load the parsed config and create the tree
@@ -167,33 +193,34 @@ function massage(root, receivers) {
     }
   }
 
+  // PromQL matcher syntax check
   if (root.matchers) {
     root.matchers.forEach((matcher) => {
       let o = {};
-
       let matchedExpressions;
+
       while ((matchedExpressions = promQlRegExp.exec(matcher)) !== null) {
         let [match, label, selector, value] = matchedExpressions;
         o.name = label;
 
         switch (selector) {
           case "=~":
-            o.isRegex = true;
             o.value = new RegExp("^(?:" + value + ")$");
+            o.op = Matcher.RE;
             matchers.push(o);
             break;
           case "!=":
-            o.isRegex = true;
-            o.value = new RegExp("^(?!" + value + "$)");
+            o.op = Matcher.NE
+            o.value = value;
             matchers.push(o);
             break;
           case "!~":
-            o.isRegex = true;
+            o.op = Matcher.NRE
             o.value = new RegExp("^(?!" + value + "$)");
             matchers.push(o);
             break;
           case "=":
-            o.isRegex = false;
+            o.op = Matcher.EQ
             o.value = value
             matchers.push(o);
             break;

--- a/static/routing-tree.js
+++ b/static/routing-tree.js
@@ -28,12 +28,11 @@ var tooltip = d3.select("body")
 const promQlRegExp = /\b(?<label>[a-z0-9_]\w*)(?<selector>=~?|![=~])"?(?<value>(?<=")(?:[^\\"]|\\.)*(?=")|\w+[^\s},]+)/gmi;
 
 function parseSearch(searchString) {
-  var labels = searchString.replace(/{|}|\"|\'/g, "").split(",");
-  var o = {};
-  labels.forEach(function(label) {
-    var l = label.trim().split("=");
-    o[l[0]] = l[1];
-  });
+  let o = {};
+  let matchedExpressions;
+  while ((matchedExpressions = promQlRegExp.exec(searchString)) !== null) {
+    o[matchedExpressions[1]] = matchedExpressions[3];
+  }
   return o;
 }
 


### PR DESCRIPTION
I added matchers syntax support to [alertmanager routing tree editor](https://www.prometheus.io/webtools/alerting/routing-tree-editor/)
PR closes #1638 closes #1965