### PR TITLE
Add support for LTS releases

### DIFF
--- a/content/download.html
+++ b/content/download.html
@@ -43,6 +43,7 @@ title: Download
           <td colspan="5">
             <strong><%= release.name %></strong>
             <%= %(<span class="label label-primary">Pre-release</span>) if release.prerelease %>
+            <%= %(<span class="label label-primary">LTS</span>) if release.lts_release %>
             <small><a href="<%= release.url %>">Release notes</a></small>
           </td>
         </tr>

--- a/lib/filters/version_warning.rb
+++ b/lib/filters/version_warning.rb
@@ -14,6 +14,9 @@ class VersionWarning < ::Nanoc::Filter
     when 0
       return content
     when -1
+      if params[:lts_release]
+        return content
+      end
       type = 'an old version'
     end
 

--- a/lib/helpers/download.rb
+++ b/lib/helpers/download.rb
@@ -100,7 +100,6 @@ module Downloads
     def self.load(dir)
       repo = JSON.parse(File.read(File.join(dir, 'repo.json')))
       releases = JSON.parse(File.read(File.join(dir, 'releases.json')))
-      puts File.basename(dir)
       lts_releases = YAML.load_file('lts.yml').fetch(File.basename(dir), [])
       new(repo, releases: releases.map { |r| Release.new(r) }, lts_releases: lts_releases)
     end

--- a/lts.yml
+++ b/lts.yml
@@ -1,0 +1,2 @@
+prometheus:
+  - "2.37"


### PR DESCRIPTION
- Mark version as 2.37 (LTS) in dropdown.
- Keep LTS releases in Downloads and mark them with a badge.
- Do not show version warning in docs for LTS

Screenshots (with 2.30 as LTS for the sample)


![dropdown](https://user-images.githubusercontent.com/291750/174113755-fa9cf069-bfbd-444e-b75e-bd7b3134ba52.png)
![download](https://user-images.githubusercontent.com/291750/174113759-df6525b0-9ec4-4485-bf9d-b00f07bd133c.png)


Signed-off-by: Julien Pivotto <roidelapluie@o11y.eu>

<!--
    Please sign CNCF's Developer Certificate of Origin and sign-off your commits by adding the -s / --sign-off flag to `git commit`

    More information on both of those can be found at https://github.com/apps/dco

    If you are proposing a new integration, exporter, or client library, please include representative sample output.
 -->
