### PR TITLE
docs[Native Histograms]: histogram_stddev and histogram_stdvar should use arithmetic mean

### DIFF
--- a/content/docs/specs/native_histograms.md
+++ b/content/docs/specs/native_histograms.md
@@ -1978,7 +1978,8 @@ averaged histogram.)
 Similarly, `histogram_stddev()` and `histogram_stdvar()` return the estimated
 standard deviation or standard variance, respectively, of the observations in a
 native histogram. For this estimation, all observations in a bucket are assumed to
-have the value of the geometric mean of the bucket boundaries.
+have the value of the geometric mean (or arithmetic mean for custom bucket histogram
+samples) of the bucket boundaries.
 
 `histogram_fraction(lower, upper, histogram)` returns the estimated fraction of
 observations in `histogram` between the provided boundaries, the scalar values

--- a/content/docs/specs/native_histograms.md
+++ b/content/docs/specs/native_histograms.md
@@ -1978,8 +1978,7 @@ averaged histogram.)
 Similarly, `histogram_stddev()` and `histogram_stdvar()` return the estimated
 standard deviation or standard variance, respectively, of the observations in a
 native histogram. For this estimation, all observations in a bucket are assumed to
-have the value of the geometric mean (or arithmetic mean for custom bucket histogram
-samples) of the bucket boundaries.
+have the value of the mean of the bucket boundaries. For the zero bucket and for buckets with custom boundaries, the arithmetic mean is used. For standard exponential buckets, the geometric mean is used.
 
 `histogram_fraction(lower, upper, histogram)` returns the estimated fraction of
 observations in `histogram` between the provided boundaries, the scalar values


### PR DESCRIPTION
Related: [#16439](https://github.com/prometheus/prometheus/issues/16439)
Updated the docs to mention that for NHCBs we are using arithmetic mean of a bucket range as representative for the observations in that bucket instead of geometric mean.
cc: @beorn7 @NeerajGartia21