### PR TITLE
New Relic Exporter new repository

### DIFF
--- a/content/docs/instrumenting/exporters.md
+++ b/content/docs/instrumenting/exporters.md
@@ -178,7 +178,7 @@ wide variety of JVM-based applications, for example [Kafka](http://kafka.apache.
    * [JMX exporter](https://github.com/prometheus/jmx_exporter) (**official**)
    * [Munin exporter](https://github.com/pvdh/munin_exporter)
    * [Nagios / Naemon exporter](https://github.com/Griesbacher/Iapetos)
-   * [New Relic exporter](https://github.com/mrf/newrelic_exporter)
+   * [New Relic exporter](https://github.com/corabank/newrelic_exporter)
    * [NRPE exporter](https://github.com/robustperception/nrpe_exporter)
    * [Osquery exporter](https://github.com/zwopir/osquery_exporter)
    * [OTC CloudEye exporter](https://github.com/tiagoReichert/otc-cloudeye-prometheus-exporter)


### PR DESCRIPTION
The actual exporter in the exporter page, was abbandoned and do not have chart to install the
exporter, and the exporter had a bug, that causes exporter terminated
by error in Kubernetes, we fixed this race condition and publish the
new exporter, with helm chart and image published at docker hub.

<!--
    Please sign CNCF's Developer Certificate of Origin and sign-off your commits by adding the -s / --sign-off flag to `git commit`

    More information on both of those can be found at https://github.com/apps/dco

    If you are proposing a new integration, exporter, or client library, please include representative sample output.
 -->
