### PR TITLE
docs(exporters): add saml-exporter

### DIFF
--- a/content/docs/instrumenting/exporters.md
+++ b/content/docs/instrumenting/exporters.md
@@ -238,6 +238,7 @@ wide variety of JVM-based applications, for example [Kafka](http://kafka.apache.
    * [rTorrent exporter](https://github.com/mdlayher/rtorrent_exporter)
    * [Rundeck exporter](https://github.com/phsmith/rundeck_exporter)
    * [SABnzbd exporter](https://github.com/msroest/sabnzbd_exporter)
+   * [SAML exporter](https://github.com/DoodleScheduling/saml-exporter)
    * [Script exporter](https://github.com/adhocteam/script_exporter)
    * [Shield exporter](https://github.com/cloudfoundry-community/shield_exporter)
    * [Smokeping prober](https://github.com/SuperQ/smokeping_prober)


### PR DESCRIPTION
Adds a new [SAML exporter](https://github.com/DoodleScheduling/saml-exporter) to the list of exporters.

Sample metrics (more information pls see readme): 
```
# HELP go_gc_duration_seconds A summary of the pause duration of garbage collection cycles.
# TYPE go_gc_duration_seconds summary
go_gc_duration_seconds{quantile="0"} 3.3817e-05
go_gc_duration_seconds{quantile="0.25"} 4.7001e-05
go_gc_duration_seconds{quantile="0.5"} 5.5631e-05
go_gc_duration_seconds{quantile="0.75"} 7.6937e-05
go_gc_duration_seconds{quantile="1"} 0.000216885
go_gc_duration_seconds_sum 0.014780159
go_gc_duration_seconds_count 225
# HELP go_goroutines Number of goroutines that currently exist.
# TYPE go_goroutines gauge
go_goroutines 11
# HELP go_info Information about the Go environment.
# TYPE go_info gauge
go_info{version="go1.20.5"} 1
# HELP go_memstats_alloc_bytes Number of bytes allocated and still in use.
# TYPE go_memstats_alloc_bytes gauge
go_memstats_alloc_bytes 3.601032e+06
# HELP go_memstats_alloc_bytes_total Total number of bytes allocated, even if freed.
# TYPE go_memstats_alloc_bytes_total counter
go_memstats_alloc_bytes_total 3.23771776e+08
# HELP go_memstats_buck_hash_sys_bytes Number of bytes used by the profiling bucket hash table.
# TYPE go_memstats_buck_hash_sys_bytes gauge
go_memstats_buck_hash_sys_bytes 4483
# HELP go_memstats_frees_total Total number of frees.
# TYPE go_memstats_frees_total counter
go_memstats_frees_total 843649
# HELP go_memstats_gc_sys_bytes Number of bytes used for garbage collection system metadata.
# TYPE go_memstats_gc_sys_bytes gauge
go_memstats_gc_sys_bytes 8.136896e+06
# HELP go_memstats_heap_alloc_bytes Number of heap bytes allocated and still in use.
# TYPE go_memstats_heap_alloc_bytes gauge
go_memstats_heap_alloc_bytes 3.601032e+06
# HELP go_memstats_heap_idle_bytes Number of heap bytes waiting to be used.
# TYPE go_memstats_heap_idle_bytes gauge
go_memstats_heap_idle_bytes 5.603328e+06
# HELP go_memstats_heap_inuse_bytes Number of heap bytes that are in use.
# TYPE go_memstats_heap_inuse_bytes gauge
go_memstats_heap_inuse_bytes 5.701632e+06
# HELP go_memstats_heap_objects Number of allocated objects.
# TYPE go_memstats_heap_objects gauge
go_memstats_heap_objects 5533
# HELP go_memstats_heap_released_bytes Number of heap bytes released to OS.
# TYPE go_memstats_heap_released_bytes gauge
go_memstats_heap_released_bytes 4.554752e+06
# HELP go_memstats_heap_sys_bytes Number of heap bytes obtained from system.
# TYPE go_memstats_heap_sys_bytes gauge
go_memstats_heap_sys_bytes 1.130496e+07
# HELP go_memstats_last_gc_time_seconds Number of seconds since 1970 of last garbage collection.
# TYPE go_memstats_last_gc_time_seconds gauge
go_memstats_last_gc_time_seconds 1.6953856654497058e+09
# HELP go_memstats_lookups_total Total number of pointer lookups.
# TYPE go_memstats_lookups_total counter
go_memstats_lookups_total 0
# HELP go_memstats_mallocs_total Total number of mallocs.
# TYPE go_memstats_mallocs_total counter
go_memstats_mallocs_total 849182
# HELP go_memstats_mcache_inuse_bytes Number of bytes in use by mcache structures.
# TYPE go_memstats_mcache_inuse_bytes gauge
go_memstats_mcache_inuse_bytes 19200
# HELP go_memstats_mcache_sys_bytes Number of bytes used for mcache structures obtained from system.
# TYPE go_memstats_mcache_sys_bytes gauge
go_memstats_mcache_sys_bytes 31200
# HELP go_memstats_mspan_inuse_bytes Number of bytes in use by mspan structures.
# TYPE go_memstats_mspan_inuse_bytes gauge
go_memstats_mspan_inuse_bytes 265600
# HELP go_memstats_mspan_sys_bytes Number of bytes used for mspan structures obtained from system.
# TYPE go_memstats_mspan_sys_bytes gauge
go_memstats_mspan_sys_bytes 293760
# HELP go_memstats_next_gc_bytes Number of heap bytes when next garbage collection will take place.
# TYPE go_memstats_next_gc_bytes gauge
go_memstats_next_gc_bytes 5.6338e+06
# HELP go_memstats_other_sys_bytes Number of bytes used for other system allocations.
# TYPE go_memstats_other_sys_bytes gauge
go_memstats_other_sys_bytes 3.066989e+06
# HELP go_memstats_stack_inuse_bytes Number of bytes in use by the stack allocator.
# TYPE go_memstats_stack_inuse_bytes gauge
go_memstats_stack_inuse_bytes 1.277952e+06
# HELP go_memstats_stack_sys_bytes Number of bytes obtained from system for stack allocator.
# TYPE go_memstats_stack_sys_bytes gauge
go_memstats_stack_sys_bytes 1.277952e+06
# HELP go_memstats_sys_bytes Number of bytes obtained from system.
# TYPE go_memstats_sys_bytes gauge
go_memstats_sys_bytes 2.411624e+07
# HELP go_threads Number of OS threads created.
# TYPE go_threads gauge
go_threads 18
# HELP http_client_request_total HTTP client request
# TYPE http_client_request_total counter
http_client_request_total{code="200",host="sp-saml",method="GET"} 339
http_client_request_total{code="404",host="example-idp",method="GET"} 339
# HELP process_cpu_seconds_total Total user and system CPU time spent in seconds.
# TYPE process_cpu_seconds_total counter
process_cpu_seconds_total 1.83
# HELP process_max_fds Maximum number of open file descriptors.
# TYPE process_max_fds gauge
process_max_fds 1.048576e+06
# HELP process_open_fds Number of open file descriptors.
# TYPE process_open_fds gauge
process_open_fds 12
# HELP process_resident_memory_bytes Resident memory size in bytes.
# TYPE process_resident_memory_bytes gauge
process_resident_memory_bytes 1.7272832e+07
# HELP process_start_time_seconds Start time of the process since unix epoch in seconds.
# TYPE process_start_time_seconds gauge
process_start_time_seconds 1.69538028838e+09
# HELP process_virtual_memory_bytes Virtual memory size in bytes.
# TYPE process_virtual_memory_bytes gauge
process_virtual_memory_bytes 7.40368384e+08
# HELP process_virtual_memory_max_bytes Maximum amount of virtual memory available in bytes.
# TYPE process_virtual_memory_max_bytes gauge
process_virtual_memory_max_bytes 1.8446744073709552e+19
# HELP saml_exporter_build_info A metric with a constant '1' value labeled by version, revision, branch, goversion from which saml_exporter was built, and the goos and goarch for the build.
# TYPE saml_exporter_build_info gauge
saml_exporter_build_info{branch="HEAD",goarch="amd64",goos="linux",goversion="go1.20.5",revision="955f51a0cd38cb63410d084af6fe3917a6c614e5",tags="unknown",version="0.0.5"} 1
# HELP saml_metadata_error_total Errors encountered while parsing SAML metadata
# TYPE saml_metadata_error_total counter
saml_metadata_error_total{url="http://example-idp/auth/realms/myorg/protocol"} 339
# HELP saml_x509_cert_not_after SAML X509 certificate expiration date
# TYPE saml_x509_cert_not_after gauge
saml_x509_cert_not_after{entityid="https://example.com",issuer_C="GB",issuer_CN="Sectigo RSA Domain Validation Secure Server CA",issuer_L="Salford",issuer_O="Sectigo Limited",issuer_ST="",serial_number="180239923182331512058915631258885458281",subject_C="",subject_CN="example.com",subject_L="",subject_O="",use="encryption"} 1.670111999e+09
saml_x509_cert_not_after{entityid="https://example.com",issuer_C="GB",issuer_CN="Sectigo RSA Domain Validation Secure Server CA",issuer_L="Salford",issuer_O="Sectigo Limited",issuer_ST="",serial_number="180239923182331512058915631258885458281",subject_C="",subject_CN="example.com",subject_L="",subject_O="",use="signing"} 1.670111999e+09
saml_x509_cert_not_after{entityid="https://example.com",issuer_C="GB",issuer_CN="Sectigo RSA Domain Validation Secure Server CA",issuer_L="Salford",issuer_O="Sectigo Limited",issuer_ST="",serial_number="235049541137919265273350428180634803620",subject_C="",subject_CN="example.com",subject_L="",subject_O="",use="encryption"} 1.702598399e+09
saml_x509_cert_not_after{entityid="https://example.com",issuer_C="GB",issuer_CN="Sectigo RSA Domain Validation Secure Server CA",issuer_L="Salford",issuer_O="Sectigo Limited",issuer_ST="",serial_number="235049541137919265273350428180634803620",subject_C="",subject_CN="example.com",subject_L="",subject_O="",use="signing"} 1.702598399e+09
# HELP saml_x509_cert_not_before SAML X509 certificate validity period start
# TYPE saml_x509_cert_not_before gauge
saml_x509_cert_not_before{entityid="https://example.com",issuer_C="GB",issuer_CN="Sectigo RSA Domain Validation Secure Server CA",issuer_L="Salford",issuer_O="Sectigo Limited",issuer_ST="",serial_number="180239923182331512058915631258885458281",subject_C="",subject_CN="example.com",subject_L="",subject_O="",use="encryption"} 1.6370208e+09
saml_x509_cert_not_before{entityid="https://example.com",issuer_C="GB",issuer_CN="Sectigo RSA Domain Validation Secure Server CA",issuer_L="Salford",issuer_O="Sectigo Limited",issuer_ST="",serial_number="180239923182331512058915631258885458281",subject_C="",subject_CN="example.com",subject_L="",subject_O="",use="signing"} 1.6370208e+09
saml_x509_cert_not_before{entityid="https://example.com",issuer_C="GB",issuer_CN="Sectigo RSA Domain Validation Secure Server CA",issuer_L="Salford",issuer_O="Sectigo Limited",issuer_ST="",serial_number="235049541137919265273350428180634803620",subject_C="",subject_CN="example.com",subject_L="",subject_O="",use="encryption"} 1.670976e+09
saml_x509_cert_not_before{entityid="https://example.com",issuer_C="GB",issuer_CN="Sectigo RSA Domain Validation Secure Server CA",issuer_L="Salford",issuer_O="Sectigo Limited",issuer_ST="",serial_number="235049541137919265273350428180634803620",subject_C="",subject_CN="example.com",subject_L="",subject_O="",use="signing"} 1.670976e+09
```