### PR TITLE
Replace free/sql_exporter with burningalchemist/sql_exporter

### DIFF
--- a/content/docs/instrumenting/exporters.md
+++ b/content/docs/instrumenting/exporters.md
@@ -55,7 +55,7 @@ wide variety of JVM-based applications, for example [Kafka](http://kafka.apache.
    * [RavenDB exporter](https://github.com/marcinbudny/ravendb_exporter)
    * [Redis exporter](https://github.com/oliver006/redis_exporter)
    * [RethinkDB exporter](https://github.com/oliver006/rethinkdb_exporter)
-   * [SQL exporter](https://github.com/free/sql_exporter)
+   * [SQL exporter](https://github.com/burningalchemist/sql_exporter)
    * [Tarantool metric library](https://github.com/tarantool/metrics)
    * [Twemproxy](https://github.com/stuartnelson3/twemproxy_exporter)
 


### PR DESCRIPTION
The free/sql_exporter has had it's last commit in November 2019. Since then, the repository has been forked and maintained by burningalchemist. This pull request changes the link to the sql_exporter to the backwards-compatible, maintained version by burningalchemist.

Signed-off-by: Patrick Hahn <patrick+prometheus@patrick246.de>
Signed-off-by: Patrick Hahn <patrick246@users.noreply.github.com>

<!--
    Please sign CNCF's Developer Certificate of Origin and sign-off your commits by adding the -s / --sign-off flag to `git commit`

    More information on both of those can be found at https://github.com/apps/dco

    If you are proposing a new integration, exporter, or client library, please include representative sample output.
 -->
