### PR TITLE
Concepts: Remove confusing examples

### DIFF
--- a/content/docs/concepts/jobs_instances.md
+++ b/content/docs/concepts/jobs_instances.md
@@ -5,8 +5,8 @@ sort_rank: 3
 
 # Jobs and instances
 
-In Prometheus terms, an endpoint you can scrape is called an _instance_,
-usually corresponding to a single process. A collection of instances with the same purpose, a process replicated for scalability or reliability for example, is called a _job_.
+In Prometheus terms, an endpoint you can scrape is called an _instance_. A
+collection of instances is called a _job_.
 
 For example, an API server job with four replicated instances:
 


### PR DESCRIPTION

I have trouble understanding what saying that an instance is "usually
corresponding to a single process" is trying to convey here and how it
might help a new user trying to understand what an instance is. I
believe the point is made more clear by just removing this example.

The same is true for the explanation of what a job is, but here I
believe the example is actively harmful. It conveys the picture that a
job is a way to group servers together based on their purpose *as a
server*, when in reality it's often more the case that you want to group
up a set of instances that you want to scrape the same set of metrics
from.

Remove these examples and let the actual content stand on its own legs.

Signed-off-by: Mattias Bengtsson <mattias.jc.bengtsson@gmail.com>
