### PR TITLE
Clarify internal usage of empty label values by federation

### DIFF
--- a/content/docs/specs/remote_write_spec.md
+++ b/content/docs/specs/remote_write_spec.md
@@ -128,6 +128,8 @@ Label names beginning with "__" are RESERVED for system usage and SHOULD NOT be 
 
 Remote write Receivers MAY ingest valid samples within a write request that otherwise contains invalid samples. Receivers MUST return a HTTP 400 status code ("Bad Request") for write requests that contain any invalid samples. Receivers SHOULD provide a human readable error message in the response body. Senders MUST NOT try and interpret the error message, and SHOULD log it as is.
 
+Whilst [Federation](https://prometheus.io/docs/prometheus/latest/federation/) relies upon an `instance` label with an empty value this is strictly an internal use case. Everything else MUST adhere to the `MUST NOT contain any empty label names or values` requirement above.
+
 ### Ordering
 Prometheus Remote Write compatible senders MUST send samples for any given series in timestamp order. Prometheus Remote Write compatible Senders MAY send multiple requests for different series in parallel.
 

--- a/content/docs/specs/remote_write_spec_2_0.md
+++ b/content/docs/specs/remote_write_spec_2_0.md
@@ -399,6 +399,8 @@ Label names beginning with "__" are RESERVED for system usage and SHOULD NOT be 
 
 Receivers also MAY impose limits on the number and length of labels, but this is receiver-specific and is out of the scope of this document.
 
+Whilst [Federation](https://prometheus.io/docs/prometheus/latest/federation/) relies upon an `instance` label with an empty value this is strictly an internal use case. Everything else MUST adhere to the `MUST NOT contain any empty label names or values` requirement above.
+
 #### Samples and Histogram Samples
 
 <!---


### PR DESCRIPTION
Ref: https://github.com/prometheus/prometheus/issues/11024

Attempt to clarify the existing usage of empty label values by the federation system.

More details of that use case here: https://github.com/prometheus/prometheus/issues/8726#issuecomment-820484765

The goal of adding this line to the documentation is to point out the internal exception to the "MUST NOT contain any empty label names or values." rule and reinforce that it should not be relied upon anywhere else.