### PR TITLE
Add recording rules to glossary

### DIFF
--- a/content/docs/introduction/glossary.md
+++ b/content/docs/introduction/glossary.md
@@ -78,6 +78,11 @@ The [Pushgateway](../../instrumenting/pushing/) persists the most recent push
 of metrics from batch jobs. This allows Prometheus to scrape their metrics
 after they have terminated.
 
+### Recording Rules
+
+Recording rules precompute frequently needed or computationally expensive expressions 
+and save their results as a new set of time series.
+
 ### Remote Read
 
 Remote read is a Prometheus feature that allows transparent reading of time series from


### PR DESCRIPTION
Added recording rules to glossary. This will provide a quick definition to a user wanting to know what a recording rule is without searching the docs. Also adding a link to navigate the user to the configuration > recording rules section could be helpful.

sign off by: Lasea75(khallai) <lasea75@gmail.com>

<!--
    Please sign CNCF's Developer Certificate of Origin and sign-off your commits by adding the -s / --sign-off flag to `git commit`

    More information on both of those can be found at https://github.com/apps/dco

    If you are proposing a new integration, exporter, or client library, please include representative sample output.
 -->
