### PR TITLE
Added "specification" section for specs as agreed in -team discussion.

### DIFF
--- a/content/_redirects
+++ b/content/_redirects
@@ -20,6 +20,9 @@
 /docs/alerting/notification_examples/       /docs/alerting/latest/notification_examples/
 /docs/alerting/management_api/              /docs/alerting/latest/management_api/
 
+# Moved RW spec from Concepts to a new section.
+/docs/concepts/remote_write_spec /docs/specs/remote_write_spec
+
 # Redirect for HTTP SD docs, which briefly lived in the wrong category / repo.
 /docs/instrumenting/http_sd/ /docs/prometheus/latest/http_sd/
 
@@ -31,6 +34,7 @@
 /docs/                      /docs/introduction/overview/                302!
 /docs/introduction/         /docs/introduction/overview/                302!
 /docs/concepts/             /docs/concepts/data_model/                  302!
+/docs/specs/                /docs/specs/remote_write_spec/              302!
 /docs/prometheus/           /docs/prometheus/latest/getting_started/    302!
 /docs/alerting/             /docs/alerting/latest/overview/             302!
 /docs/visualization/        /docs/visualization/browser/                302!

--- a/content/docs/specs/index.md
+++ b/content/docs/specs/index.md
@@ -1,5 +1,5 @@
 ---
 title: Specifications
-sort_rank: 2
-nav_icon: unlock
+sort_rank: 11
+nav_icon: file-text-o
 ---

--- a/content/docs/specs/index.md
+++ b/content/docs/specs/index.md
@@ -1,0 +1,5 @@
+---
+title: Specifications
+sort_rank: 2
+nav_icon: unlock
+---

--- a/content/docs/specs/remote_write_spec.md
+++ b/content/docs/specs/remote_write_spec.md
@@ -1,5 +1,5 @@
 ---
-title: Prometheus Remote-Write Specification
+title: Prometheus Remote-Write
 sort_rank: 4
 ---
 


### PR DESCRIPTION
This section will contain specs used by more projects than just Prometheus server e.g. RW protocols. 

Exposition formats are for now in https://prometheus.io/docs/introduction/overview/ but one idea is to mention those there but have full specs in this new section.

Used `unlock` icon - I like the intention of not-locking the ecosystem with OSS specs and standards. Also considered: `bullhorn` icon (important? announced loud?), `certificate` (kind of official, but icon does not look like cert really), `globe` (aka connecting the world) and `users` (aka connecting ppl).

I ensured https://prometheus.io/docs/concepts/remote_write_spec/ link still will works (check https://deploy-preview-2474--prometheus-docs.netlify.app/docs/concepts/remote_write_spec/)

![image](https://github.com/prometheus/docs/assets/6950331/65d7d757-4fb4-4c2e-903b-4499fde1028c)
