### PR TITLE
Remote Write defaults have increased

### DIFF
--- a/content/docs/practices/remote_write.md
+++ b/content/docs/practices/remote_write.md
@@ -44,14 +44,15 @@ In addition to the series cache, each shard and its queue increases memory
 usage. Shard memory is proportional to the `number of shards * (capacity +
 max_samples_per_send)`. When tuning, consider reducing `max_shards` alongside
 increases to `capacity` and `max_samples_per_send` to avoid inadvertently
-running out of memory. The default values for `capacity: 2500` and
-`max_samples_per_send: 500` will constrain shard memory usage to less than 500
-kB per shard.
+running out of memory. The default values for `capacity: 10000` and
+`max_samples_per_send: 2000` will constrain shard memory usage to less than 2
+MB per shard.
 
 Remote write will also increase CPU and network usage. However, for the same
 reasons as above, it is difficult to predict by how much. It is generally a
 good practice to check for CPU and network saturation if your Prometheus server
-falls behind sending samples via remote write.
+falls behind sending samples via remote write
+(`prometheus_remote_storage_samples_pending`).
 
 ## Parameters
 


### PR DESCRIPTION
Note that I multiplied the old "500 kB" figure by 4, keeping the same "200 bytes per sample" -- but I'm not sure where that number comes from.

The increased defaults are from prometheus/prometheus@889ef998f4f73d0d1fbd961e59494584e3616e42

Added breadcrumb to `prometheus_remote_storage_samples_pending` metric.