### PR TITLE
Adds Heii On-Call to alert manager webhook provider integrations

### DIFF
--- a/content/docs/operating/integrations.md
+++ b/content/docs/operating/integrations.md
@@ -84,6 +84,7 @@ For notification mechanisms not natively supported by the Alertmanager, the
   * [GitLab](https://docs.gitlab.com/ee/operations/metrics/alerts.html#external-prometheus-instances)
   * [Gotify](https://github.com/DRuggeri/alertmanager_gotify_bridge)
   * [GELF](https://github.com/b-com-software-basis/alertmanager2gelf)
+  * [Heii On-Call](https://heiioncall.com/guides/prometheus-integration)
   * [Icinga2](https://github.com/vshn/signalilo)
   * [iLert](https://docs.ilert.com/integrations/prometheus)
   * [IRC Bot](https://github.com/multimfi/bot)


### PR DESCRIPTION
[Heii On-Call](https://heiioncall.com/) is a rotation management and alerting service. We implement the alert manager webhook receiver specification as a first class trigger type. This PR adds Heii On-Call to the list of supported integrations

![image](https://github.com/prometheus/docs/assets/587984/fbfa091d-8df8-4b0b-9d03-0cff15c6696d)

![image](https://github.com/prometheus/docs/assets/587984/f2b3a793-5ae8-40a6-9c97-1cda21628bf0)