### PR TITLE
Add RTPEngine to 3rd-party software that export Prometheus metrics

### DIFF
--- a/content/docs/instrumenting/exporters.md
+++ b/content/docs/instrumenting/exporters.md
@@ -294,6 +294,7 @@ separate exporters are needed:
    * [Quobyte](https://www.quobyte.com/) (**direct**)
    * [RabbitMQ](https://rabbitmq.com/prometheus.html)
    * [RobustIRC](http://robustirc.net/)
+   * [RTPEngine](https://github.com/sipwise/rtpengine)
    * [ScyllaDB](http://github.com/scylladb/scylla)
    * [Skipper](https://github.com/zalando/skipper)
    * [SkyDNS](https://github.com/skynetservices/skydns) (**direct**)


### PR DESCRIPTION
It can be configured to directly export Prometheus metrics.