### PR TITLE
New design doc for TSDB out of order support

### DIFF
--- a/content/docs/introduction/design-doc.md
+++ b/content/docs/introduction/design-doc.md
@@ -46,6 +46,7 @@ still relevant.
 | Serverless, MQTT, and IoT use cases in the Prometheus ecosystem | | TODO | |
 | Static arithmetic for timestamps and durations | | TODO | |
 | [Prometheus long-term supported releases](https://docs.google.com/document/d/1wCXLnvh460UG10Mw019UbYMWDwSWWdvgwY61LHY0A0w/edit) | 2022-03-02 | Proposed | |
+| [Support for out of order samples in the TSDB](https://docs.google.com/document/d/1Kppm7qL9C-BJB1j6yb6-9ObG3AbdZnFUBYPNNWwDBYM/edit) | 2022-04-13 | Proposed | |
 
 # Problem statements and exploratory documents
 


### PR DESCRIPTION
Adds the recent design document to bring out of order support to the TSDB 
reference to the list of design docs.

The design doc was originally shared as part of
https://github.com/prometheus/prometheus/issues/8535 conversation.

cc @roidelapluie since you suggested to share it here https://github.com/prometheus/prometheus/issues/8535#issuecomment-878381037