### PR TITLE
Rename "Alerting" to "Alertmanager"

### DIFF
--- a/content/docs/alerting/index.md
+++ b/content/docs/alerting/index.md
@@ -1,5 +1,5 @@
 ---
-title: Alerting
+title: Alert Manager
 sort_rank: 7
 nav_icon: bell-o
 ---


### PR DESCRIPTION
After #2473 finally reaming the "Prometheus" section to "Prometheus Server", I think we should also rename the top-level "Alerting" section to "Alertmanager". This section is just the embedded documentation from the Alertmanager repository, and it speaks volumes that the "Precise alerting" link on the landing page leads to https://prometheus.io/docs/prometheus/latest/configuration/alerting_rules/ rather than the so-called "Alerting" section.

In defense of the current section name, there is an "Alerting Overview" subsection that links to other places, but I think it's still better to call the whole section "Alertmanager', also because it makes it easier to find the actual Alertmanager documentation if you are looking specifically for it (rather than Alerting in general).

Final point: The first item if you expand the "Alerting" navbar is the selection of the Alertmanager version, which is also confusing if the title just above it just reads "Alerting".

<!--
    Please sign CNCF's Developer Certificate of Origin and sign-off your commits by adding the -s / --sign-off flag to `git commit`

    More information on both of those can be found at https://github.com/apps/dco

    If you are proposing a new integration, exporter, or client library, please include representative sample output.
 -->
