### PR TITLE
Adding OpenZiti as software exposing Prometheus metrics

### DIFF
--- a/content/docs/instrumenting/exporters.md
+++ b/content/docs/instrumenting/exporters.md
@@ -289,6 +289,7 @@ separate exporters are needed:
    * [MinIO](https://docs.minio.io/docs/how-to-monitor-minio-using-prometheus.html)
    * [PATROL with Monitoring Studio X](https://www.sentrysoftware.com/library/swsyx/prometheus/exposing-patrol-parameters-in-prometheus.html)
    * [Netdata](https://github.com/firehol/netdata)
+   * [OpenZiti](https://openziti.github.io)
    * [Pomerium](https://pomerium.com/reference/#metrics-address)
    * [Pretix](https://pretix.eu/)
    * [Quobyte](https://www.quobyte.com/) (**direct**)


### PR DESCRIPTION
I would like to add [OpenZiti](https://openziti.github.io/) as software that exposes metrics in the Prometheus format.
