### PR TITLE
fix: exclude versions with build metadata from downloads

### DIFF
--- a/lib/helpers/download.rb
+++ b/lib/helpers/download.rb
@@ -82,7 +82,7 @@ module Downloads
     def releases
       stable_releases = []
       releases = []
-      @releases.select(&:version).sort.reverse.each do |r|
+      @releases.select{ |r| r.version && !r.version.build }.sort.reverse.each do |r|
         if r.prerelease
           releases << r if releases.empty?
         elsif @lts_releases.include?(r.major_minor) and not stable_releases.include?(r.major_minor)


### PR DESCRIPTION
This change ensures that only versions without build metadata are included in the list of available downloads on prometheus.io to prevent non-stable releases from being published on the main download page. For example, Prometheus 2.43.0-rc.1+stringlabels is excluded from the list of available downloads.

<!--
    Please sign CNCF's Developer Certificate of Origin and sign-off your commits by adding the -s / --sign-off flag to `git commit`

    More information on both of those can be found at https://github.com/apps/dco

    If you are proposing a new integration, exporter, or client library, please include representative sample output.
 -->
