### PR TITLE
otlp: add note about otlp receiver being available in versions >= 3.x

### DIFF
--- a/content/docs/guides/opentelemetry.md
+++ b/content/docs/guides/opentelemetry.md
@@ -67,6 +67,8 @@ otlp:
     - ...
 ```
 
+NOTE: This feature is not available in Prometheus 1.x and 2.x, consider upgrading to 3.x or include resource attributes at query time
+
 ## Including resource attributes at query time
 
 An alternative to promoting resource attributes, as described in the previous section, is to add labels from the `target_info` metric when querying.


### PR DESCRIPTION
Adds a note in the OpenTelemetry guide about the OTLP receiver being available only in the 3.x version.

I was trying it and it kept failing, when checking the prometheus changelogs and noticed it was only available in the `v3.0.0-beta.0` version. As most people are running 2.x, a note about it is useful.

Signed-off-by: Matheus Nogueira <matheus.nogueira2008@gmail.com>

<!--
    Please sign CNCF's Developer Certificate of Origin and sign-off your commits by adding the -s / --sign-off flag to `git commit`

    More information on both of those can be found at https://github.com/apps/dco

    If you are proposing a new integration, exporter, or client library, please include representative sample output.
 -->
