### PR TITLE
docs: fix prom-migrator link

### DIFF
--- a/content/docs/operating/integrations.md
+++ b/content/docs/operating/integrations.md
@@ -66,7 +66,7 @@ data volumes.
   * [VictoriaMetrics](https://github.com/VictoriaMetrics/VictoriaMetrics): write
   * [Wavefront](https://github.com/wavefrontHQ/prometheus-storage-adapter): write
 
-[Prom-migrator](https://github.com/timescale/promscale/tree/master/cmd/prom-migrator) is a tool for migrating data between remote storage systems.
+[Prom-migrator](https://github.com/timescale/promscale/tree/master/migration-tool/cmd/prom-migrator) is a tool for migrating data between remote storage systems.
 
 ## Alertmanager Webhook Receiver
 


### PR DESCRIPTION
This moved: https://github.com/timescale/promscale/commit/a0cae7d8a7c3ff5a1790245e06e9080bdc55f51e