### PR TITLE
Update remote write test suite url

### DIFF
--- a/content/docs/concepts/remote_write_spec.md
+++ b/content/docs/concepts/remote_write_spec.md
@@ -26,7 +26,7 @@ The remote write protocol contains opportunities for batching, e.g. sending mult
 
 The remote write protocol is not intended for use by applications to push metrics to Prometheus remote-write-compatible receivers.  It is intended that a Prometheus remote-write-compatible sender scrapes instrumented applications or exporters and sends remote write messages to a server.
 
-A test suite can be found at https://github.com/prometheus/compliance/tree/main/remote_write.
+A test suite can be found at https://github.com/prometheus/compliance/tree/main/remote_write_sender.
 
 ### Glossary
 


### PR DESCRIPTION
The remote write URL test suite in https://prometheus.io/docs/concepts/remote_write_spec/ is outdate. This PR fix does a one-liner fix to the updated URL. 