### PR TITLE
OTel docs: recommend promoting `service.version` and `deployment.environment`

### DIFF
--- a/content/docs/guides/opentelemetry.md
+++ b/content/docs/guides/opentelemetry.md
@@ -92,9 +92,11 @@ otlp:
     - service.instance.id
     - service.name
     - service.namespace
+    - service.version
     - cloud.availability_zone
     - cloud.region
     - container.name
+    - dployment.environment
     - deployment.environment.name
     - k8s.cluster.name
     - k8s.container.name

--- a/content/docs/guides/opentelemetry.md
+++ b/content/docs/guides/opentelemetry.md
@@ -96,7 +96,7 @@ otlp:
     - cloud.availability_zone
     - cloud.region
     - container.name
-    - dployment.environment
+    - deployment.environment
     - deployment.environment.name
     - k8s.cluster.name
     - k8s.container.name


### PR DESCRIPTION
In the Prometheus OpenTelemetry documentation section ([here](https://prometheus.io/docs/guides/opentelemetry/#promoting-resource-attributes)), recommend promoting `service.version` and `deployment.environment` for the following reasons:
* `service.version` is very useful to slice and dice metrics for root cause analysis
* `deployment.environment` is the previous name for `deployment.environment.name` and many users still use this older attribute name

