### PR TITLE
Add prometheus weathermen exporter

### DIFF
--- a/content/docs/instrumenting/exporters.md
+++ b/content/docs/instrumenting/exporters.md
@@ -154,6 +154,7 @@ wide variety of JVM-based applications, for example [Kafka](http://kafka.apache.
    * [Rancher exporter](https://github.com/infinityworksltd/prometheus-rancher-exporter)
    * [Speedtest exporter](https://github.com/nlamirault/speedtest_exporter)
    * [Tankerkönig API Exporter](https://github.com/lukasmalkmus/tankerkoenig_exporter)
+   * [Prometheus Weathermen (multi API weather exporter)](https://github.com/lstrojny/prometheus-weathermen)
 
 ### Logging
    * [Fluentd exporter](https://github.com/V3ckt0r/fluentd_exporter)


### PR DESCRIPTION
A multi provider weather exporter written in Rust (https://github.com/lstrojny/prometheus-weathermen)

### Example output:
```
# HELP weather_temperature_celsius prometheus-weathermen temperature.
# TYPE weather_temperature_celsius gauge
# UNIT weather_temperature_celsius celsius
weather_temperature_celsius{version="0.3.0",source="de.dwd",location="Home",city="München-Stadt",latitude="…",longitude="…"} 8.399999618530274
weather_temperature_celsius{version="0.3.0",source="org.openweathermap",location="Home",city="Altstadt",latitude="…",longitude="…"} 7.1199951171875
# HELP weather_relative_humidity_ratio prometheus-weathermen relative humidity.
# TYPE weather_relative_humidity_ratio gauge
# UNIT weather_relative_humidity_ratio ratio
weather_relative_humidity_ratio{version="0.3.0",source="org.openweathermap",location="Home",city="Altstadt",latitude="…",longitude="…"} 0.6
weather_relative_humidity_ratio{version="0.3.0",source="de.dwd",location="Home",city="München-Stadt",latitude="…",longitude="…"} 0.522
# EOF
```