### PR TITLE
Remove English-centric phrasing for metric naming

### DIFF
--- a/content/docs/instrumenting/writing_exporters.md
+++ b/content/docs/instrumenting/writing_exporters.md
@@ -128,8 +128,7 @@ automatically doesn’t always produce nice results for things like
 Exposed metrics should not contain colons, these are reserved for user
 defined recording rules to use when aggregating.
 
-Only `[a-zA-Z0-9:_]` are valid in metric names, any other characters
-should be sanitized to an underscore.
+Only `[a-zA-Z0-9:_]` are valid in metric names.
 
 The `_sum`, `_count`, `_bucket` and `_total` suffixes are used by
 Summaries, Histograms and Counters. Unless you’re producing one of


### PR DESCRIPTION
I think the phrasing around allowed characters in metric names should be changed, for a couple of reasons.

First, consider the metric name `合計httpリクエスト`. (If I believe Google Translate, that means "total HTTP requests".) The documentation seems to imply that, since the characters in this metric name are not allowed, one might instead call it `__http_____`. 🙂 Consider a less extreme example: if I have `jalapeños_purchased_total`, "sanitizing" it would result in `jalape_os_purchased_total`, which is similarly silly. I don't think this is a useful suggestion, so maybe it shouldn't be included in the documentation.

Second (and respectfully, because I think it's unlikely that this was the intention of the original author), the "sanitized" phrasing might imply that non-English character sets are somehow diseased and in need of cleansing. So I think this phrasing should just be removed.

Signed-off-by: Mike Pontillo <mpontillo@digitalocean.com>

<!--
    Please sign CNCF's Developer Certificate of Origin and sign-off your commits by adding the -s / --sign-off flag to `git commit`

    More information on both of those can be found at https://github.com/apps/dco

    If you are proposing a new integration, exporter, or client library, please include representative sample output.
 -->
