### PR TITLE
Add 404 page and redirect path

### DIFF
--- a/content/_redirects
+++ b/content/_redirects
@@ -49,3 +49,6 @@
 
 # Blog post duplicated
 /blog/2021/05/14/prometheus-conformance-results/ /blog/2021/10/14/prometheus-conformance-results/ 302!
+
+# Custom 404 page for all nonexistent assets
+/*                          /docs/404/                                  404

--- a/content/docs/404.md
+++ b/content/docs/404.md
@@ -1,0 +1,17 @@
+---
+title: 404
+is_hidden: true
+---
+
+# 404
+
+## Oops! The page you requested could not be found.
+
+Here are a few things you can try:
+
+* Check the URL to make sure you typed it correctly.
+* Try searching for the page you're looking for in the documentation search bar.
+* Browse the documentation table of contents to see if you can find the page you're looking for.
+* If you're still having trouble, please contact us for assistance.
+
+Thank you for your patience.


### PR DESCRIPTION
Relates to prometheus#1795

still TODO: 
- add link to latest docs. 

This is what the page looks like when I run it:

![image](https://github.com/prometheus/docs/assets/13047598/103c5755-86b2-4a5b-bcc9-581ce1abb86b)

As this is my first contribution, I thought it would be a good idea to start the discussion by opening a PR. Hope this is ok, and look forward to some suggestions on how to improve.