### PR TITLE
Gitignore core.* files

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -18,3 +18,5 @@ prometheus_rsa
 # Ruby artifacts
 .bundle/
 vendor/
+
+/core.*


### PR DESCRIPTION
Note sure what these files are, but they don't seem to be needed under version control. Local build causes a lot of them to be created:

```console
$ ls core.*
core.5096
...
core.5906
$ ls core.* | wc -l
103
```