### PR TITLE
integrations: add link to prom2tower

### DIFF
--- a/content/docs/operating/integrations.md
+++ b/content/docs/operating/integrations.md
@@ -91,6 +91,7 @@ For notification mechanisms not natively supported by the Alertmanager, the
   * [Matrix](https://github.com/matrix-org/go-neb)
   * [Phabricator / Maniphest](https://github.com/knyar/phalerts)
   * [prom2teams](https://github.com/idealista/prom2teams): forwards notifications to Microsoft Teams
+  * [Ansible Tower](https://github.com/pja237/prom2tower): call Ansible Tower (AWX) API on alerts (launch jobs etc.)
   * [Rocket.Chat](https://rocket.chat/docs/administrator-guides/integrations/prometheus/)
   * [ServiceNow](https://github.com/FXinnovation/alertmanager-webhook-servicenow)
   * [Signal](https://github.com/dgl/alertmanager-webhook-signald)


### PR DESCRIPTION
Signed-off-by: Jager,Petar <petar.jager@gmail.com>

Hello @simonpasquier , @w0rm ,

please check this PR, it adds prom2tower link to the list of integrations.
Prometheus2tower is a service that integrates alertmanager and ansible tower (awx), more elaborate description is in the repo README :)

Best,
Petar 