### PR TITLE
Add various references to native histograms

### DIFF
--- a/content/docs/concepts/data_model.md
+++ b/content/docs/concepts/data_model.md
@@ -42,12 +42,18 @@ A label with an empty label value is considered equivalent to a label that does 
 See also the [best practices for naming metrics and labels](/docs/practices/naming/).
 
 ## Samples
+
 Samples form the actual time series data. Each sample consists of:
 
    * a float64 value
    * a millisecond-precision timestamp
 
+NOTE: Beginning with Prometheus v2.40, there is experimental support for native
+histograms. Instead of a simple float64, the sample value may now take the form
+of a full histogram.
+
 ## Notation
+
 Given a metric name and a set of labels, time series are frequently identified
 using this notation:
 

--- a/content/docs/concepts/metric_types.md
+++ b/content/docs/concepts/metric_types.md
@@ -68,6 +68,13 @@ remember that the histogram is
 [histograms and summaries](/docs/practices/histograms) for details of histogram
 usage and differences to [summaries](#summary).
 
+NOTE: Beginning with Prometheus v2.40, there is experimental support for native
+histograms. A native histogram requires only one time series, which includes a
+dynamic number of buckets in addition to the sum and count of
+observations. Native histograms allow much higher resolution at a fraction of
+the cost. Detailed documentation will follow once native histograms are closer
+to becoming a stable feature.
+
 Client library usage documentation for histograms:
 
    * [Go](http://godoc.org/github.com/prometheus/client_golang/prometheus#Histogram)

--- a/content/docs/instrumenting/exposition_formats.md
+++ b/content/docs/instrumenting/exposition_formats.md
@@ -10,12 +10,18 @@ exposition format. There are various [client libraries](/docs/instrumenting/clie
 that implement this format for you. If your preferred language doesn't have a client
 library you can [create your own](/docs/instrumenting/writing_clientlibs/).
 
-NOTE: Some earlier versions of Prometheus supported an exposition format based on
-[Protocol Buffers](https://developers.google.com/protocol-buffers/) (aka Protobuf) in
-addition to the current text-based format. As of version 2.0, however, Prometheus no
-longer supports the Protobuf-based format. You can read about the reasoning behind
-this change in [this
-document](https://github.com/OpenObservability/OpenMetrics/blob/main/legacy/markdown/protobuf_vs_text.md).
+NOTE: Some earlier versions of Prometheus supported an exposition format based
+on [Protocol Buffers](https://developers.google.com/protocol-buffers/) (aka
+Protobuf) in addition to the current text-based format. As of version 2.0,
+however, Prometheus no longer supports the Protobuf-based format. You can read
+about the reasoning behind this change in [this
+document](https://github.com/OpenObservability/OpenMetrics/blob/main/legacy/markdown/protobuf_vs_text.md). However,
+beginning with Prometheus v2.40, there is experimental support for native
+histograms, which – at least in its initial experimental state – utilizes the
+old Protobuf format (with some newer additions) again. Therefore, a very recent
+Prometheus server with the experimental native histogram support enabled, will
+again be able to ingest the Protobuf format. This support is experimental and
+might get removed again.
 
 ## Text-based format
 
@@ -170,3 +176,7 @@ To enable this experimental feature you must have at least version v2.26.0 and a
 For details on historical format versions, see the legacy
 [Client Data Exposition Format](https://docs.google.com/document/d/1ZjyKiKxZV83VI9ZKAXRGKaUKK2BIWCT7oiGBKDBpjEY/edit?usp=sharing)
 document.
+
+The current version of the original Protobuf format (with the recent extensions
+for native histograms) is maintained in the [prometheus/client_model
+repository](https://github.com/prometheus/client_model).

--- a/content/docs/practices/histograms.md
+++ b/content/docs/practices/histograms.md
@@ -3,6 +3,10 @@ title: Histograms and summaries
 sort_rank: 4
 ---
 
+NOTE: This document predates native histograms (added as an experimental
+feature in Prometheus v2.40). Once native histograms are closer to becoming a
+stable feature, this document will be thoroughly updated.
+
 # Histograms and summaries
 
 Histograms and summaries are more complex metric types. Not only does


### PR DESCRIPTION
This is not yet an exhaustive documentation. The changes here are mostly meant to avoid confusion.

Once native histograms are closer to becoming a stable feature, we will be able (and should) provide more detailed documentation.

Note that additional documentation is provided as part of the v2.40 release in the prometheus/prometheus repository.

(We should probably hold back merging this until at least a RC of v2.40 is available.)