### PR TITLE
Fix link in alerting_based_on_metrics.md

### DIFF
--- a/content/docs/tutorials/alerting_based_on_metrics.md
+++ b/content/docs/tutorials/alerting_based_on_metrics.md
@@ -6,7 +6,7 @@ sort_rank: 5
 # Alerting based on metrics 
 
 In this tutorial we will create alerts on the `ping_request_count` metric that we instrumented earlier in the 
-[Instrumenting HTTP server written in Go](./instrumenting_http_server_in_go.md) tutorial.
+[Instrumenting HTTP server written in Go](./instrumenting_http_server_in_go/) tutorial.
 
 For the sake of this tutorial we will alert when the `ping_request_count` metric is greater than 5, Checkout real world [best practices](../../practices/alerting) to learn more about alerting principles.
 


### PR DESCRIPTION
This PR fixes the link to [Instrumenting HTTP server written in Go ](https://prometheus.io/docs/tutorials/instrumenting_http_server_in_go/)