### PR TITLE
Add LibreTranslate to list of software exporters

### DIFF
--- a/content/docs/instrumenting/exporters.md
+++ b/content/docs/instrumenting/exporters.md
@@ -284,6 +284,7 @@ separate exporters are needed:
    * [JavaMelody](https://github.com/javamelody/javamelody/wiki/UserGuideAdvanced#exposing-metrics-to-prometheus)
    * [Kong](https://github.com/Kong/kong-plugin-prometheus)
    * [Kubernetes](https://github.com/kubernetes/kubernetes) (**direct**)
+   * [LibreTranslate](https://github.com/LibreTranslate/LibreTranslate#prometheus-metrics)
    * [Linkerd](https://github.com/BuoyantIO/linkerd)
    * [mgmt](https://github.com/purpleidea/mgmt/blob/master/docs/prometheus.md)
    * [MidoNet](https://github.com/midonet/midonet)


### PR DESCRIPTION
Hello :wave:

Just thought of adding LibreTranslate to the list, which currently can export Prometheus metrics from a `/metrics` endpoint:

```
# HELP request_inprogress Multiprocess metric
# TYPE request_inprogress gauge
request_inprogress{api_key="",endpoint="/translate",request_ip="127.0.0.1"} 0.0
# HELP request_seconds Multiprocess metric
# TYPE request_seconds summary
request_seconds_count{api_key="",endpoint="/translate",request_ip="127.0.0.1",status="200"} 0.0
request_seconds_sum{api_key="",endpoint="/translate",request_ip="127.0.0.1",status="200"} 0.0
```
