### PR TITLE
Update link to the python custom exporter docs

### DIFF
--- a/content/docs/instrumenting/writing_exporters.md
+++ b/content/docs/instrumenting/writing_exporters.md
@@ -344,7 +344,7 @@ each scrape.
 Rather create new metrics each time. In Go this is done with
 [MustNewConstMetric](https://godoc.org/github.com/prometheus/client_golang/prometheus#MustNewConstMetric)
 in your `Collect()` method. For Python see
-[https://github.com/prometheus/client_python#custom-collectors](https://github.com/prometheus/client_python#custom-collectors)
+[https://github.com/prometheus/client_python#custom-collectors](https://prometheus.github.io/client_python/collector/custom/)
 and for Java generate a `List<MetricFamilySamples>` in your collect
 method, see
 [StandardExports.java](https://github.com/prometheus/client_java/blob/master/simpleclient_hotspot/src/main/java/io/prometheus/client/hotspot/StandardExports.java)


### PR DESCRIPTION
The docs for the python prometheus client have moved to https://prometheus.github.io/client_python

<!--
    Please sign CNCF's Developer Certificate of Origin and sign-off your commits by adding the -s / --sign-off flag to `git commit`

    More information on both of those can be found at https://github.com/apps/dco

    If you are proposing a new integration, exporter, or client library, please include representative sample output.
 -->
