### PR TITLE
Only consider non-draft releases for downloads page

### DIFF
--- a/lib/helpers/download.rb
+++ b/lib/helpers/download.rb
@@ -99,7 +99,7 @@ module Downloads
 
     def self.load(dir)
       repo = JSON.parse(File.read(File.join(dir, 'repo.json')))
-      releases = JSON.parse(File.read(File.join(dir, 'releases.json')))
+      releases = JSON.parse(File.read(File.join(dir, 'releases.json'))).reject { |r| r['draft'] }
       lts_releases = YAML.load_file('lts.yml').fetch(File.basename(dir), [])
       new(repo, releases: releases.map { |r| Release.new(r) }, lts_releases: lts_releases)
     end


### PR DESCRIPTION
Currently the Makefile uses authenticated GitHub accesses to download a JSON containing *all* releases (since we're authenticated), including draft ones.

The script that then assembles the downloads page tries to also download the checksums for those draft releases, which fails with a 404 if you are not authenticated (and we probably don't want to show these anyway).

Interestingly the build works on Netlify anyway. Probably the GitHub API token used there doesn't actually have the rights to see draft releases on the Prometheus org. But it still produces build errors for people building the site locally with their own GitHub access token.

<!--
    Please sign CNCF's Developer Certificate of Origin and sign-off your commits by adding the -s / --sign-off flag to `git commit`

    More information on both of those can be found at https://github.com/apps/dco

    If you are proposing a new integration, exporter, or client library, please include representative sample output.
 -->
