### PR TITLE
Unofficial Go client addition

### DIFF
--- a/content/docs/instrumenting/clientlibs.md
+++ b/content/docs/instrumenting/clientlibs.md
@@ -28,6 +28,7 @@ Unofficial third-party client libraries:
 * [Dart](https://github.com/tentaclelabs/prometheus_client)
 * [Elixir](https://github.com/deadtrickster/prometheus.ex)
 * [Erlang](https://github.com/deadtrickster/prometheus.erl)
+* [Go](https://github.com/pascaldekloe/metrics)
 * [Haskell](https://github.com/fimad/prometheus-haskell)
 * [Lua](https://github.com/knyar/nginx-lua-prometheus) for Nginx
 * [Lua](https://github.com/tarantool/metrics) for Tarantool


### PR DESCRIPTION
Output looks like the following.

```
< HTTP/1.1 200 OK
< Content-Type: text/plain;version=0.0.4;charset=utf-8
< Date: Sun, 07 Mar 2021 15:22:47 GMT
< Content-Length: 351
< 
# Prometheus Samples

# TYPE db_connects_total counter
# HELP db_connects_total Number of established initiations.
db_connects_total 4 1615130567389

# TYPE db_cache_bytes gauge
# HELP db_cache_bytes Size of collective responses.
db_cache_bytes 7600 1615130567389

# TYPE db_disk_usage_ratio gauge
db_disk_usage_ratio{device="sda"} 0.19 1615130563595
```