### PR TITLE
Update exporters.md - Fix Repojacking in Prometheus Exporters

### DIFF
--- a/content/docs/instrumenting/exporters.md
+++ b/content/docs/instrumenting/exporters.md
@@ -129,10 +129,10 @@ wide variety of JVM-based applications, for example [Kafka](http://kafka.apache.
    * [Apache exporter](https://github.com/Lusitaniae/apache_exporter)
    * [HAProxy exporter](https://github.com/prometheus/haproxy_exporter) (**official**)
    * [Nginx metric library](https://github.com/knyar/nginx-lua-prometheus)
-   * [Nginx VTS exporter](https://github.com/hnlq715/nginx-vts-exporter)
+   * [Nginx VTS exporter](https://github.com/sysulq/nginx-vts-exporter)
    * [Passenger exporter](https://github.com/stuartnelson3/passenger_exporter)
    * [Squid exporter](https://github.com/boynux/squid-exporter)
-   * [Tinyproxy exporter](https://github.com/igzivkov/tinyproxy_exporter)
+   * [Tinyproxy exporter](https://github.com/gmm42/tinyproxy_exporter)
    * [Varnish exporter](https://github.com/jonnenauha/prometheus_varnish_exporter)
    * [WebDriver exporter](https://github.com/mattbostock/webdriver_exporter)
 
@@ -145,8 +145,8 @@ wide variety of JVM-based applications, for example [Kafka](http://kafka.apache.
    * [Cloudflare exporter](https://gitlab.com/gitlab-org/cloudflare_exporter)
    * [Cryptowat exporter](https://github.com/nbarrientos/cryptowat_exporter)
    * [DigitalOcean exporter](https://github.com/metalmatze/digitalocean_exporter)
-   * [Docker Cloud exporter](https://github.com/infinityworksltd/docker-cloud-exporter)
-   * [Docker Hub exporter](https://github.com/infinityworksltd/docker-hub-exporter)
+   * [Docker Cloud exporter](https://github.com/infinityworks/docker-cloud-exporter)
+   * [Docker Hub exporter](https://github.com/infinityworks/docker-hub-exporter)
    * [Fastly exporter](https://github.com/peterbourgon/fastly-exporter)
    * [GitHub exporter](https://github.com/githubexporter/github-exporter)
    * [Gmail exporter](https://github.com/jamesread/prometheus-gmail-exporter/)
@@ -154,7 +154,7 @@ wide variety of JVM-based applications, for example [Kafka](http://kafka.apache.
    * [Mozilla Observatory exporter](https://github.com/Jimdo/observatory-exporter)
    * [OpenWeatherMap exporter](https://github.com/RichiH/openweathermap_exporter)
    * [Pagespeed exporter](https://github.com/foomo/pagespeed_exporter)
-   * [Rancher exporter](https://github.com/infinityworksltd/prometheus-rancher-exporter)
+   * [Rancher exporter](https://github.com/infinityworks/prometheus-rancher-exporter)
    * [Speedtest exporter](https://github.com/nlamirault/speedtest_exporter)
    * [Tankerkönig API Exporter](https://github.com/lukasmalkmus/tankerkoenig_exporter)
 
@@ -164,9 +164,9 @@ wide variety of JVM-based applications, for example [Kafka](http://kafka.apache.
    * [Grok exporter](https://github.com/fstab/grok_exporter)
 
 ### FinOps
-   * [AWS Cost Exporter](https://github.com/opensourceelectrolux/aws-cost-exporter)
-   * [Azure Cost Exporter](https://github.com/opensourceelectrolux/azure-cost-exporter)
-   * [Kubernetes Cost Exporter](https://github.com/opensourceelectrolux/kubernetes-cost-exporter)
+   * [AWS Cost Exporter](https://github.com/electrolux-oss/aws-cost-exporter)
+   * [Azure Cost Exporter](https://github.com/electrolux-oss/azure-cost-exporter)
+   * [Kubernetes Cost Exporter](https://github.com/electrolux-oss/kubernetes-cost-exporter)
 
 ### Other monitoring systems
    * [Akamai Cloudmonitor exporter](https://github.com/ExpressenAB/cloudmonitor_exporter)


### PR DESCRIPTION
Repojacking is a security vulnerability that occurs when an attacker takes control of a repository name that was previously owned by another user or organization. This typically happens when the original owner deletes or renames their repository. If this repository is still referenced by other projects, an attacker can create a new repository with the same name, introducing malicious code that could be executed by those relying on the original repository link.
In Prometheus's case, several exporters listed on Prometheus's official documentation could be claimed by an attacker. The attacker could create a repository with the old username and project name, potentially hosting a malicious exporter. 

For example, currently, when a user clicks on the "aws-cost-exporter" link, GitHub redirects them to https://github.com/electrolux-oss/aws-cost-exporter, even though the original link points to https://github.com/opensourceelectrolux/aws-cost-exporter. Since the username "opensourceelectrolux" is available for claim, an attacker could take over this username and host a malicious exporter under https://github.com/opensourceelectrolux/aws-cost-exporter. 

This PR updates the links to ensure they point to trusted sources.
<!--
    Please sign CNCF's Developer Certificate of Origin and sign-off your commits by adding the -s / --sign-off flag to `git commit`

    More information on both of those can be found at https://github.com/apps/dco

    If you are proposing a new integration, exporter, or client library, please include representative sample output.
 -->

Thanks,
Yakir Kadkoda @yakirk 
Ofek Itach @Ofekitach

