### PR TITLE
Add Prometheus.jl (Julia) to the list of unofficial clients

### DIFF
--- a/content/docs/instrumenting/clientlibs.md
+++ b/content/docs/instrumenting/clientlibs.md
@@ -30,6 +30,7 @@ Unofficial third-party client libraries:
 * [Elixir](https://github.com/deadtrickster/prometheus.ex)
 * [Erlang](https://github.com/deadtrickster/prometheus.erl)
 * [Haskell](https://github.com/fimad/prometheus-haskell)
+* [Julia](https://github.com/fredrikekre/Prometheus.jl)
 * [Lua](https://github.com/knyar/nginx-lua-prometheus) for Nginx
 * [Lua](https://github.com/tarantool/metrics) for Tarantool
 * [.NET / C#](https://github.com/prometheus-net/prometheus-net)


### PR DESCRIPTION
I authored a prometheus client for [Julia](https://julialang.org): [Prometheus.jl](https://github.com/fredrikekre/Prometheus.jl). This patch adds a link to this under the *Unofficial third-party client libraries* section.

(We use this client to monitor the package servers for the Julia ecosystem, sample output can be seen e.g. here: https://pkg.julialang.org/metrics).