### PR TITLE
Make sure v2.45.0 LTS appears in a new line

### DIFF
--- a/content/docs/introduction/release-cycle.md
+++ b/content/docs/introduction/release-cycle.md
@@ -36,6 +36,8 @@ having a Prometheus server maintained by the community.
     <tbody>
         <tr>
             <td>Prometheus 2.37</td><td>2022-07-14</td><td>2023-07-31</td>
+        </tr>
+        <tr>
             <td>Prometheus 2.45</td><td>2023-06</td><td>2024-07-31</td>
         </tr>
     </tbody>


### PR DESCRIPTION
Attempting to fix this issue 
![image](https://github.com/prometheus/docs/assets/2439858/15ec525c-6c58-4fe9-a506-26694ccd976d)

My local preview of the changes shows 
![image](https://github.com/prometheus/docs/assets/2439858/81b00cc5-3585-4f6d-8c1d-98b8e2e11817)

