### PR TITLE
Fix header anchor CSS

### DIFF
--- a/content/css/docs.css
+++ b/content/css/docs.css
@@ -400,14 +400,7 @@ footer {
 }
 
 .doc-content a.header-anchor {
-  padding-left: 15px;
-}
-
-.doc-content a.header-anchor:after {
-  content: "\F0C1";
-  font-family: FontAwesome;
-  font-weight: normal;
-  font-size: .8em;
+  padding-left: 8px;
 }
 
 .doc-content a.header-anchor:link,

--- a/content/css/docs.css
+++ b/content/css/docs.css
@@ -400,7 +400,9 @@ footer {
 }
 
 .doc-content a.header-anchor {
+  font-size: .8em;
   padding-left: 8px;
+  text-decoration: none;
 }
 
 .doc-content a.header-anchor:link,

--- a/lib/filters/add_anchors.rb
+++ b/lib/filters/add_anchors.rb
@@ -15,7 +15,7 @@ class AddAnchorsFilter < ::Nanoc::Filter
       next if h_node['id'].nil?
       node = Nokogiri::XML::DocumentFragment.parse("<a></a>").at_css("a").tap do |a|
         a.content = ''
-        a['class'] = 'header-anchor'
+        a['class'] = 'header-anchor ti ti-link'
 
         # Replace sequences of non-word characters with single dashes. Remove
         # extra dashes at the beginning or end.


### PR DESCRIPTION
This is a leftover from 60899b37d2886a3a801c49f133d9ef548e308d19, where Font Awesome was removed. The missing font causes the link icon to show as a tofu. Tabler, the new library that was introduced as a replacement has a link icon CSS class we can use instead. I also adjusted the left pad.

<!--
    Please sign CNCF's Developer Certificate of Origin and sign-off your commits by adding the -s / --sign-off flag to `git commit`

    More information on both of those can be found at https://github.com/apps/dco

    If you are proposing a new integration, exporter, or client library, please include representative sample output.
 -->
