### PR TITLE
fixing typo in the jobs_instances page

### DIFF
--- a/content/docs/concepts/jobs_instances.md
+++ b/content/docs/concepts/jobs_instances.md
@@ -45,7 +45,7 @@ the following time series:
 
 The `up` time series is useful for instance availability monitoring.
 
-With the [`extra-scrape-metrics` feature flag](/docs/prometheus/latest/feature_flags/#extra-scrape-metrics) several addditonal metrics are available:
+With the [`extra-scrape-metrics` feature flag](/docs/prometheus/latest/feature_flags/#extra-scrape-metrics) several additional metrics are available:
 
 * `scrape_timeout_seconds{job="<job-name>", instance="<instance-id>"}`: The configured `scrape_timeout` for a target.
 * `scrape_sample_limit{job="<job-name>", instance="<instance-id>"}`: The configured `sample_limit` for a target. Returns zero if there is no limit configured.


### PR DESCRIPTION
Hello, 

This PR to resolve a typo in the documentation page [jobs_instances/](https://prometheus.io/docs/concepts/jobs_instances/). The word "additional" is misspelled as `addditonal` with an extra *d* and a missing *i*  in the second syllable.

## The related issue :

Fixes #2565 

## Current Text:

    With the [extra-scrape-metrics feature flag](https://github.com/docs/prometheus/latest/feature_flags/#extra-scrape-metrics) several addditonal metrics are available:

## Corrected Text:

    With the [extra-scrape-metrics feature flag](https://github.com/docs/prometheus/latest/feature_flags/#extra-scrape-metrics) several additional metrics are available: