### PR TITLE
Remove obsolete sponsor

### DIFF
--- a/content/community.md
+++ b/content/community.md
@@ -196,9 +196,4 @@ We would also like to acknowledge early contributions by engineers from
 [Docker](https://www.docker.com/) and
 [Boxever](http://www.boxever.com/).
 
-Special thanks to [DigitalOcean](https://digitalocean.com/) for
-providing hosting resources.
-
-<a href="https://digitalocean.com/"><img class="orig-size" src="/assets/digitalocean_logo.svg" alt="DigitalOcean logo" style="width: 200px"></a>
-
 The Prometheus logo was contributed by Robin Greenwood.


### PR DESCRIPTION
We migrated the demo site hosting to a new provider. Remove the DigitalOcean sponsorship acknowledgement.

<!--
    Please sign CNCF's Developer Certificate of Origin and sign-off your commits by adding the -s / --sign-off flag to `git commit`

    More information on both of those can be found at https://github.com/apps/dco

    If you are proposing a new integration, exporter, or client library, please include representative sample output.
 -->
