### PR TITLE
Add ICMP Exporter

### DIFF
--- a/content/docs/instrumenting/exporters.md
+++ b/content/docs/instrumenting/exporters.md
@@ -230,6 +230,7 @@ wide variety of JVM-based applications, for example [Kafka](http://kafka.apache.
    * [JFrog Artifactory Exporter](https://github.com/peimanja/artifactory_exporter)
    * [Hostapd Exporter](https://github.com/Fundacio-i2CAT/hostapd_prometheus_exporter)
    * [IBM Security Verify Access / Security Access Manager Exporter](https://gitlab.com/zeblawson/isva-prometheus-exporter)
+   * [ICMP Exporter](https://github.com/SidingsMedia/icmp_exporter)
    * [IPsec exporter](https://github.com/torilabs/ipsec-prometheus-exporter)
    * [ipset exporter](https://github.com/hatamiarash7/ipset-exporter)
    * [IRCd exporter](https://github.com/dgl/ircd_exporter)


### PR DESCRIPTION
<!--
    Please sign CNCF's Developer Certificate of Origin and sign-off your commits by adding the -s / --sign-off flag to `git commit`

    More information on both of those can be found at https://github.com/apps/dco

    If you are proposing a new integration, exporter, or client library, please include representative sample output.
 -->

ICMP Exporter is a very simple exporter to monitor latency to target hosts. It is designed to be flexible and implement features other exporters currently don't, the main one being (and the entire reason it was created in the first place) being able to specify the source interface for a ping. It can also specify the TTL of pings, useful when monitoring links between routers and alike. It is build in Go using  [prometheus/client_golang](https://github.com/prometheus/client_golang/).

Source can be found at [SidingsMedia/icmp_exporter](https://github.com/SidingsMedia/icmp_exporter).

Sample output (standard go and process metrics omitted)
```
# HELP icmp_avg_rtt Average round trip time to the target.
# TYPE icmp_avg_rtt gauge
icmp_avg_rtt{host="fe80::100",interface="wg21588"} 0.000630916
# HELP icmp_exporter_build_info A metric with a constant '1' value labeled by version, revision, branch, goversion from which icmp_exporter was built, and the goos and goarch for the build.
# TYPE icmp_exporter_build_info gauge
icmp_exporter_build_info{branch="",goarch="amd64",goos="linux",goversion="go1.24.2",revision="36743040b8f8072a6f4a04a18cae8c83a6027785",tags="unknown",version=""} 1
# HELP icmp_max_rtt Maximum round trip time to the target.
# TYPE icmp_max_rtt gauge
icmp_max_rtt{host="fe80::100",interface="wg21588"} 0.001514166
# HELP icmp_min_rtt Minimum round trip time to the target.
# TYPE icmp_min_rtt gauge
icmp_min_rtt{host="fe80::100",interface="wg21588"} 0.000136242
# HELP icmp_packet_lost Percentage of packets lost in this run.
# TYPE icmp_packet_lost gauge
icmp_packet_loss{host="fe80::100",interface="wg21588"} 0
# HELP icmp_packets_recv Number of packets received in this run.
# TYPE icmp_packets_recv gauge
icmp_packets_recv{host="fe80::100",interface="wg21588"} 3
# HELP icmp_packets_sent Number of packets sent in this run.
# TYPE icmp_packets_sent gauge
icmp_packets_sent{host="fe80::100",interface="wg21588"} 3
# HELP icmp_std_dev_rtt Standard deviation of round trip time to the target.
# TYPE icmp_std_dev_rtt gauge
icmp_std_dev_rtt{host="fe80::100",interface="wg21588"} 0.000626052
```
