### PR TITLE
Removed remote-write-receiver allowed values in enable-feature flag

### DIFF
--- a/content/blog/2021-11-16-agent.md
+++ b/content/blog/2021-11-16-agent.md
@@ -138,7 +138,7 @@ Flags:
       --storage.agent.path="data-agent/"
                                  Base path for metrics storage. Use with agent mode only.
       (... other flags)
-      --enable-feature= ...      Comma separated feature names to enable. Valid options: agent, exemplar-storage, expand-external-labels, memory-snapshot-on-shutdown, promql-at-modifier, promql-negative-offset, remote-write-receiver,
+      --enable-feature= ...      Comma separated feature names to enable. Valid options: agent, exemplar-storage, expand-external-labels, memory-snapshot-on-shutdown, promql-at-modifier, promql-negative-offset,
                                  extra-scrape-metrics, new-service-discovery-manager. See https://prometheus.io/docs/prometheus/latest/feature_flags/ for more details.
 ```
 


### PR DESCRIPTION
<!--
    Please sign CNCF's Developer Certificate of Origin and sign-off your commits by adding the -s / --sign-off flag to `git commit`

    More information on both of those can be found at https://github.com/apps/dco

    If you are proposing a new integration, exporter, or client library, please include representative sample output.
 -->

The `--enable-feature=remote-write-receiver` flag is deprecated and is going to be removed from Prometheus 3.0 and instead users should use `--web.enable-remote-write-receiver`.

Refs - https://github.com/prometheus/prometheus/issues/13206 https://github.com/prometheus/prometheus/pull/13435