### PR TITLE
docs: Fix links master -> main

### DIFF
--- a/MAINTAINERS.md
+++ b/MAINTAINERS.md
@@ -1,12 +1,12 @@
 Documentation that refers to a specific project within the Prometheus ecosystem
 is maintained by the maintainers of the respective project. For example, refer
 to the maintainers specified in Alertmanager's
-[MAINTAINERS.md](https://github.com/prometheus/alertmanager/blob/master/MAINTAINERS.md)
+[MAINTAINERS.md](https://github.com/prometheus/alertmanager/blob/main/MAINTAINERS.md)
 file for documentation about the Alertmanager.
 
 Note that the documentation for the Prometheus server is located in the
 [prometheus/prometheus
-repository](https://github.com/prometheus/prometheus/tree/master/docs) itself.
+repository](https://github.com/prometheus/prometheus/tree/main/docs) itself.
 
 For anything that is not documentation for a specific project, refer to the
 following maintainers with their focus areas:

--- a/README.md
+++ b/README.md
@@ -9,7 +9,7 @@ See [`CONTRIBUTING.md`](CONTRIBUTING.md) for general instructions for new Promet
 
 The main documentation contents of this website are located in the [`content/docs`](content/docs) directory.
 
-Documentation concerning the Prometheus server is [maintained in the Prometheus server repository](https://github.com/prometheus/prometheus/tree/master/docs) and cloned into the website at build time.
+Documentation concerning the Prometheus server is [maintained in the Prometheus server repository](https://github.com/prometheus/prometheus/tree/main/docs) and cloned into the website at build time.
 
 As a guideline, please keep the documentation generally applicable and avoid use-case-specific changes.
 
@@ -61,7 +61,7 @@ If you have the prerequisite access rights, you can view the Netlify settings he
 * GitHub webhook notifying Netlify of branch changes: https://github.com/prometheus/docs/settings/hooks
 * Netlify project: https://app.netlify.com/sites/prometheus-docs
 
-Changes to the `master` branch are deployed to the main site at https://prometheus.io.
+Changes to the `main` branch are deployed to the main site at https://prometheus.io.
 
 Netlify also creates preview deploys for every pull request. To view these for a PR where all checks have passed:
 

--- a/content/blog/2015-06-01-advanced-service-discovery.md
+++ b/content/blog/2015-06-01-advanced-service-discovery.md
@@ -16,7 +16,7 @@ mechanisms to Prometheus.
 
 Aside from many smaller fixes and improvements, you can now also reload your configuration during
 runtime by sending a `SIGHUP` to the Prometheus process. For a full list of changes, check the
-[changelog for this release](https://github.com/prometheus/prometheus/blob/master/CHANGELOG.md#0140--2015-06-01).
+[changelog for this release](https://github.com/prometheus/prometheus/blob/main/CHANGELOG.md#0140--2015-06-01).
 
 In this blog post, we will take a closer look at the built-in service discovery mechanisms and provide
 some practical examples. As an additional resource, see

--- a/content/blog/2017-06-21-prometheus-20-alpha3-new-rule-format.md
+++ b/content/blog/2017-06-21-prometheus-20-alpha3-new-rule-format.md
@@ -25,7 +25,7 @@ Alerting and recording rules are one of the critical features of Prometheus. But
  
 * All rules ran with the same interval. We could have some heavy rules that are better off being run at a 10-minute interval and some rules that could be run at 15-second intervals.
 
-* All rules were evaluated concurrently, which is actually Prometheus’ oldest [open bug](https://github.com/prometheus/prometheus/blob/master/rules/manager.go#L267). This has a couple of issues, the obvious one being that the load spikes every eval interval if you have a lot of rules. The other being that rules that depend on each other might be fed outdated data. For example:
+* All rules were evaluated concurrently, which is actually Prometheus’ oldest [open bug](https://github.com/prometheus/prometheus/blob/main/rules/manager.go#L267). This has a couple of issues, the obvious one being that the load spikes every eval interval if you have a lot of rules. The other being that rules that depend on each other might be fed outdated data. For example:
 
 ```
 instance:network_bytes:rate1m = sum by(instance) (rate(network_bytes_total[1m]))

--- a/content/blog/2018-07-05-implementing-custom-sd.md
+++ b/content/blog/2018-07-05-implementing-custom-sd.md
@@ -16,9 +16,9 @@ outside the team and then not maintained or tested well. We want to commit to on
 integration with service discovery mechanisms that we know we can maintain, and that work as intended.
 For this reason, there is currently a moratorium on new SD integrations.
 
-However, we know there is still a desire to be able to integrate with other SD mechanisms, such as 
-Docker Swarm. Recently a small code change plus an example was committed to the documentation 
-[directory](https://github.com/prometheus/prometheus/tree/master/documentation/examples/custom-sd)
+However, we know there is still a desire to be able to integrate with other SD mechanisms, such as
+Docker Swarm. Recently a small code change plus an example was committed to the documentation
+[directory](https://github.com/prometheus/prometheus/tree/main/documentation/examples/custom-sd)
 within the Prometheus repository for implementing a custom service discovery integration without having
 to merge it into the main Prometheus binary. The code change allows us to make use of the internal
 Discovery Manager code to write another executable that interacts with a new SD mechanism and outputs
@@ -26,17 +26,17 @@ a file that is compatible with Prometheus' file\_sd. By co-locating Prometheus a
 we can configure Prometheus to read the file\_sd-compatible output of our executable, and therefore
 scrape targets from that service discovery mechanism. In the future this will enable us to move SD
 integrations out of the main Prometheus binary, as well as to move stable SD integrations that make
-use of the adapter into the Prometheus 
-[discovery](https://github.com/prometheus/prometheus/tree/master/discovery) package. 
+use of the adapter into the Prometheus
+[discovery](https://github.com/prometheus/prometheus/tree/main/discovery) package.
 
-Integrations using file_sd, such as those that are implemented with the adapter code, are listed 
+Integrations using file_sd, such as those that are implemented with the adapter code, are listed
 [here](https://prometheus.io/docs/operating/integrations/#file-service-discovery).
 
 Let’s take a look at the example code.
 
 ## Adapter
-First we have the file 
-[adapter.go](https://github.com/prometheus/prometheus/blob/master/documentation/examples/custom-sd/adapter/adapter.go).
+First we have the file
+[adapter.go](https://github.com/prometheus/prometheus/blob/main/documentation/examples/custom-sd/adapter/adapter.go).
 You can just copy this file for your custom SD implementation, but it's useful to understand what's
 happening here.
 
@@ -70,13 +70,13 @@ from our SD mechanism.
         Labels  map[string]string `json:"labels"`
     }
 
-This `customSD` struct exists mostly to help us convert the internal Prometheus `targetgroup.Group` 
+This `customSD` struct exists mostly to help us convert the internal Prometheus `targetgroup.Group`
 struct into JSON for the file\_sd format.
 
 When running, the adapter will listen on a channel for updates from our custom SD implementation.
 Upon receiving an update, it will parse the targetgroup.Groups into another `map[string]*customSD`,
 and compare it with what’s stored in the `groups` field of Adapter. If the two are different, we assign
-the new groups to the Adapter struct, and write them as JSON to the output file. Note that this 
+the new groups to the Adapter struct, and write them as JSON to the output file. Note that this
 implementation assumes that each update sent by the SD implementation down the channel contains
 the full list of all target groups the SD knows about.
 
@@ -84,11 +84,11 @@ the full list of all target groups the SD knows about.
 
 Now we want to actually use the Adapter to implement our own custom SD. A full working example is in
 the same examples directory
-[here](https://github.com/prometheus/prometheus/blob/master/documentation/examples/custom-sd/adapter-usage/main.go).  
+[here](https://github.com/prometheus/prometheus/blob/main/documentation/examples/custom-sd/adapter-usage/main.go).
 
-Here you can see that we’re importing the adapter code 
+Here you can see that we’re importing the adapter code
 `"github.com/prometheus/prometheus/documentation/examples/custom-sd/adapter"` as well as some other
-Prometheus libraries. In order to write a custom SD we need an implementation of the Discoverer interface. 
+Prometheus libraries. In order to write a custom SD we need an implementation of the Discoverer interface.
 
     // Discoverer provides information about target groups. It maintains a set
     // of sources from which TargetGroups can originate. Whenever a discovery provider
@@ -110,13 +110,13 @@ We really just have to implement one function, `Run(ctx context.Context, up chan
 This is the function the manager within the Adapter code will call within a goroutine. The Run function
 makes use of a context to know when to exit, and is passed a channel for sending it's updates of target groups.
 
-Looking at the [Run](https://github.com/prometheus/prometheus/blob/master/documentation/examples/custom-sd/adapter-usage/main.go#L153-L211) 
+Looking at the [Run](https://github.com/prometheus/prometheus/blob/main/documentation/examples/custom-sd/adapter-usage/main.go#L153-L211)
 function within the provided example, we can see a few key things happening that we would need to do
 in an implementation for another SD. We periodically make calls, in this case to Consul (for the sake
-of this example, assume there isn’t already a built-in Consul SD implementation), and convert the 
+of this example, assume there isn’t already a built-in Consul SD implementation), and convert the
 response to a set of `targetgroup.Group` structs. Because of the way Consul works, we have to first make
 a call to get all known services, and then another call per service to get information about all the
-backing instances. 
+backing instances.
 
 Note the comment above the loop that’s calling out to Consul for each service:
 
@@ -149,7 +149,7 @@ Prometheus as Docker containers via docker-compose when working with the example
         container_name: consul
         ports:
         - 8300:8300
-        - 8500:8500      
+        - 8500:8500
         volumes:
         - ${PWD}/consul.json:/consul/config/consul.json
     prometheus:

--- a/content/blog/2019-10-10-remote-read-meets-streaming.md
+++ b/content/blog/2019-10-10-remote-read-meets-streaming.md
@@ -5,14 +5,14 @@ kind: article
 author_name: Bartlomiej Plotka (@bwplotka)
 ---
 
-The new Prometheus version 2.13.0 is available and as always, it includes many fixes and improvements. You can read what's changed [here](https://github.com/prometheus/prometheus/blob/release-2.13/CHANGELOG.md). 
-However, there is one feature that some projects and users were waiting for: [chunked, streamed version of remote read API](https://docs.google.com/document/d/1JqrU3NjM9HoGLSTPYOvR217f5HBKBiJTqikEB9UiJL0/edit#heading=h.3en2gbeew2sa).  
+The new Prometheus version 2.13.0 is available and as always, it includes many fixes and improvements. You can read what's changed [here](https://github.com/prometheus/prometheus/blob/release-2.13/CHANGELOG.md).
+However, there is one feature that some projects and users were waiting for: [chunked, streamed version of remote read API](https://docs.google.com/document/d/1JqrU3NjM9HoGLSTPYOvR217f5HBKBiJTqikEB9UiJL0/edit#heading=h.3en2gbeew2sa).
 
 In this article I would like to present a deep dive of what we changed in the remote protocol, why it was changed and how to use it effectively.
 
 ## Remote APIs
 
-Since version 1.x, Prometheus has the ability to interact directly with its storage using the [remote API](https://prometheus.io/docs/prometheus/latest/storage/#remote-storage-integrations). 
+Since version 1.x, Prometheus has the ability to interact directly with its storage using the [remote API](https://prometheus.io/docs/prometheus/latest/storage/#remote-storage-integrations).
 
 This API allows 3rd party systems to interact with metrics data through two methods:
 
@@ -21,32 +21,32 @@ This API allows 3rd party systems to interact with metrics data through two meth
 
 ![Remote read and write architecture](/assets/blog/2019-10-08/remote_integrations.png)
 
-Both methods are using HTTP with messages encoded with [protobufs](https://github.com/protocolbuffers/protobuf). 
+Both methods are using HTTP with messages encoded with [protobufs](https://github.com/protocolbuffers/protobuf).
 The request and response for both methods are compressed using [snappy](https://github.com/google/snappy).
 
-### Remote Write 
+### Remote Write
 
-This is the most popular way to replicate Prometheus data into 3rd party system. In this mode, Prometheus streams samples, 
-by periodically sending a batch of samples to the given endpoint. 
+This is the most popular way to replicate Prometheus data into 3rd party system. In this mode, Prometheus streams samples,
+by periodically sending a batch of samples to the given endpoint.
 
 Remote write was recently improved massively in March with [WAL-based remote write](https://grafana.com/blog/2019/03/25/whats-new-in-prometheus-2.8-wal-based-remote-write/) which
-improved the reliability and resource consumption. It is also worth to note that the remote write is supported by almost all 3rd 
+improved the reliability and resource consumption. It is also worth to note that the remote write is supported by almost all 3rd
 party integrations mentioned [here](https://prometheus.io/docs/operating/integrations/#remote-endpoints-and-storage).
 
 ### Remote Read
 
 The read method is less common. It was added in [March 2017](https://github.com/prometheus/prometheus/commit/febed48703b6f82b54b4e1927c53ab6c46257c2f) (server side) and
-has not seen significant development since then. 
+has not seen significant development since then.
 
 The release of Prometheus 2.13.0 includes a fix for known resource bottlenecks in the Read API. This article will focus on these improvements.
 
-The key idea of the remote read is to allow querying Prometheus storage ([TSDB](https://github.com/prometheus/prometheus/tree/master/tsdb)) directly without PromQL evaluation. 
+The key idea of the remote read is to allow querying Prometheus storage ([TSDB](https://github.com/prometheus/prometheus/tree/main/tsdb)) directly without PromQL evaluation.
 It is similar to the [`Querier`](https://github.com/prometheus/prometheus/blob/91d7175eaac18b00e370965f3a8186cc40bf9f55/storage/interface.go#L53) interface
-that the PromQL engine uses to retrieve data from storage. 
+that the PromQL engine uses to retrieve data from storage.
 
 This essentially allows read access of time series in TSDB that Prometheus collected. The main use cases for remote read are:
 
-* Seamless Prometheus upgrades between different data formats of Prometheus, so having [Prometheus reading from another Prometheus](https://www.robustperception.io/accessing-data-from-prometheus-1-x-in-prometheus-2-0). 
+* Seamless Prometheus upgrades between different data formats of Prometheus, so having [Prometheus reading from another Prometheus](https://www.robustperception.io/accessing-data-from-prometheus-1-x-in-prometheus-2-0).
 * Prometheus being able to read from 3rd party long term storage systems e.g InfluxDB.
 * 3rd party system querying data from Prometheus e.g [Thanos](https://thanos.io).
 
@@ -95,11 +95,11 @@ Remote read returns the matched time series with **raw** samples of value and ti
 ## Problem Statement
 
 There were two key problems for such a simple remote read. It was easy to use and understand, but there were no
-streaming capabilities within single HTTP request for the protobuf format we defined. Secondly, the response was 
+streaming capabilities within single HTTP request for the protobuf format we defined. Secondly, the response was
 including raw samples (`float64` value and `int64` timestamp) instead of
 an encoded, compressed batch of samples called "chunks" that are used to store metrics inside TSDB.
 
-The server algorithm for remote read without streaming was: 
+The server algorithm for remote read without streaming was:
 
 1. Parse request.
 1. Select metrics from TSDB.
@@ -108,8 +108,8 @@ The server algorithm for remote read without streaming was:
       * Add to response protobuf
 1. Marshal response.
 1. Snappy compress.
-1. Send back the HTTP response.  
- 
+1. Send back the HTTP response.
+
 The whole response of the remote read had to be buffered in a raw, uncompressed format in order to marshsal it in a
 potentially huge protobuf message before sending it to the client. The whole response has to then be fully buffered in the client again to be able
 to unmarshal it from the received protobuf. Only after that the client was able to use raw samples.
@@ -127,9 +127,9 @@ as your browser simply will not be happy fetching, storing and rendering hundred
 for dashboards and rendering purposes it is not practical to have that much data, as humans can't possibly read it.
 That is why usually we craft queries that have no more than 20 series.
 
-This is great, but a very common technique is to compose queries in such way that query returns **aggregated** 20 series, 
+This is great, but a very common technique is to compose queries in such way that query returns **aggregated** 20 series,
 however underneath the query engine has to touch potentially thousands of series to evaluate the response (e.g when using [aggregators](https://prometheus.io/docs/prometheus/latest/querying/operators/#aggregation-operators)).
-That is why systems like Thanos, which among other data, uses TSDB data from remote read, it's very often the case that the request is heavy. 
+That is why systems like Thanos, which among other data, uses TSDB data from remote read, it's very often the case that the request is heavy.
 
 ## Solution
 
@@ -164,10 +164,10 @@ type SeriesIterator interface {
 ```
 
 These sets of interfaces allow "streaming" flow inside the process. We no longer have to have a precomputed list of series that hold samples.
-With this interface each `SeriesSet.Next()` implementation can fetch series on demand. 
-In a similar way, within each series. we can also dynamically fetch each sample respectively via `SeriesIterator.Next`.  
+With this interface each `SeriesSet.Next()` implementation can fetch series on demand.
+In a similar way, within each series. we can also dynamically fetch each sample respectively via `SeriesIterator.Next`.
 
-With this contract, Prometheus can minimize allocated memory, because the PromQL engine can iterate over samples optimally to evaluate the query. 
+With this contract, Prometheus can minimize allocated memory, because the PromQL engine can iterate over samples optimally to evaluate the query.
 In the same way TSDB implements `SeriesSet` in a way that fetches the series optimally from blocks stored in the filesystem one by one, minimizing allocations.
 
 This is important for the remote read API, as we can reuse the same pattern of streaming using iterators by sending to the
@@ -199,8 +199,8 @@ message ChunkedSeries {
 ```
 
 As you can see the frame does not include raw samples anymore. That's the second improvement we did: We send in the message
-samples batched in chunks (see [this video](https://www.youtube.com/watch?v=b_pEevMAC3I) to learn more about chunks), 
-which are exactly the same chunks we store in the TSDB. 
+samples batched in chunks (see [this video](https://www.youtube.com/watch?v=b_pEevMAC3I) to learn more about chunks),
+which are exactly the same chunks we store in the TSDB.
 
 We ended up with the following server algorithm:
 
@@ -212,7 +212,7 @@ We ended up with the following server algorithm:
             * if the frame is >= 1MB; break
   * Marshal `ChunkedReadResponse` message.
   * Snappy compress
-  * Send the message   
+  * Send the message
 
 You can find full design [here](https://docs.google.com/document/d/1JqrU3NjM9HoGLSTPYOvR217f5HBKBiJTqikEB9UiJL0/edit#).
 
@@ -220,7 +220,7 @@ You can find full design [here](https://docs.google.com/document/d/1JqrU3NjM9HoG
 
 How does the performance of this new approach compare to the old solution?
 
-Let's compare remote read characteristics between Prometheus `2.12.0` and `2.13.0`. As for the initial results presented 
+Let's compare remote read characteristics between Prometheus `2.12.0` and `2.13.0`. As for the initial results presented
 at the beginning of this article, I was using Prometheus as a server, and a Thanos sidecar as a client of remote read.
 I was invoking testing remote read request by running gRPC call against Thanos sidecar using `grpcurl`.
 Test was performed from my laptop (Lenovo X1 16GB, i7 8th) with Kubernetes in docker (using [kind](https://github.com/kubernetes-sigs/kind)).
@@ -239,7 +239,7 @@ The full test bench is available in [thanosbench repo](https://github.com/thanos
 
 ![Prometheus 2.13.0: Heap-only allocations of single read 8h of 10k series](/assets/blog/2019-10-08/10series8hours-2.13-allocs.png)
 
-Reducing memory was the key item we aimed for with our solution. Instead of allocating GBs of memory, Prometheus buffers 
+Reducing memory was the key item we aimed for with our solution. Instead of allocating GBs of memory, Prometheus buffers
 roughly 50MB during the whole request, whereas for Thanos there is only a marginal memory use. Thanks to the streamed
 Thanos gRPC StoreAPI, sidecar is now a very simple proxy.
 
@@ -247,8 +247,8 @@ Additionally, I tried different time ranges and number of series, but as expecte
 a maximum of 50MB in allocations for Prometheus and nothing really visible for Thanos. This proves that our remote read
 uses **constant memory per request no matter how many samples you ask for**. Allocated memory per request is also drastically less
 influenced by the cardinality of the data, so number of series fetched like it used to be.
- 
-This allowing easier capacity planning against user traffic, with help of the concurrency limit. 
+
+This allowing easier capacity planning against user traffic, with help of the concurrency limit.
 
 ### CPU
 
@@ -260,12 +260,12 @@ This allowing easier capacity planning against user traffic, with help of the co
 
 ![Prometheus 2.13.0: CPU time of single read 8h of 10k series](/assets/blog/2019-10-08/10kseries8hours-2.13-cpu.png)
 
-During my tests, CPU usage was also improved, with 2x less CPU time used. 
+During my tests, CPU usage was also improved, with 2x less CPU time used.
 
 ### Latency
 
 We achieved to reduce remote read request latency as well, thanks to streaming and less encoding.
- 
+
 Remote read request latency for 8h range with 10,000 series:
 
 |      | 2.12.0: avg time | 2.13.0: avg time |
@@ -283,7 +283,7 @@ And with 2h time range:
 | sys  | 0m0.973s         | 0m0.536s         |
 
 Additionally to the ~2.5x lower latency, the response is streamed immediately in comparison to the non-streamed
-version where the client latency was 27s (`real` minus `user` time) just on processing and marshaling on Prometheus and on the Thanos side. 
+version where the client latency was 27s (`real` minus `user` time) just on processing and marshaling on Prometheus and on the Thanos side.
 
 ## Compatibility
 
@@ -299,11 +299,11 @@ The remote read protocol was extended in a backward and forward compatible way:
 
 To use the new, streamed remote read in Prometheus v2.13.0, a 3rd party system has to add  `accepted_response_types = [STREAMED_XOR_CHUNKS]` to the request.
 
-Then Prometheus will stream `ChunkedReadResponse` instead of old message. Each `ChunkedReadResponse` message is 
+Then Prometheus will stream `ChunkedReadResponse` instead of old message. Each `ChunkedReadResponse` message is
 following varint size and fixed size bigendian uint32 for CRC32 Castagnoli checksum.
 
 For Go it is recommended to use the [ChunkedReader](https://github.com/prometheus/prometheus/blob/48b2c9c8eae2d4a286d8e9384c2918aefd41d8de/storage/remote/chunked.go#L103)
- to read directly from the stream.   
+ to read directly from the stream.
 
 Note that `storage.remote.read-sample-limit` flag is no longer working for `STREAMED_XOR_CHUNKS`.
 `storage.remote.read-concurrent-limit` works as previously.
@@ -311,7 +311,7 @@ Note that `storage.remote.read-sample-limit` flag is no longer working for `STRE
 There also new option `storage.remote.read-max-bytes-in-frame` which controls the maximum size of each message. It is advised
 to keep it 1MB as the default as it is recommended by Google to keep protobuf message [not larger than 1MB](https://developers.google.com/protocol-buffers/docs/techniques#large-data).
 
-As mentioned before, [Thanos](https://thanos.io) gains a lot with this improvement. Streamed remote read is added in `v0.7.0`, so this or any following version, 
+As mentioned before, [Thanos](https://thanos.io) gains a lot with this improvement. Streamed remote read is added in `v0.7.0`, so this or any following version,
 will use streamed remote read automatically whenever Prometheus 2.13.0 or newer is used with the Thanos sidecar.
 
 ## Next Steps
@@ -319,7 +319,7 @@ will use streamed remote read automatically whenever Prometheus 2.13.0 or newer 
 Release 2.13.0 introduces extended remote read and Prometheus server side implementation, However at the moment of writing
 there are still few items to do in order to fully get advantage from the extended remote read protocol:
 
-* Support for client side of Prometheus remote read: [In progress](https://github.com/prometheus/prometheus/issues/5926) 
+* Support for client side of Prometheus remote read: [In progress](https://github.com/prometheus/prometheus/issues/5926)
 * Avoid re-encoding of chunks for blocks during remote read: [In progress](https://github.com/prometheus/prometheus/pull/5882)
 
 ## Summary
@@ -329,6 +329,6 @@ To sum up, the main benefits of chunked, streaming of remote read are:
 * Both client and server are capable of using **practically constant memory size per request**. This is because the Prometheus sends just single small frames one by one instead of the whole response during remote read. This massively helps with
 capacity planning, especially for a non-compressible resource like memory.
 * Prometheus server does not need to decode chunks to raw samples anymore during remote read. The same for client side for
-encoding, **if** the system is reusing native TSDB XOR compression (like Thanos does). 
+encoding, **if** the system is reusing native TSDB XOR compression (like Thanos does).
 
 As always, if you have any issues or feedback, feel free to submit a ticket on GitHub or ask questions on the mailing list.

--- a/content/community.html
+++ b/content/community.html
@@ -159,7 +159,7 @@ title: Community
     <h1>Code of Conduct</h1>
     <p>
       To make Prometheus a welcoming and harassment-free experience for everyone, we follow the
-      <a href="https://github.com/cncf/foundation/blob/master/code-of-conduct.md">CNCF Code of Conduct</a>.
+      <a href="https://github.com/cncf/foundation/blob/main/code-of-conduct.md">CNCF Code of Conduct</a>.
     </p>
 
     <h1>Legal Umbrella</h1>

--- a/content/docs/instrumenting/exposition_formats.md
+++ b/content/docs/instrumenting/exposition_formats.md
@@ -15,7 +15,7 @@ NOTE: Some earlier versions of Prometheus supported an exposition format based o
 addition to the current text-based format. As of version 2.0, however, Prometheus no
 longer supports the Protobuf-based format. You can read about the reasoning behind
 this change in [this
-document](https://github.com/OpenObservability/OpenMetrics/blob/master/legacy/markdown/protobuf_vs_text.md).
+document](https://github.com/OpenObservability/OpenMetrics/blob/main/legacy/markdown/protobuf_vs_text.md).
 
 ## Text-based format
 

--- a/content/docs/instrumenting/writing_exporters.md
+++ b/content/docs/instrumenting/writing_exporters.md
@@ -526,4 +526,4 @@ port allocations.
 
 Once you’re ready to announce your exporter to the world, email the
 mailing list and send a PR to add it to [the list of available
-exporters](https://github.com/prometheus/docs/blob/master/content/docs/instrumenting/exporters.md).
+exporters](https://github.com/prometheus/docs/blob/main/content/docs/instrumenting/exporters.md).

--- a/content/docs/introduction/design-doc.md
+++ b/content/docs/introduction/design-doc.md
@@ -24,7 +24,7 @@ still relevant.
 
 | Document | Initial date | Status | Pull requests |
 | -------- | ------------ | ------ | ------------- |
-| [Secure Alertmanager cluster traffic](https://github.com/prometheus/alertmanager/blob/master/doc/design/secure-cluster-traffic.md) | 2019‑02‑21 | Approved | [alertmanager#2237](https://github.com/prometheus/alertmanager/pull/2237) |
+| [Secure Alertmanager cluster traffic](https://github.com/prometheus/alertmanager/blob/main/doc/design/secure-cluster-traffic.md) | 2019‑02‑21 | Approved | [alertmanager#2237](https://github.com/prometheus/alertmanager/pull/2237) |
 | TSDB Head Improvements ([part1](https://docs.google.com/document/d/184urkLQnM7rqLmGvS66I15jU2pyPk_qwd8v_qDlXczo/edit) - [part 2](https://docs.google.com/document/d/1pnEsxB0CDLOxQipGw_vhkJpoDZfZPs_KjqCriumDAXQ/edit)) | 2019‑12‑09 | Partially implemented | |
 | [Persist Retroactive Rules](https://docs.google.com/document/d/16s_-RxYwQYcb4G4mvpmjPolEbD24o54a1LPqJ538Vhc/edit) | 2020‑06‑12 | Partially implemented | [#7675](https://github.com/prometheus/prometheus/pull/7675) |
 | [topk/bottomk aggregation over time](https://docs.google.com/document/d/1uSbD3T2beM-iX4-Hp7V074bzBRiRNlqUdcWP6JTDQSs/edit) | 2020‑09‑30 | Implemented | [#8121](https://github.com/prometheus/prometheus/pull/8121) [#8425](https://github.com/prometheus/prometheus/pull/8425) |

--- a/content/docs/introduction/faq.md
+++ b/content/docs/introduction/faq.md
@@ -93,7 +93,7 @@ It's now maintained and extended by a wide range of companies and individuals.
 ### What license is Prometheus released under?
 
 Prometheus is released under the
-[Apache 2.0](https://github.com/prometheus/prometheus/blob/master/LICENSE) license.
+[Apache 2.0](https://github.com/prometheus/prometheus/blob/main/LICENSE) license.
 
 ### What is the plural of Prometheus?
 

--- a/content/docs/visualization/consoles.md
+++ b/content/docs/visualization/consoles.md
@@ -123,7 +123,7 @@ Valid output formats for the third argument to `prom_query_drilldown`:
 * `printf.3g`: Display 3 significant digits.
 
 Custom formats can be defined. See
-[prom.lib](https://github.com/prometheus/prometheus/blob/master/console_libraries/prom.lib) for examples.
+[prom.lib](https://github.com/prometheus/prometheus/blob/main/console_libraries/prom.lib) for examples.
 
 ## Graph Library
 


### PR DESCRIPTION
There are a few repos which have migrated from `master` to `main` this
reflects that change for the ones which have made the transition.

Additionally cleanup some End of Line whitespace.

Signed-off-by: Harold Dost <github@hdost.com>