### PR TITLE
Add Pingmesh-exporter to exporters link

### DIFF
--- a/content/docs/instrumenting/exporters.md
+++ b/content/docs/instrumenting/exporters.md
@@ -183,6 +183,7 @@ wide variety of JVM-based applications, for example [Kafka](http://kafka.apache.
    * [Osquery exporter](https://github.com/zwopir/osquery_exporter)
    * [OTC CloudEye exporter](https://github.com/tiagoReichert/otc-cloudeye-prometheus-exporter)
    * [Pingdom exporter](https://github.com/giantswarm/prometheus-pingdom-exporter)
+   * [Pingmesh exporter](https://github.com/kubeservice-stack/pingmesh-agent)
    * [Promitor (Azure Monitor)](https://promitor.io)
    * [scollector exporter](https://github.com/tgulacsi/prometheus_scollector)
    * [Sensu exporter](https://github.com/reachlin/sensu_exporter)


### PR DESCRIPTION
<!--
    Please sign CNCF's Developer Certificate of Origin and sign-off your commits by adding the -s / --sign-off flag to `git commit`

    More information on both of those can be found at https://github.com/apps/dco

    If you are proposing a new integration, exporter, or client library, please include representative sample output.
 -->

### Description:
This pull request adds the [Pingmesh exporter](https://github.com/prometheus-community/helm-charts/blob/main/charts/prometheus-pingmesh-exporter/README.md) to the documentation's exporters section. The [Pingmesh exporter](https://github.com/kubeservice-stack/pingmesh-agent use for large-scale data center network latency measurement and analysis.

### Changes made:
Added a new link in the exporters section with a link to the location of the repository with the exporter.

