### PR TITLE
feat: Add statuspage exporter to list of exporters

### DIFF
--- a/content/docs/instrumenting/exporters.md
+++ b/content/docs/instrumenting/exporters.md
@@ -186,7 +186,7 @@ wide variety of JVM-based applications, for example [Kafka](http://kafka.apache.
    * [Promitor (Azure Monitor)](https://promitor.io)
    * [scollector exporter](https://github.com/tgulacsi/prometheus_scollector)
    * [Sensu exporter](https://github.com/reachlin/sensu_exporter)
-   * [site24x7_exporer](https://github.com/svenstaro/site24x7_exporter)
+   * [site24x7_exporter](https://github.com/svenstaro/site24x7_exporter)
    * [SNMP exporter](https://github.com/prometheus/snmp_exporter) (**official**)
    * [StatsD exporter](https://github.com/prometheus/statsd_exporter) (**official**)
    * [TencentCloud monitor exporter](https://github.com/tencentyun/tencentcloud-exporter)

--- a/content/docs/instrumenting/exporters.md
+++ b/content/docs/instrumenting/exporters.md
@@ -186,11 +186,12 @@ wide variety of JVM-based applications, for example [Kafka](http://kafka.apache.
    * [Promitor (Azure Monitor)](https://promitor.io)
    * [scollector exporter](https://github.com/tgulacsi/prometheus_scollector)
    * [Sensu exporter](https://github.com/reachlin/sensu_exporter)
-   * [site24x7_exporter](https://github.com/svenstaro/site24x7_exporter)
+   * [site24x7_exporer](https://github.com/svenstaro/site24x7_exporter)
    * [SNMP exporter](https://github.com/prometheus/snmp_exporter) (**official**)
    * [StatsD exporter](https://github.com/prometheus/statsd_exporter) (**official**)
    * [TencentCloud monitor exporter](https://github.com/tencentyun/tencentcloud-exporter)
    * [ThousandEyes exporter](https://github.com/sapcc/1000eyes_exporter)
+   * [StatusPage exporter](https://github.com/sergeyshevch/statuspage-exporter)
 
 ### Miscellaneous
    * [ACT Fibernet Exporter](https://git.captnemo.in/nemo/prometheus-act-exporter)


### PR DESCRIPTION
<!--
    Please sign CNCF's Developer Certificate of Origin and sign-off your commits by adding the -s / --sign-off flag to `git commit`

    More information on both of those can be found at https://github.com/apps/dco

    If you are proposing a new integration, exporter, or client library, please include representative sample output.
 -->

Hello! I want to add my StatusPage exporter to the list of community exporters. 

This exporter allows the monitoring multiple external status pages using a multi-target exporter pattern. It already supports the 2 most used status page engines and more are in progress. 

For now it supported by me but also adopted by SRE team in my organization