### PR TITLE
fix(instrumenting): Fix link to python pushgateway docs

### DIFF
--- a/content/docs/instrumenting/pushing.md
+++ b/content/docs/instrumenting/pushing.md
@@ -21,7 +21,7 @@ class.
 
  * For use from Go see the [Push](https://godoc.org/github.com/prometheus/client_golang/prometheus/push#Pusher.Push) and [Add](https://godoc.org/github.com/prometheus/client_golang/prometheus/push#Pusher.Add) methods.
 
- * For use from Python see [Exporting to a Pushgateway](https://github.com/prometheus/client_python#exporting-to-a-pushgateway).
+ * For use from Python see [Exporting to a Pushgateway](https://prometheus.github.io/client_python/exporting/pushgateway/).
 
  * For use from Ruby see the [Pushgateway documentation](https://github.com/prometheus/client_ruby#pushgateway).
 


### PR DESCRIPTION
The Link to the Python docs in the Pushgateway Section of the docs seems to be outdated. It used to point to a specific heading in the readme of the python client, but it seems that project has since moved to a dedicated documentation website. This PR addresses this by using the new Link.

Note: I'm not sure whether this is the exact location that it used to point to, but I think the connection makes sense this way.