### PR TITLE
Relace `ELK stack` with different solutions

### DIFF
--- a/content/docs/introduction/faq.md
+++ b/content/docs/introduction/faq.md
@@ -71,7 +71,7 @@ For cases where you must push, we offer the [Pushgateway](/docs/instrumenting/pu
 
 ### How to feed logs into Prometheus?
 
-Short answer: Don't! Use something like the [ELK stack](https://www.elastic.co/products) instead.
+Short answer: Don't! Use something like the [Elastic stack](https://www.elastic.co/products) instead.
 
 Longer answer: Prometheus is a system to collect and process metrics, not an
 event logging system. The Raintank blog post

--- a/content/docs/introduction/faq.md
+++ b/content/docs/introduction/faq.md
@@ -71,7 +71,7 @@ For cases where you must push, we offer the [Pushgateway](/docs/instrumenting/pu
 
 ### How to feed logs into Prometheus?
 
-Short answer: Don't! Use something like [Loki](https://grafana.com/oss/loki/) or [OpenSearch](https://opensearch.org/) instead.
+Short answer: Don't! Use something like [Grafana Loki](https://grafana.com/oss/loki/) or [OpenSearch](https://opensearch.org/) instead.
 
 Longer answer: Prometheus is a system to collect and process metrics, not an
 event logging system. The Raintank blog post

--- a/content/docs/introduction/faq.md
+++ b/content/docs/introduction/faq.md
@@ -71,7 +71,7 @@ For cases where you must push, we offer the [Pushgateway](/docs/instrumenting/pu
 
 ### How to feed logs into Prometheus?
 
-Short answer: Don't! Use something like the [Elastic stack](https://www.elastic.co/products) instead.
+Short answer: Don't! Use something like [Loki](https://grafana.com/oss/loki/) or [OpenSearch](https://opensearch.org/) instead.
 
 Longer answer: Prometheus is a system to collect and process metrics, not an
 event logging system. The Raintank blog post


### PR DESCRIPTION
ELK is legacy name, nowadays we should use Elastic stack instead - https://www.elastic.co/what-is/elk-stack.

<!--
    Please sign CNCF's Developer Certificate of Origin and sign-off your commits by adding the -s / --sign-off flag to `git commit`

    More information on both of those can be found at https://github.com/apps/dco

    If you are proposing a new integration, exporter, or client library, please include representative sample output.
 -->
