### PR TITLE
Complete date for v2.45.0 in LTS information page

### DIFF
--- a/content/docs/introduction/release-cycle.md
+++ b/content/docs/introduction/release-cycle.md
@@ -38,7 +38,7 @@ having a Prometheus server maintained by the community.
             <td>Prometheus 2.37</td><td>2022-07-14</td><td>2023-07-31</td>
         </tr>
         <tr>
-            <td>Prometheus 2.45</td><td>2023-06</td><td>2024-07-31</td>
+            <td>Prometheus 2.45</td><td>2023-06-23</td><td>2024-07-31</td>
         </tr>
     </tbody>
 </table>


### PR DESCRIPTION
This simple PR updates the release date for v2.45.0 in the LTS information page.
Ref: <https://github.com/prometheus/prometheus/releases/tag/v2.45.0>