### PR TITLE
Fix relative links in alerting tutorial

### DIFF
--- a/content/docs/tutorials/alerting_based_on_metrics.md
+++ b/content/docs/tutorials/alerting_based_on_metrics.md
@@ -8,11 +8,11 @@ sort_rank: 5
 In this tutorial we will create alerts on the `ping_request_count` metric that we instrumented earlier in the 
 [Instrumenting HTTP server written in Go](./instrumenting_http_server_in_go.md) tutorial.
 
-For the sake of this tutorial we will alert when the `ping_request_count` metric is greater than 5, Checkout real world [best practices](../practices/alerting) to learn more about alerting principles.
+For the sake of this tutorial we will alert when the `ping_request_count` metric is greater than 5, Checkout real world [best practices](../../practices/alerting) to learn more about alerting principles.
 
 Download the latest release of Alertmanager for your operating system from [here](https://github.com/prometheus/alertmanager/releases)
 
-Alertmanager supports various receivers like `email`, `webhook`, `pagerduty`, `slack` etc through which it can notify when an alert is firing. You can find the list of receivers and how to configure them [here](../alerting/latest/configuration). We will use `webhook` as a receiver for this tutorial, head over to [webhook.site](https://webhook.site) and copy the webhook URL which we will use later to configure the Alertmanager.
+Alertmanager supports various receivers like `email`, `webhook`, `pagerduty`, `slack` etc through which it can notify when an alert is firing. You can find the list of receivers and how to configure them [here](../../alerting/latest/configuration). We will use `webhook` as a receiver for this tutorial, head over to [webhook.site](https://webhook.site) and copy the webhook URL which we will use later to configure the Alertmanager.
 
 First let's setup Alertmanager with webhook receiver.
 


### PR DESCRIPTION
Links need to go up one more level.

Fixes: https://github.com/prometheus/docs/issues/2173

Signed-off-by: SuperQ <superq@gmail.com>

<!--
    Please sign CNCF's Developer Certificate of Origin and sign-off your commits by adding the -s / --sign-off flag to `git commit`

    More information on both of those can be found at https://github.com/apps/dco

    If you are proposing a new integration, exporter, or client library, please include representative sample output.
 -->
