### PR TITLE
adding podman (OCI containers and pods manager) metrics exporter

### DIFF
--- a/content/docs/instrumenting/exporters.md
+++ b/content/docs/instrumenting/exporters.md
@@ -230,6 +230,7 @@ wide variety of JVM-based applications, for example [Kafka](http://kafka.apache.
    * [Pact Broker exporter](https://github.com/ContainerSolutions/pactbroker_exporter)
    * [PHP-FPM exporter](https://github.com/bakins/php-fpm-exporter)
    * [PowerDNS exporter](https://github.com/ledgr/powerdns_exporter)
+   * [Podman exporter](https://github.com/navidys/prometheus-podman-exporter)
    * [Process exporter](https://github.com/ncabatoff/process-exporter)
    * [rTorrent exporter](https://github.com/mdlayher/rtorrent_exporter)
    * [Rundeck exporter](https://github.com/phsmith/rundeck_exporter)


### PR DESCRIPTION
I would like to add podman (OCI containers and pods manager) exporter to the list of available metrics exporter.

Signed-off-by: Navid Yaghoobi <navidys@fedoraproject.org>

<!--
    Please sign CNCF's Developer Certificate of Origin and sign-off your commits by adding the -s / --sign-off flag to `git commit`

    More information on both of those can be found at https://github.com/apps/dco

    If you are proposing a new integration, exporter, or client library, please include representative sample output.
 -->
