### PR TITLE
updating podman exporter link to github.com/containers/prometheus-pod…

### DIFF
--- a/content/docs/instrumenting/exporters.md
+++ b/content/docs/instrumenting/exporters.md
@@ -230,7 +230,7 @@ wide variety of JVM-based applications, for example [Kafka](http://kafka.apache.
    * [Pact Broker exporter](https://github.com/ContainerSolutions/pactbroker_exporter)
    * [PHP-FPM exporter](https://github.com/bakins/php-fpm-exporter)
    * [PowerDNS exporter](https://github.com/ledgr/powerdns_exporter)
-   * [Podman exporter](https://github.com/navidys/prometheus-podman-exporter)
+   * [Podman exporter](https://github.com/containers/prometheus-podman-exporter)
    * [Process exporter](https://github.com/ncabatoff/process-exporter)
    * [rTorrent exporter](https://github.com/mdlayher/rtorrent_exporter)
    * [Rundeck exporter](https://github.com/phsmith/rundeck_exporter)


### PR DESCRIPTION
Hi @RichiH
podman exporter has been migrated to [containers repository](https://github.com/containers). 
I have updated the the link which was previsouly merged with PR #2160 with the new one.

Thanks

Signed-off-by: Navid Yaghoobi <navidys@fedoraproject.org>

<!--
    Please sign CNCF's Developer Certificate of Origin and sign-off your commits by adding the -s / --sign-off flag to `git commit`

    More information on both of those can be found at https://github.com/apps/dco

    If you are proposing a new integration, exporter, or client library, please include representative sample output.
 -->
