### PR TITLE
Add Prefect2 exporter to list of miscellaneous exporters

### DIFF
--- a/content/docs/instrumenting/exporters.md
+++ b/content/docs/instrumenting/exporters.md
@@ -240,6 +240,7 @@ wide variety of JVM-based applications, for example [Kafka](http://kafka.apache.
    * [PHP-FPM exporter](https://github.com/bakins/php-fpm-exporter)
    * [PowerDNS exporter](https://github.com/ledgr/powerdns_exporter)
    * [Podman exporter](https://github.com/containers/prometheus-podman-exporter)
+   * [Prefect2 exporter](https://github.com/pathfinder177/prefect2-prometheus-exporter)
    * [Process exporter](https://github.com/ncabatoff/process-exporter)
    * [rTorrent exporter](https://github.com/mdlayher/rtorrent_exporter)
    * [Rundeck exporter](https://github.com/phsmith/rundeck_exporter)


### PR DESCRIPTION
Please add this new [exporter](https://github.com/pathfinder177/prefect2-prometheus-exporter) to exporter list. Please let me know if something missing, thanks.

Sample output:
```
# HELP prefect2_flows_runs_24h Prefect2 flows for 24h
# TYPE prefect2_flows_runs_24h gauge
prefect2_flows_runs_24h{state="FAILED"} 12.0
prefect2_flows_runs_24h{state="CANCELLED"} 0.0
prefect2_flows_runs_24h{state="CRASHED"} 0.0
```