### PR TITLE
docs: add greptimedb as a compatible prw receiver

### DIFF
--- a/content/docs/concepts/remote_write_spec.md
+++ b/content/docs/concepts/remote_write_spec.md
@@ -190,6 +190,7 @@ The spec is intended to describe how the following components interact:
 - [Cortex](https://github.com/cortexproject/cortex/blob/master/pkg/util/push/push.go#L20) (as a "receiver")
 - [Elastic Agent](https://docs.elastic.co/integrations/prometheus#prometheus-server-remote-write) (as a "receiver")
 - [Grafana Agent](https://github.com/grafana/agent) (as both a "sender" and a "receiver")
+- [GreptimeDB](https://github.com/greptimeTeam/greptimedb) (as a ["receiver"](https://docs.greptime.com/user-guide/write-data/prometheus#prometheus))
 - InfluxData’s Telegraf agent. ([as a sender](https://github.com/influxdata/telegraf/tree/master/plugins/serializers/prometheusremotewrite), and [as a receiver](https://github.com/influxdata/telegraf/pull/8967))
 - [M3](https://m3db.io/docs/integrations/prometheus/#prometheus-configuration) (as a "receiver")
 - [Mimir](https://github.com/grafana/mimir) (as a "receiver")

--- a/content/docs/operating/integrations.md
+++ b/content/docs/operating/integrations.md
@@ -49,6 +49,7 @@ data volumes.
   * [Google Cloud Spanner](https://github.com/google/truestreet): read and write
   * [Grafana Mimir](https://github.com/grafana/mimir): read and write
   * [Graphite](https://github.com/prometheus/prometheus/tree/main/documentation/examples/remote_storage/remote_storage_adapter): write
+  * [GreptimeDB](https://github.com/GreptimeTeam/greptimedb): read and write
   * [InfluxDB](https://docs.influxdata.com/influxdb/v1.8/supported_protocols/prometheus): read and write
   * [Instana](https://www.instana.com/docs/ecosystem/prometheus/#remote-write): write
   * [IRONdb](https://github.com/circonus-labs/irondb-prometheus-adapter): read and write


### PR DESCRIPTION
The patch adds [greptimedb](https://github.com/greptimeteam/greptimedb) as remote writer receiver.