### PR TITLE
Patch 1

### DIFF
--- a/content/docs/instrumenting/exposition_formats.md
+++ b/content/docs/instrumenting/exposition_formats.md
@@ -81,7 +81,7 @@ The remaining lines describe samples (one per line) using the following syntax
 ```
 metric_name [
   "{" label_name "=" `"` label_value `"` { "," label_name "=" `"` label_value `"` } [ "," ] "}"
-] value [ timestamp ]
+] value
 ```
 
 In the sample syntax:
@@ -89,7 +89,8 @@ In the sample syntax:
 *  `metric_name` and `label_name` carry the usual Prometheus expression language restrictions.
 * `label_value` can be any sequence of UTF-8 characters, but the backslash (`\`), double-quote (`"`), and line feed (`\n`) characters have to be escaped as `\\`, `\"`, and `\n`, respectively.
 * `value` is a float represented as required by Go's [`ParseFloat()`](https://golang.org/pkg/strconv/#ParseFloat) function. In addition to standard numerical values, `NaN`, `+Inf`, and `-Inf` are valid values representing not a number, positive infinity, and negative infinity, respectively.
-* The `timestamp` is an `int64` (milliseconds since epoch, i.e. 1970-01-01 00:00:00 UTC, excluding leap seconds), represented as required by Go's [`ParseInt()`](https://golang.org/pkg/strconv/#ParseInt) function.
+
+Timestamps are not supported.
 
 #### Grouping and sorting
 


### PR DESCRIPTION
Removed mention of user timestamps being supported, as they specifically are mentioned NOT to be, when use is attempted. If there is a way to use them, please document with example.

`
prometheus-node-exporter[1224]: ts=2023-09-04T07:14:27.714Z caller=textfile.go:219 level=error collector=textfile msg="failed to collect textfile data" file=test.prom err="textfile \"/var/lib/prometheus/node-exporter/junk.prom\" contains unsupported client-side timestamps, skipping entire file"
`