### PR TITLE
Fix links to images in agent blog post

### DIFF
--- a/content/blog/2021-11-16-agent.md
+++ b/content/blog/2021-11-16-agent.md
@@ -23,13 +23,13 @@ In this (lengthy) blog post, I would love to introduce a new operational mode of
 
 The core design of Prometheus has been unchanged for the project's entire lifetime. Inspired by [Google's Borgmon monitoring system](https://sre.google/sre-book/practical-alerting/#the-rise-of-borgmon), you can deploy a Prometheus server alongside the applications you want to monitor, tell Prometheus how to reach them, and allow to scrape the current values of their metrics at regular intervals. Such a collection method, which is often referred to as the "pull model", is the core principle that [allows Prometheus to be lightweight and reliable](https://prometheus.io/blog/2016/07/23/pull-does-not-scale-or-does-it/). Furthermore, it enables application instrumentation and exporters to be dead simple, as they only need to provide a simple human-readable HTTP endpoint with the current value of all tracked metrics (in OpenMetrics format). All without complex push infrastructure and non-trivial client libraries. Overall, a simplified typical Prometheus monitoring deployment looks as below:
 
-![Prometheus high-level view](/assets/blog/2021-11-16/prom.png)
+![Prometheus high-level view](/static/blog/2021-11-16/prom.png)
 
 This works great, and we have seen millions of successful deployments like this over the years that process dozens of millions of active series. Some of them for longer time retention, like two years or so. All allow to query, alert, and record metrics useful for both cluster admins and developers.
 
 However, the cloud-native world is constantly growing and evolving. With the growth of managed Kubernetes solutions and clusters created on-demand within seconds, we are now finally able to treat clusters as "cattle", not as "pets" (in other words, we care less about individual instances of those). In some cases, solutions do not even have the cluster notion anymore, e.g. [kcp](https://github.com/kcp-dev/kcp), [Fargate](https://aws.amazon.com/fargate/) and other platforms.
 
-![Yoda](/assets/blog/2021-11-16/yoda.gif)
+![Yoda](/static/blog/2021-11-16/yoda.gif)
 
 The other interesting use case that emerges is the notion of **Edge** clusters or networks. With industries like telecommunication, automotive and IoT devices adopting cloud-native technologies, we see more and more much smaller clusters with a restricted amount of resources. This is forcing all data (including observability) to be transferred to remote, bigger counterparts as almost nothing can be stored on those remote nodes.
 
@@ -45,7 +45,7 @@ Naively, we could think about implementing this by either putting Prometheus on 
 
 Prometheus introduced three ways to support the global view case, each with its own pros and cons. Let's briefly go through those. They are shown in orange color in the diagram below:
 
-![Prometheus global view](/assets/blog/2021-11-16/prom-remote.png)
+![Prometheus global view](/static/blog/2021-11-16/prom-remote.png)
 
 * **Federation** was introduced as the first feature for aggregation purposes. It allows a global-level Prometheus server to scrape a subset of metrics from a leaf Prometheus. Such a "federation" scrape reduces some unknowns across networks because metrics exposed by federation endpoints include the original samples' timestamps. Yet, it usually suffers from the inability to federate all metrics and not lose data during longer network partitions (minutes).
 * **Prometheus Remote Read** allows selecting raw metrics from a remote Prometheus server's database without a direct PromQL query. You can deploy Prometheus or other solutions (e.g. Thanos) on the global level to perform PromQL queries on this data while fetching the required metrics from multiple remote locations. This is really powerful as it allows you to store data "locally" and access it only when needed. Unfortunately, there are cons too. Without features like [Query Pushdown](https://github.com/thanos-io/thanos/issues/305) we are in extreme cases pulling GBs of compressed metric data to answer a single query. Also, if we have a network partition, we are temporarily blind. Last but not least, certain security guidelines are not allowing ingress traffic, only egress one.
@@ -83,7 +83,7 @@ From Prometheus `v2.32.0` (next release), everyone will be able to run the Prome
 
 The Agent mode optimizes Prometheus for the remote write use case. It disables querying, alerting, and local storage, and replaces it with a customized TSDB WAL. Everything else stays the same: scraping logic, service discovery and related configuration. It can be used as a drop-in replacement for Prometheus if you want to just forward your data to a remote Prometheus server or any other Remote-Write-compliant project. In essence it looks like this:
 
-![Prometheus agent](/assets/blog/2021-11-16/agent.png)
+![Prometheus agent](/static/blog/2021-11-16/agent.png)
 
 The best part about Prometheus Agent is that it's built into Prometheus. Same scraping APIs, same semantics, same configuration and discovery mechanism.
 


### PR DESCRIPTION
The links to the images for the [agent blog post](https://github.com/prometheus/docs/blob/main/content/blog/2021-11-16-agent.md) aren't rendering the images. This PR fixes the path to those images.

Signed-off-by: jessicagreben <jessicagrebens@gmail.com>

<!--
    Please sign CNCF's Developer Certificate of Origin and sign-off your commits by adding the -s / --sign-off flag to `git commit`

    More information on both of those can be found at https://github.com/apps/dco

    If you are proposing a new integration, exporter, or client library, please include representative sample output.
 -->
