### PR TITLE
Add webscraper-exporter to the exporters list

### DIFF
--- a/content/docs/instrumenting/exporters.md
+++ b/content/docs/instrumenting/exporters.md
@@ -245,6 +245,7 @@ wide variety of JVM-based applications, for example [Kafka](http://kafka.apache.
    * [Teamspeak3 exporter](https://github.com/hikhvar/ts3exporter)
    * [Transmission exporter](https://github.com/metalmatze/transmission-exporter)
    * [Unbound exporter](https://github.com/kumina/unbound_exporter)
+   * [Webscraper exporter](https://github.com/cestef/webscraper-exporter)
    * [WireGuard exporter](https://github.com/MindFlavor/prometheus_wireguard_exporter)
    * [Xen exporter](https://github.com/lovoo/xenstats_exporter)
 


### PR DESCRIPTION
Signed-off-by: cstef <colin@petit-suisse.fr>

An exporter for website performance metrics built using puppeteer: https://github.com/cstefFlexin/webscraper-exporter

CLI preview:

<img width="924" alt="image" src="https://user-images.githubusercontent.com/53212129/153927669-1eb7934d-7d80-465f-a364-159f78d741c7.png">

`/` endpoint: 

<img width="308" alt="image" src="https://user-images.githubusercontent.com/53212129/153927738-2e2aa8c1-a78d-4f4b-a706-46a34fa452a3.png">

Metrics exposed:

<img width="543" alt="image" src="https://user-images.githubusercontent.com/53212129/153927797-36545be2-66e0-4cbb-8904-ad03f0bff4ea.png">
