### PR TITLE
Add LavinMQ to list of Prometheus exporters

### DIFF
--- a/content/docs/instrumenting/exporters.md
+++ b/content/docs/instrumenting/exporters.md
@@ -284,6 +284,7 @@ separate exporters are needed:
    * [JavaMelody](https://github.com/javamelody/javamelody/wiki/UserGuideAdvanced#exposing-metrics-to-prometheus)
    * [Kong](https://github.com/Kong/kong-plugin-prometheus)
    * [Kubernetes](https://github.com/kubernetes/kubernetes) (**direct**)
+   * [LavinMQ](https://lavinmq.com/)
    * [Linkerd](https://github.com/BuoyantIO/linkerd)
    * [mgmt](https://github.com/purpleidea/mgmt/blob/master/docs/prometheus.md)
    * [MidoNet](https://github.com/midonet/midonet)


### PR DESCRIPTION
Hello team 😊 
I would like to add LavinMQ to the list of Prometheus exporters. LavinMQ is a message broker built on [Crystal](https://crystal-lang.org/) and implements the [AMQP](https://www.amqp.org/specification/0-9-1/amqp-org-download) protocol.

LavinMQ collects broker metrics, formats it and bridges Prometheus and LavinMQ with an exporter endpoint, enabling seamless monitoring and metrics collection of your LavinMQ instances. 

Read more on the [LavinMQ Website](https://lavinmq.com/) or on [Github](https://github.com/cloudamqp/lavinmq)

Thank you very much, 
Christina & LavinMQ Team