### PR TITLE
Fix "Alert Manager" -> "Alertmanager" spelling in nav menu

### DIFF
--- a/content/docs/alerting/index.md
+++ b/content/docs/alerting/index.md
@@ -1,5 +1,5 @@
 ---
-title: Alert Manager
+title: Alertmanager
 sort_rank: 7
 nav_icon: bell-o
 ---


### PR DESCRIPTION
We've always used the single word version everywhere else, and it's kind of the brand now. The comment in https://github.com/prometheus/docs/pull/2476 also mentions in the intent to name it "Alertmanager", but then named it "Alert Manager" (accidentally?).

<!--
    Please sign CNCF's Developer Certificate of Origin and sign-off your commits by adding the -s / --sign-off flag to `git commit`

    More information on both of those can be found at https://github.com/apps/dco

    If you are proposing a new integration, exporter, or client library, please include representative sample output.
 -->
