### PR TITLE
Add a "tl;dr:" style note at the top of the security page

### DIFF
--- a/content/docs/operating/security.md
+++ b/content/docs/operating/security.md
@@ -3,6 +3,17 @@ title: Security
 sort_rank: 4
 ---
 
+NOTE: Before we dive into the technical details below, we would like to
+emphasize that Prometheus, as a monitoring system, collects and serves
+information about the systems it is monitoring. Therefore, the HTTP endpoints
+provided by Prometheus components should not be exposed to publicly accessible
+networks like the internet (unless you know what you are doing and have taken
+appropriate measures). This includes (but is not limited to) the `/metrics`
+endpoint of instrumented binaries, the various API endpoints of server
+components, and the `/pprof` endpoint of server components implemented in Go.
+Furthermore, it is easily possible to overload and ultimately DoS servers with
+requests to these endpoints.
+
 # Security Model
 
 Prometheus is a sophisticated system with many components and many integrations


### PR DESCRIPTION
The security model is written in a very technical form that is hard to understand for naive users. Naive users are, sadly, also most prone to run Prometheus components exposed to the internet. I have little hope that those users will read this page at all, but if they do, they should get the message. Furthermore, we have had multiple incidents where 3rd parties "uncover" "vulnerabilities and security flaws". There is nothing to uncover, and the flagged behaviors are by design. We have to make that more clear.

This partially addresses #2201, but I think we need to do more. In particular, we should add a section about /pprof (and why we have it on by default), be clearer about DoS'ing ("It is more likely that a component will be accidentally taken out by a trusted user than by malicious action." can easily be understood in an unintended way), and provide more context about the usage of the word "untrusted".

<!--
    Please sign CNCF's Developer Certificate of Origin and sign-off your commits by adding the -s / --sign-off flag to `git commit`

    More information on both of those can be found at https://github.com/apps/dco

    If you are proposing a new integration, exporter, or client library, please include representative sample output.
 -->
