### PR TITLE
Fix links to java client documentation

### DIFF
--- a/content/docs/concepts/metric_types.md
+++ b/content/docs/concepts/metric_types.md
@@ -25,7 +25,7 @@ use a counter for the number of currently running processes; instead use a gauge
 Client library usage documentation for counters:
 
    * [Go](http://godoc.org/github.com/prometheus/client_golang/prometheus#Counter)
-   * [Java](https://github.com/prometheus/client_java#counter)
+   * [Java](https://prometheus.github.io/client_java/getting-started/metric-types/#counter)
    * [Python](https://prometheus.github.io/client_python/instrumenting/counter/)
    * [Ruby](https://github.com/prometheus/client_ruby#counter)
    * [.Net](https://github.com/prometheus-net/prometheus-net#counters)
@@ -42,7 +42,7 @@ concurrent requests.
 Client library usage documentation for gauges:
 
    * [Go](http://godoc.org/github.com/prometheus/client_golang/prometheus#Gauge)
-   * [Java](https://github.com/prometheus/client_java#gauge)
+   * [Java](https://prometheus.github.io/client_java/getting-started/metric-types/#gauge)
    * [Python](https://prometheus.github.io/client_python/instrumenting/gauge/)
    * [Ruby](https://github.com/prometheus/client_ruby#gauge)
    * [.Net](https://github.com/prometheus-net/prometheus-net#gauges)
@@ -80,7 +80,7 @@ to becoming a stable feature.
 Client library usage documentation for histograms:
 
    * [Go](http://godoc.org/github.com/prometheus/client_golang/prometheus#Histogram)
-   * [Java](https://github.com/prometheus/client_java#histogram)
+   * [Java](https://prometheus.github.io/client_java/getting-started/metric-types/#histogram)
    * [Python](https://prometheus.github.io/client_python/instrumenting/histogram/)
    * [Ruby](https://github.com/prometheus/client_ruby#histogram)
    * [.Net](https://github.com/prometheus-net/prometheus-net#histogram)
@@ -106,7 +106,7 @@ to [histograms](#histogram).
 Client library usage documentation for summaries:
 
    * [Go](http://godoc.org/github.com/prometheus/client_golang/prometheus#Summary)
-   * [Java](https://github.com/prometheus/client_java#summary)
+   * [Java](https://prometheus.github.io/client_java/getting-started/metric-types/#summary)
    * [Python](https://prometheus.github.io/client_python/instrumenting/summary/)
    * [Ruby](https://github.com/prometheus/client_ruby#summary)
    * [.Net](https://github.com/prometheus-net/prometheus-net#summary)

--- a/content/docs/introduction/faq.md
+++ b/content/docs/introduction/faq.md
@@ -181,7 +181,7 @@ either standalone or as a Java Agent.
 ### What is the performance impact of instrumentation?
 
 Performance across client libraries and languages may vary. For Java,
-[benchmarks](https://github.com/prometheus/client_java/blob/master/benchmarks/README.md)
+[benchmarks](https://github.com/prometheus/client_java/blob/main/benchmarks/README.md)
 indicate that incrementing a counter/gauge with the Java client will take
 12-17ns, depending on contention. This is negligible for all but the most
 latency-critical code.

--- a/content/docs/practices/instrumentation.md
+++ b/content/docs/practices/instrumentation.md
@@ -245,7 +245,7 @@ inside a given process, you may wish to take some care as to how many metrics
 you update.
 
 A Java counter takes
-[12-17ns](https://github.com/prometheus/client_java/blob/master/benchmark/README.md)
+[12-17ns](https://github.com/prometheus/client_java/blob/main/benchmarks/README.md)
 to increment depending on contention. Other languages will have similar
 performance. If that amount of time is significant for your inner loop, limit
 the number of metrics you increment in the inner loop and avoid labels (or


### PR DESCRIPTION
I noticed some of these links were not working since the java client has moved their documentation from GitHub to their new docs site.

There are still 2 broken links that I did not fix in this PR because I could not find the corresponding new file.

https://github.com/prometheus/docs/blob/main/content/docs/instrumenting/writing_exporters.md?plain=1#L350

and

https://github.com/prometheus/docs/blob/main/content/docs/instrumenting/writing_exporters.md?plain=1#L387

But I figured it wouldn't hurt to make a PR for the ones that were trivial to fix!

I believe the `CONTRIBUTING.md` is asking me to ping the maintainers of the java client since the docs relate to their project, so @fstab @dhoard @tomwilkie