### PR TITLE
Update exposition_formats.md

### DIFF
--- a/content/docs/instrumenting/exposition_formats.md
+++ b/content/docs/instrumenting/exposition_formats.md
@@ -6,9 +6,9 @@ sort_rank: 6
 # Exposition formats
 
 Metrics can be exposed to Prometheus using a simple [text-based](#text-based-format)
-exposition format. There are various [client libraries](/docs/instrumenting/clientlibs/)
+exposition format. There are various [client libraries](/content/docs/instrumenting/clientlibs.md/)
 that implement this format for you. If your preferred language doesn't have a client
-library you can [create your own](/docs/instrumenting/writing_clientlibs/).
+library you can [create your own](/content/docs/instrumenting/writing_clientlibs.md/).
 
 ## Text-based format
 


### PR DESCRIPTION
fixing broken links in documentation.

>library you can [create your own](/content/docs/instrumenting/writing_clientlibs.md/).
exposition format. There are various [client libraries](/content/docs/instrumenting/clientlibs.md/)

these links from these first two lines of this documentation section were broken.
