### PR TITLE
Update the description of HA for Alertmanager in faq.md 

### DIFF
--- a/content/docs/introduction/faq.md
+++ b/content/docs/introduction/faq.md
@@ -37,10 +37,7 @@ There are always trade-offs to make when running services, and Prometheus values
 Yes, run identical Prometheus servers on two or more separate machines.
 Identical alerts will be deduplicated by the [Alertmanager](https://github.com/prometheus/alertmanager).
 
-For [high availability of the Alertmanager](https://github.com/prometheus/alertmanager#high-availability),
-you can run multiple instances in a
-[Mesh cluster](https://github.com/weaveworks/mesh) and configure the Prometheus
-servers to send notifications to each of them.
+Alertmanager supports [high availability]((https://github.com/prometheus/alertmanager#high-availability)) by interconnecting multiple Alertmanager instances building an Alertmanager cluster. Instances of a cluster communicate on top of a gossip protocol managed via [Hashicorps Memberlist](https://github.com/hashicorp/memberlist) library. 
 
 ### I was told Prometheus “doesn't scale”.
 

--- a/content/docs/introduction/faq.md
+++ b/content/docs/introduction/faq.md
@@ -37,7 +37,7 @@ There are always trade-offs to make when running services, and Prometheus values
 Yes, run identical Prometheus servers on two or more separate machines.
 Identical alerts will be deduplicated by the [Alertmanager](https://github.com/prometheus/alertmanager).
 
-Alertmanager supports [high availability]((https://github.com/prometheus/alertmanager#high-availability)) by interconnecting multiple Alertmanager instances building an Alertmanager cluster. Instances of a cluster communicate on top of a gossip protocol managed via [Hashicorps Memberlist](https://github.com/hashicorp/memberlist) library. 
+Alertmanager supports [high availability](https://github.com/prometheus/alertmanager#high-availability) by interconnecting multiple Alertmanager instances building an Alertmanager cluster. Instances of a cluster communicate on top of a gossip protocol managed via [Hashicorps Memberlist](https://github.com/hashicorp/memberlist) library. 
 
 ### I was told Prometheus “doesn't scale”.
 

--- a/content/docs/introduction/faq.md
+++ b/content/docs/introduction/faq.md
@@ -37,7 +37,7 @@ There are always trade-offs to make when running services, and Prometheus values
 Yes, run identical Prometheus servers on two or more separate machines.
 Identical alerts will be deduplicated by the [Alertmanager](https://github.com/prometheus/alertmanager).
 
-Alertmanager supports [high availability](https://github.com/prometheus/alertmanager#high-availability) by interconnecting multiple Alertmanager instances building an Alertmanager cluster. Instances of a cluster communicate on top of a gossip protocol managed via [Hashicorps Memberlist](https://github.com/hashicorp/memberlist) library. 
+Alertmanager supports [high availability](https://github.com/prometheus/alertmanager#high-availability) by interconnecting multiple Alertmanager instances to build an Alertmanager cluster. Instances of a cluster communicate using a gossip protocol managed via [HashiCorp's Memberlist](https://github.com/hashicorp/memberlist) library. 
 
 ### I was told Prometheus “doesn't scale”.
 


### PR DESCRIPTION
The description of high availability for the Alertmanager was outdated.
It was written that weaveworks/mesh is used to implement the Gossip protocol, but I believe that hashicorps/memberlist is used to implement the Gossip protocol now.

