### PR TITLE
Solve contradictive metrics naming recomendation

### DIFF
--- a/content/docs/practices/naming.md
+++ b/content/docs/practices/naming.md
@@ -58,8 +58,10 @@ Use labels to differentiate the characteristics of the thing that is being measu
  * `api_http_requests_total` - differentiate request types: `operation="create|update|delete"`
  * `api_request_duration_seconds` - differentiate request stages: `stage="extract|transform|load"`
 
-Do not put the label names in the metric name, as this introduces redundancy
-and will cause confusion if the respective labels are aggregated away.
+Do not put the label values in the metric name, as this introduces redundancy
+and will cause confusion if the respective labels are aggregated away. Still,
+it's allowed to coincide prefixes specific to application metrics with
+a non-instrumented label with the application name e.g. `job`.
 
 CAUTION: Remember that every unique combination of key-value label
 pairs represents a new time series, which can dramatically increase the amount


### PR DESCRIPTION
For metrics specific to an application it's recommended to put the application name as a prefix and for all metrics, it's recommended not to put labels into metrics names. After the discussion in the [issue](https://github.com/prometheus/docs/issues/2167) it appeared that for metrics specific to applications it's ok.

Besides that, the "Do not put the label **names** in the metric name" has been changed to "Do not put the label **values** in the metric name" that was probably just a typo.

Signed-off-by: Aleksey Bobyr <agat00@gmail.com>