### PR TITLE
chore: add a storage exporter to docs

### DIFF
--- a/content/docs/instrumenting/exporters.md
+++ b/content/docs/instrumenting/exporters.md
@@ -124,6 +124,7 @@ wide variety of JVM-based applications, for example [Kafka](http://kafka.apache.
    * [Pure Storage exporter](https://github.com/PureStorage-OpenConnect/pure-exporter)
    * [ScaleIO exporter](https://github.com/syepes/sio2prom)
    * [Tivoli Storage Manager/IBM Spectrum Protect exporter](https://github.com/treydock/tsm_exporter)
+   * [Azure storage usage exporter](https://github.com/PDOK/azure-storage-usage-exporter)
 
 ### HTTP
    * [Apache exporter](https://github.com/Lusitaniae/apache_exporter)


### PR DESCRIPTION
add a storage exporter to docs

sample output: https://github.com/PDOK/azure-storage-usage-exporter?tab=readme-ov-file#example-metrics-output