### PR TITLE
Histogram counts must include the +Inf bucket

### DIFF
--- a/content/docs/instrumenting/writing_clientlibs.md
+++ b/content/docs/instrumenting/writing_clientlibs.md
@@ -211,7 +211,7 @@ to designate buckets.
 
 A histogram MUST offer a way to manually choose the buckets. Ways to set
 buckets in a `linear(start, width, count)` and `exponential(start, factor,
-count)` fashion SHOULD be offered. Count MUST exclude the `+Inf` bucket.
+count)` fashion SHOULD be offered. Count MUST include the `+Inf` bucket.
 
 A histogram SHOULD have the same default buckets as other client libraries.
 Buckets MUST NOT be changeable once the metric is created.


### PR DESCRIPTION
The current documentaton for histograms says "Count MUST exclude the +Inf bucket". Looks like this is a type, client libraries include the +Inf buckets in the count. 

Signed-off-by: Fabian Stäber <fabian@fstab.de>

<!--
    Please sign CNCF's Developer Certificate of Origin and sign-off your commits by adding the -s / --sign-off flag to `git commit`

    More information on both of those can be found at https://github.com/apps/dco

    If you are proposing a new integration, exporter, or client library, please include representative sample output.
 -->
