### PR TITLE
Update OTLP guide with what's new in 3.2

### DIFF
--- a/content/docs/guides/opentelemetry.md
+++ b/content/docs/guides/opentelemetry.md
@@ -157,14 +157,12 @@ otlp:
   translation_strategy: NoUTF8EscapingWithSuffixes
 ```
 
-> Currently there's a known limitation in the OTLP translation package where characters get removed from metric/label names if multiple UTF-8 characters are concatenated between words, e.g. `my___metric` becomes `my_metric`. Please see https://github.com/prometheus/prometheus/issues/15362 for more details.
-
 ## Delta Temporality
 
-The [OpenTelemetry specification says](https://opentelemetry.io/docs/specs/otel/metrics/data-model/#temporality) that both Delta temporality and Cumulative temporality are supported.
+The [OpenTelemetry specification says](https://opentelemetry.io/docs/specs/otel/metrics/data-model/#temporality) that both Delta temporality and Cumulative temporality are supported. While Delta temporality is common in systems like statsd and graphite, cumulative temporality is the default temporality for Prometheus.
 
-While Delta temporality is common in systems like statsd and graphite, cumulative temporality is the default temporality for Prometheus.
+Today, Prometheus embeds the [deltatocumulative processor](https://github.com/open-telemetry/opentelemetry-collector-contrib/tree/main/processor/deltatocumulativeprocessor) from [OpenTelemetry-Collector-contrib](https://github.com/open-telemetry/opentelemetry-collector-contrib), which is capable of ingesting deltas and transforms it into their equivalent cumulative value before they get stored in Prometheus' TSDB.
 
-Today Prometheus does not have support for delta temporality but we are learning from the OpenTelemetry community and we are considering adding support for it in the future.
+This feature is ***experimental***, so start Prometheus with the feature-flag `otlp-deltatocumulative` enabled to use it.
 
-If you are coming from a delta temporality system we recommend that you use the [delta to cumulative processor](https://github.com/open-telemetry/opentelemetry-collector-contrib/tree/main/processor/deltatocumulativeprocessor) in your OTel pipeline.
+The team is still working on a more efficient way of handling OTLP deltas.

--- a/content/docs/guides/opentelemetry.md
+++ b/content/docs/guides/opentelemetry.md
@@ -159,9 +159,9 @@ otlp:
 
 ## Delta Temporality
 
-The [OpenTelemetry specification says](https://opentelemetry.io/docs/specs/otel/metrics/data-model/#temporality) that both Delta temporality and Cumulative temporality are supported. While Delta temporality is common in systems like statsd and graphite, cumulative temporality is the default temporality for Prometheus.
+The [OpenTelemetry specification says](https://opentelemetry.io/docs/specs/otel/metrics/data-model/#temporality) that both Delta temporality and Cumulative temporality are supported. While delta temporality is common in systems like statsd and graphite, cumulative temporality is the default in Prometheus.
 
-Today, Prometheus embeds the [deltatocumulative processor](https://github.com/open-telemetry/opentelemetry-collector-contrib/tree/main/processor/deltatocumulativeprocessor) from [OpenTelemetry-Collector-contrib](https://github.com/open-telemetry/opentelemetry-collector-contrib), which is capable of ingesting deltas and transforms it into their equivalent cumulative value before they get stored in Prometheus' TSDB.
+Today, Prometheus embeds the [delta to cumulative processor](https://github.com/open-telemetry/opentelemetry-collector-contrib/tree/main/processor/deltatocumulativeprocessor) from [OpenTelemetry-Collector-contrib](https://github.com/open-telemetry/opentelemetry-collector-contrib), which is capable of ingesting deltas and transforming them into the equivalent cumulative representation before storing in Prometheus' TSDB.
 
 This feature is ***experimental***, so start Prometheus with the feature-flag `otlp-deltatocumulative` enabled to use it.
 


### PR DESCRIPTION
This PR depends on Prometheus 3.2 release.

It updates the OTLP guide with the new updates we've merged for 3.2, removing the warning about the bug we fixed in https://github.com/prometheus/prometheus/pull/15664 and the new delta support added in https://github.com/prometheus/prometheus/pull/15165.

---

DO NOT MERGE until 3.2 is out