### PR TITLE
update links to openmetrics to reference the v1.0.0 release

### DIFF
--- a/content/docs/instrumenting/exposition_formats.md
+++ b/content/docs/instrumenting/exposition_formats.md
@@ -152,7 +152,7 @@ and it is also available to use for federating metrics since at least v2.23.0.
 
 ### Exemplars (Experimental)
 
-Utilizing the OpenMetrics format allows for the exposition and querying of [Exemplars](https://github.com/OpenObservability/OpenMetrics/blob/main/specification/OpenMetrics.md#exemplars).
+Utilizing the OpenMetrics format allows for the exposition and querying of [Exemplars](https://github.com/prometheus/OpenMetrics/blob/v1.0.0/specification/OpenMetrics.md#exemplars).
 Exemplars provide a point in time snapshot related to a metric set for an otherwise summarized MetricFamily. Additionally they may have a Trace ID attached to them which when used to together
 with a tracing system can provide more detailed information related to the specific service.
 

--- a/content/docs/specs/native_histograms.md
+++ b/content/docs/specs/native_histograms.md
@@ -181,7 +181,7 @@ dimensions:
    like” histograms where each bucket is a gauge, representing arbitrary
    distributions at a point in time. The concept of a gauge histogram was
    previously introduced for classic histograms by
-   [OpenMetrics](https://github.com/OpenObservability/OpenMetrics/blob/main/specification/OpenMetrics.md#gaugehistogram).
+   [OpenMetrics](https://github.com/prometheus/OpenMetrics/blob/v1.0.0/specification/OpenMetrics.md#gaugehistogram).
 2. Integer vs. floating point (short: float): The obvious use case of
    histograms is to count observations, resulting in integer numbers of
    observations ≥ 0 within each bucket, including the _zero bucket_, and for

--- a/content/docs/specs/remote_write_spec_2_0.md
+++ b/content/docs/specs/remote_write_spec_2_0.md
@@ -431,7 +431,7 @@ Typically, Senders can detect when a time series will no longer be appended usin
 
 Metadata SHOULD follow the official Prometheus guidelines for [Type](https://prometheus.io/docs/instrumenting/writing_exporters/#types) and [Help](https://prometheus.io/docs/instrumenting/writing_exporters/#help-strings).
 
-Metadata MAY follow the official OpenMetrics guidelines for [Unit](https://github.com/OpenObservability/OpenMetrics/blob/main/specification/OpenMetrics.md#unit).
+Metadata MAY follow the official OpenMetrics guidelines for [Unit](https://github.com/prometheus/OpenMetrics/blob/v1.0.0/specification/OpenMetrics.md#unit).
 
 #### Exemplars
 


### PR DESCRIPTION
Related to https://github.com/prometheus/OpenMetrics/issues/287

The OM 2.0 effort is kicked off, and will start developing on main. This updates the links to OpenMetrics to reference the 1.0 release. The OM project has also been moved into the prometheus github org.