### PR TITLE
Fix run go server

### DIFF
--- a/content/docs/tutorials/instrumenting_http_server_in_go.md
+++ b/content/docs/tutorials/instrumenting_http_server_in_go.md
@@ -115,7 +115,7 @@ Run the example
 ```sh
 go mod init prom_example
 go mod tidy
-go run main.go
+go run server.go
 ```
 
 Now hit the localhost:8090/ping endpoint a couple of times and sending a request to localhost:8090 will provide the metrics.

--- a/content/docs/tutorials/instrumenting_http_server_in_go.md
+++ b/content/docs/tutorials/instrumenting_http_server_in_go.md
@@ -31,7 +31,7 @@ Compile and run the server
 
 ```bash
 go build server.go
-./server.go
+./server
 ```
 
 Now open `http://localhost:8090/ping` in your browser and you must see `pong`.


### PR DESCRIPTION
Error executing:
```fish
$ ./server.go
fish: Unknown command. './server.go' exists but is not an executable file.
$ ls -l
total 12720
-rw-r--r--@ 1 joao  staff      175 Oct 14 12:04 go.mod
-rw-r--r--@ 1 joao  staff      499 Oct 14 12:04 go.sum
-rwxr-xr-x@ 1 joao  staff  6499714 Oct 14 12:11 server*
-rw-r--r--@ 1 joao  staff      209 Oct 14 12:10 server.go
```