### PR TITLE
Switch to use of gtag.js library for analytics

### DIFF
--- a/layouts/footer.html
+++ b/layouts/footer.html
@@ -6,15 +6,14 @@
     <script src="/assets/docs.js"></script>
     <!-- IE10 viewport hack for Surface/desktop Windows 8 bug -->
     <script src="/assets/ie10-viewport-bug-workaround.js"></script>
-    <!-- Google Analytics -->
+    <!-- Global site tag (gtag.js) - Google Analytics -->
+    <script async src="https://www.googletagmanager.com/gtag/js?id=UA-58468480-1"></script>
     <script>
-      (function(i,s,o,g,r,a,m){i['GoogleAnalyticsObject']=r;i[r]=i[r]||function(){
-      (i[r].q=i[r].q||[]).push(arguments)},i[r].l=1*new Date();a=s.createElement(o),
-      m=s.getElementsByTagName(o)[0];a.async=1;a.src=g;m.parentNode.insertBefore(a,m)
-      })(window,document,'script','//www.google-analytics.com/analytics.js','ga');
+      window.dataLayer = window.dataLayer || [];
+      function gtag(){dataLayer.push(arguments);}
+      gtag('js', new Date());
 
-      ga('create', 'UA-58468480-1', 'auto');
-      ga('send', 'pageview');
+      gtag('config', 'UA-58468480-1');
     </script>
 
     <!-- Algolia Docsearch -->


### PR DESCRIPTION
- Contributes to #2181, a step towards using GA4
- Note that this PR only switches to using the [gtag.js] library.
  **The same UA property ID is used**. 
  By switching to use of [gtag.js], we enable [connected] site tags to work. In particular, the connection (forwarding) to the newly created GA4 site tag.

/cc @juliusv 

[connected]: https://support.google.com/analytics/answer/9973999
[gtag.js]: https://developers.google.com/analytics/devguides/collection/gtagjs