### PR TITLE
Add extra-scrape-metrics to jobs and instances

### DIFF
--- a/content/docs/concepts/jobs_instances.md
+++ b/content/docs/concepts/jobs_instances.md
@@ -44,3 +44,9 @@ the following time series:
    the approximate number of new series in this scrape. *New in v2.10*
 
 The `up` time series is useful for instance availability monitoring.
+
+With the [`extra-scrape-metrics` feature flag](/docs/prometheus/latest/feature_flags/#extra-scrape-metrics) several addditonal metrics are available:
+
+* `scrape_timeout_seconds{job="<job-name>", instance="<instance-id>"}`: The configured `scrape_timeout` for a target.
+* `scrape_sample_limit{job="<job-name>", instance="<instance-id>"}`: The configured `sample_limit` for a target. Returns zero if there is no limit configured.
+* `scrape_body_size_bytes{job="<job-name>", instance="<instance-id>"}`: The uncompressed size of the most recent scrape response, if successful. Scrapes failing because `body_size_limit` is exceeded report -1, other scrape failures report 0.


### PR DESCRIPTION
Include documentation about the `extra-scrape-metrics` metrics feature flag as additional cross-reference docmentation.

<!--
    Please sign CNCF's Developer Certificate of Origin and sign-off your commits by adding the -s / --sign-off flag to `git commit`

    More information on both of those can be found at https://github.com/apps/dco

    If you are proposing a new integration, exporter, or client library, please include representative sample output.
 -->
