### PR TITLE
Add Alertmanager STOMP forwarder integration link

### DIFF
--- a/content/docs/operating/integrations.md
+++ b/content/docs/operating/integrations.md
@@ -97,6 +97,7 @@ For notification mechanisms not natively supported by the Alertmanager, the
   * [SIGNL4](https://www.signl4.com/blog/portfolio_item/prometheus-alertmanager-mobile-alert-notification-duty-schedule-escalation)
   * [SMS](https://github.com/messagebird/sachet): supports [multiple providers](https://github.com/messagebird/sachet/blob/master/examples/config.yaml)
   * [SNMP traps](https://github.com/maxwo/snmp_notifier)
+  * [STOMP](https://github.com/thewillyhuman/alertmanager-stomp-forwarder)
   * [Squadcast](https://support.squadcast.com/docs/prometheus)
   * [Telegram bot](https://github.com/inCaller/prometheus_bot)
   * [xMatters](https://github.com/xmatters/xm-labs-prometheus)


### PR DESCRIPTION
**Description:**
This pull request adds the STOMP integration to the documentation's integrations section. The STOMP integration allows users to forward alerts from the alertmanager system to a STOMP server using the [alertmanager-stomp-forwarder](https://github.com/thewillyhuman/alertmanager-stomp-forwarder) server.

**Changes made:**
Added a new link in the integration section with a link to the location of the repository with the forwarder.

Please @RichiH review and merge this pull request at your convenience. Thank you!