### PR TITLE
Exclude Web UI from the downloads

### DIFF
--- a/lib/helpers/download.rb
+++ b/lib/helpers/download.rb
@@ -129,7 +129,7 @@ module Downloads
     # If both formats are available, only .zip is returned (covers Windows use case).
     def binaries
       assets.
-        select { |d| d['name'] && %w[.tar.gz .zip].any? { |ext| d['name'].end_with?(ext) } }.
+        select { |d| d['name'] && %w[.tar.gz .zip].any? { |ext| d['name'].end_with?(ext) } && !d['name'].include?('-web-ui-') }.
         map { |d| Binary.new(d) }.
         group_by { |b| [b.os, b.arch] }.
         map { |_, binaries| binaries.sort_by(&:name).last }.


### PR DESCRIPTION
Prometheus now provides web UI tarballs to better integrate with
downstream distributions.

We need to explictly exclude them from our downloads.

Signed-off-by: Julien Pivotto <roidelapluie@o11y.eu>

<!--
    Please sign CNCF's Developer Certificate of Origin and sign-off your commits by adding the -s / --sign-off flag to `git commit`

    More information on both of those can be found at https://github.com/apps/dco

    If you are proposing a new integration, exporter, or client library, please include representative sample output.
 -->
