### PR TITLE
Update README: remove obsolete/unnecessary command

### DIFF
--- a/README.md
+++ b/README.md
@@ -19,7 +19,6 @@ You need to have a working Ruby environment set up (including [bundler](https://
 and then install the necessary gems:
 
 ```bash
-cd docs
 make bundle
 ```
 


### PR DESCRIPTION
There's no `docs` folder in this repo. Maybe the `cd` command was meant to refer to this repo itself, but there's no other context in the README implying that we wouldn't already be in this repo to execute the command.