### PR TITLE
Correct release date for 2.53

### DIFF
--- a/content/docs/introduction/release-cycle.md
+++ b/content/docs/introduction/release-cycle.md
@@ -41,7 +41,7 @@ having a Prometheus server maintained by the community.
             <td>Prometheus 2.45</td><td>2023-06-23</td><td>2024-07-31</td>
         </tr>
         <tr class="success">
-            <td>Prometheus 2.53</td><td>2024-07-01</td><td>2025-07-31</td>
+            <td>Prometheus 2.53</td><td>2024-06-16</td><td>2025-07-31</td>
         </tr>
     </tbody>
 </table>


### PR DESCRIPTION
2024-06-19 based on https://groups.google.com/g/prometheus-announce/c/NdiVkFJUN0c and https://github.com/prometheus/prometheus/releases/tag/v2.53.0
