### PR TITLE
[PRW 2.0] (rc.1) Breaking change of io.prometheus.write.v2.Request for Receiver convenience.

### DIFF
--- a/content/docs/specs/remote_write_spec_2_0.md
+++ b/content/docs/specs/remote_write_spec_2_0.md
@@ -201,7 +201,7 @@ The simplified version of the new `io.prometheus.write.v2.Request` is presented 
 // Request represents a request to write the given timeseries to a remote destination.
 message Request {
   // Since Request supersedes 1.0 spec's prometheus.WriteRequest, we reserve the top-down message
-  // for the deterministic interop between those two, see types_test.go for details.
+  // for the deterministic interop between those two.
   // Generally it's not needed, because Receivers must use the Content-Type header, but we want to
   // be sympathetic to adopters with mistaken implementations and have deterministic error (empty
   // message if you use the wrong proto schema).


### PR DESCRIPTION
See rationales in https://github.com/prometheus/prometheus/pull/14330

Sucks to make breaking change, but I just merged the rc.0 a few hours ago, so I think it's fine. If it would be weeks we would probably NOT do this change.