### PR TITLE
Replace 'build' with 'create'

### DIFF
--- a/content/docs/instrumenting/writing_clientlibs.md
+++ b/content/docs/instrumenting/writing_clientlibs.md
@@ -116,14 +116,14 @@ For example in the Java Simpleclient we have:
 
 ```java
 class YourClass {
-  static final Counter requests = Counter.build()
+  static final Counter requests = Counter.create()
       .name("requests_total")
       .help("Requests.").register();
 }
 ```
 
 This will register requests with the default CollectorRegistry. By calling
-`build()` rather than `register()` the metric won’t be registered (handy for
+`create()` rather than `register()` the metric won’t be registered (handy for
 unittests), you can also pass in a CollectorRegistry to `register()` (handy for
 batch jobs).
 


### PR DESCRIPTION
At least for the Java client, it appears the 'build' method was renamed 'create'?

https://prometheus.github.io/client_java/io/prometheus/client/Summary.Builder.html

<!--
    Please sign CNCF's Developer Certificate of Origin and sign-off your commits by adding the -s / --sign-off flag to `git commit`

    More information on both of those can be found at https://github.com/apps/dco

    If you are proposing a new integration, exporter, or client library, please include representative sample output.
 -->
