### PR TITLE
Add RDS exporter

### DIFF
--- a/content/docs/instrumenting/exporters.md
+++ b/content/docs/instrumenting/exporters.md
@@ -30,7 +30,9 @@ wide variety of JVM-based applications, for example [Kafka](http://kafka.apache.
 [Cassandra](http://cassandra.apache.org/).
 
 ### Databases
+
    * [Aerospike exporter](https://github.com/aerospike/aerospike-prometheus-exporter)
+   * [AWS RDS exporter](https://github.com/qonto/prometheus-rds-exporter)
    * [ClickHouse exporter](https://github.com/f1yegor/clickhouse_exporter)
    * [Consul exporter](https://github.com/prometheus/consul_exporter) (**official**)
    * [Couchbase exporter](https://github.com/blakelead/couchbase_exporter)


### PR DESCRIPTION
Please add this new [exporter](https://github.com/qonto/prometheus-rds-exporter/) to exporter list.
I added it in `database` section since it support multiple database engine running on AWS RDS service.

Please let me know if something missing, thanks.

Sample output:

```bash
# HELP rds_ca_certificate_valid_until Timestamp of the expiration of the RDS Certificate Authority
# TYPE rds_ca_certificate_valid_until gauge
rds_ca_certificate_valid_until{aws_account_id="truncated",aws_region="truncated",dbidentifier="pg1"} 1.72434653e+09
# HELP rds_cpu_usage_percent_average Instance CPU used
# TYPE rds_cpu_usage_percent_average gauge
rds_cpu_usage_percent_average{aws_account_id="truncated",aws_region="truncated",dbidentifier="pg1"} 47.15
# HELP rds_instance_info RDS instance information
# TYPE rds_instance_info gauge
rds_instance_info{aws_account_id="truncated",aws_region="truncated",ca_certificate_identifier="rds-ca-2019",dbi_resource_id="truncated",dbidentifier="truncated",deletion_protection="true",engine="postgres",engine_version="13.11",instance_class="db.t3.xlarge",multi_az="false",pending_maintenance="pending",pending_modified_values="false",performance_insights_enabled="true",role="replica",source_dbidentifier="truncated",storage_type="gp3"} 1
# HELP rds_free_storage_bytes Free storage on the instance
# TYPE rds_free_storage_bytes gauge
rds_free_storage_bytes{aws_account_id="truncated",aws_region="truncated",dbidentifier="pg1"} 4.5444841472e+10
# HELP rds_transaction_logs_disk_usage_bytes Disk space used by transaction logs (only on PostgreSQL)
# TYPE rds_transaction_logs_disk_usage_bytes gauge
rds_transaction_logs_disk_usage_bytes{aws_account_id="truncated",aws_region="truncated",dbidentifier="pg1"} 2.415927296e+09
# HELP rds_write_iops_average Average number of disk write I/O operations per second
# TYPE rds_write_iops_average gauge
rds_write_iops_average{aws_account_id="truncated",aws_region="truncated",dbidentifier="pg1"} 49.15573483573083
```