### PR TITLE
Update understanding_metric_types.md

### DIFF
--- a/content/docs/tutorials/understanding_metric_types.md
+++ b/content/docs/tutorials/understanding_metric_types.md
@@ -3,7 +3,7 @@ title: Understanding metric types
 sort_rank: 2
 ---
 
-# Types of metrics.
+# Understanding metric types
 
 Prometheus supports four types of metrics, they are
     - Counter

--- a/content/docs/tutorials/understanding_metric_types.md
+++ b/content/docs/tutorials/understanding_metric_types.md
@@ -9,7 +9,9 @@ Prometheus supports four types of metrics, they are
     - Counter
     - Gauge
     - Histogram
-    - Summary 
+    - Summary
+
+Additional information and links to instrumentation libraries can be found at [Metric Types](/docs/concepts/metric_types/)
 
 ## Counter
 


### PR DESCRIPTION
1. Page markdown 'title' to match the link on the left (`title`). Not all pages do this, but most do and where they don't they're usually some extension of the link one the left (e.g. Visualization/Grafana -> "GRAFANA SUPPORT FOR PROMETHEUS")
2. Add link to the other page that documents the same information.

The two pages perhaps could be combined and conflated, but as a less review-heavy discoverability step, just linking from the later to the former.

Chose to link from this to the other, due to the _other_ being more recently updated.

Specifically discovered this problem given _this_ page did not link to the "choosing Summaries vs Histograms" page

Signed-off-by: andrewa-stripe <110132603+andrewa-stripe@users.noreply.github.com>
