### PR TITLE
add `nextdns-exporter` to list of exporters

### DIFF
--- a/content/docs/instrumenting/exporters.md
+++ b/content/docs/instrumenting/exporters.md
@@ -223,6 +223,7 @@ wide variety of JVM-based applications, for example [Kafka](http://kafka.apache.
    * [Meteor JS web framework exporter](https://atmospherejs.com/sevki/prometheus-exporter)
    * [Minecraft exporter module](https://github.com/Baughn/PrometheusIntegration)
    * [Minecraft exporter](https://github.com/dirien/minecraft-prometheus-exporter)
+   * [NextDNS exporter](https://github.com/raylas/nextdns-exporter)
    * [Nomad exporter](https://gitlab.com/yakshaving.art/nomad-exporter)
    * [nftables exporter](https://github.com/Intrinsec/nftables_exporter)
    * [OpenStack exporter](https://github.com/openstack-exporter/openstack-exporter)


### PR DESCRIPTION
Signed-off-by: Raymond Douglas <r@rymnd.org>

---

This is to add [nextdns-exporter](https://github.com/raylas/nextdns-exporter) to the list of exporters.

NextDNS exporter scrapes the [NextDNS](https://nextdns.io) API and surfaces DNS query data as Prometheus metrics.

### Sample output

```
# HELP nextdns_allowed_queries_total Total number of allowed queries.
# TYPE nextdns_allowed_queries_total gauge
nextdns_allowed_queries_total{profile="7vsf3s"} 0
# HELP nextdns_blocked_queries Number of blocked queries per domain.
# TYPE nextdns_blocked_queries gauge
nextdns_blocked_queries{domain="app-measurement.com",profile="7vsf3s",root="",tracker=""} 2
nextdns_blocked_queries{domain="metrics.icloud.com",profile="7vsf3s",root="icloud.com",tracker=""} 5
# HELP nextdns_blocked_queries_total Total number of blocked queries.
# TYPE nextdns_blocked_queries_total gauge
nextdns_blocked_queries_total{profile="7vsf3s"} 7
# HELP nextdns_destination_queries Number of queries per geographic destination.
# TYPE nextdns_destination_queries gauge
nextdns_destination_queries{code="AU",name="Australia",profile="7vsf3s"} 1
nextdns_destination_queries{code="DE",name="Germany",profile="7vsf3s"} 6
nextdns_destination_queries{code="IE",name="Ireland",profile="7vsf3s"} 1
nextdns_destination_queries{code="US",name="United States of America",profile="7vsf3s"} 101
[...]
```