### PR TITLE
chore(exporters): Adds SQS exporter

### DIFF
--- a/content/docs/instrumenting/exporters.md
+++ b/content/docs/instrumenting/exporters.md
@@ -140,6 +140,7 @@ wide variety of JVM-based applications, for example [Kafka](http://kafka.apache.
    * [AWS ECS exporter](https://github.com/slok/ecs-exporter)
    * [AWS Health exporter](https://github.com/Jimdo/aws-health-exporter)
    * [AWS SQS exporter](https://github.com/jmal98/sqs_exporter)
+   * [AWS SQS Prometheus exporter](https://github.com/jmriebold/sqs-prometheus-exporter)
    * [Azure Health exporter](https://github.com/FXinnovation/azure-health-exporter)
    * [BigBlueButton](https://github.com/greenstatic/bigbluebutton-exporter)
    * [Cloudflare exporter](https://gitlab.com/gitlab-org/cloudflare_exporter)


### PR DESCRIPTION
This adds a link to a second (Golang-based) SQS exporter to the exporters page.