### PR TITLE
Adjust formatting for Golang Instrumentation Doc

### DIFF
--- a/content/docs/guides/go-application.md
+++ b/content/docs/guides/go-application.md
@@ -59,35 +59,35 @@ The application [above](#how-go-exposition-works) exposes only the default Go me
 package main
 
 import (
-        "net/http"
-        "time"
+	"net/http"
+	"time"
 
-        "github.com/prometheus/client_golang/prometheus"
-        "github.com/prometheus/client_golang/prometheus/promauto"
-        "github.com/prometheus/client_golang/prometheus/promhttp"
+	"github.com/prometheus/client_golang/prometheus"
+	"github.com/prometheus/client_golang/prometheus/promauto"
+	"github.com/prometheus/client_golang/prometheus/promhttp"
 )
 
 func recordMetrics() {
-        go func() {
-                for {
-                        opsProcessed.Inc()
-                        time.Sleep(2 * time.Second)
-                }
-        }()
+	go func() {
+		for {
+			opsProcessed.Inc()
+			time.Sleep(2 * time.Second)
+		}
+	}()
 }
 
 var (
-        opsProcessed = promauto.NewCounter(prometheus.CounterOpts{
-                Name: "myapp_processed_ops_total",
-                Help: "The total number of processed events",
-        })
+	opsProcessed = promauto.NewCounter(prometheus.CounterOpts{
+		Name: "myapp_processed_ops_total",
+		Help: "The total number of processed events",
+	})
 )
 
 func main() {
-        recordMetrics()
+	recordMetrics()
 
-        http.Handle("/metrics", promhttp.Handler())
-        http.ListenAndServe(":2112", nil)
+	http.Handle("/metrics", promhttp.Handler())
+	http.ListenAndServe(":2112", nil)
 }
 ```
 


### PR DESCRIPTION
I was reading some of the instrumentation documentation and noticed the Go code was slightly off and awkward to read. This is just a small change that formats it using the Golang formatter, which is slightly more idiomatic. 