### PR TITLE
add redfish api exporter that references the comcast/fishymetrics repo

### DIFF
--- a/content/docs/instrumenting/exporters.md
+++ b/content/docs/instrumenting/exporters.md
@@ -82,6 +82,7 @@ wide variety of JVM-based applications, for example [Kafka](http://kafka.apache.
    * [Node/system metrics exporter](https://github.com/prometheus/node_exporter) (**official**)
    * [NVIDIA GPU exporter](https://github.com/mindprince/nvidia_gpu_prometheus_exporter)
    * [ProSAFE exporter](https://github.com/dalance/prosafe_exporter)
+   * [Redfish exporter](https://github.com/comcast/fishymetrics)
    * [SmartRAID exporter](https://gitlab.com/calestyo/prometheus-smartraid-exporter)
    * [Waveplus Radon Sensor Exporter](https://github.com/jeremybz/waveplus_exporter)
    * [Weathergoose Climate Monitor Exporter](https://github.com/branttaylor/watchdog-prometheus-exporter)


### PR DESCRIPTION
sample output when testing against the dmtf redfish-mockup-server
```bash
$ curl 'http://localhost:10023/scrape?model=dmtf-mock&target=localhost:8000'
# HELP redfish_cpu_status Current cpu status 1 = OK, 0 = BAD
# TYPE redfish_cpu_status gauge
redfish_cpu_status{chassisModel="dmtf-mock",chassisSerialNumber="437XR1138R2",id="CPU1",model="Multi-Core Intel(R) Xeon(R) processor 7xxx Series",socket="CPU 1",totalCores="8"} 1
redfish_cpu_status{chassisModel="dmtf-mock",chassisSerialNumber="437XR1138R2",id="FPGA1",model="Stratix 10",socket="",totalCores=""} 1
# HELP redfish_device_info Current snapshot of device firmware information
# TYPE redfish_device_info gauge
redfish_device_info{biosVersion="P79 v1.45 (12/06/2017)",chassisModel="dmtf-mock",chassisSerialNumber="437XR1138R2",firmwareVersion="1.45.455b66-rev4",name="web483"} 1
# HELP redfish_memory_dimm_status Current dimm status 1 = OK, 0 = BAD
# TYPE redfish_memory_dimm_status gauge
redfish_memory_dimm_status{capacityMiB="32768",chassisModel="dmtf-mock",chassisSerialNumber="437XR1138R2",manufacturer="",name="DIMM Slot 1",partNumber=""} 1
redfish_memory_dimm_status{capacityMiB="32768",chassisModel="dmtf-mock",chassisSerialNumber="437XR1138R2",manufacturer="",name="DIMM Slot 2",partNumber=""} 1
redfish_memory_dimm_status{capacityMiB="32768",chassisModel="dmtf-mock",chassisSerialNumber="437XR1138R2",manufacturer="",name="DIMM Slot 3",partNumber=""} 1
# HELP redfish_memory_status Current memory status 1 = OK, 0 = BAD
# TYPE redfish_memory_status gauge
redfish_memory_status{chassisModel="dmtf-mock",chassisSerialNumber="437XR1138R2",totalSystemMemoryGiB="96"} 1
# HELP redfish_power_supply_output Power supply output in watts
# TYPE redfish_power_supply_output gauge
redfish_power_supply_output{bayNumber="0",chassisModel="dmtf-mock",chassisSerialNumber="437XR1138R2",firmwareVersion="1.00",manufacturer="ManufacturerName",model="499253-B21",name="Power Supply Bay",powerSupplyType="AC",serialNumber="1Z0000001"} 325
# HELP redfish_power_supply_status Current power supply status 1 = OK, 0 = BAD
# TYPE redfish_power_supply_status gauge
redfish_power_supply_status{bayNumber="0",chassisModel="dmtf-mock",chassisSerialNumber="437XR1138R2",firmwareVersion="1.00",manufacturer="ManufacturerName",model="499253-B21",name="Power Supply Bay",powerSupplyType="AC",serialNumber="1Z0000001"} 0
# HELP redfish_power_supply_total_consumed Total output of all power supplies in watts
# TYPE redfish_power_supply_total_consumed gauge
redfish_power_supply_total_consumed{chassisModel="dmtf-mock",chassisSerialNumber="437XR1138R2",memberId="/redfish/v1/Chassis/1U/Power"} 344
# HELP redfish_power_voltage_output Power voltage output in watts
# TYPE redfish_power_voltage_output gauge
redfish_power_voltage_output{chassisModel="dmtf-mock",chassisSerialNumber="437XR1138R2",name="VRM1 Voltage"} 12
redfish_power_voltage_output{chassisModel="dmtf-mock",chassisSerialNumber="437XR1138R2",name="VRM2 Voltage"} 5
# HELP redfish_power_voltage_status Current power voltage status 1 = OK, 0 = BAD
# TYPE redfish_power_voltage_status gauge
redfish_power_voltage_status{chassisModel="dmtf-mock",chassisSerialNumber="437XR1138R2",name="VRM1 Voltage"} 1
redfish_power_voltage_status{chassisModel="dmtf-mock",chassisSerialNumber="437XR1138R2",name="VRM2 Voltage"} 1
# HELP redfish_thermal_fan_speed Current fan speed in the unit of percentage, possible values are 0 - 100
# TYPE redfish_thermal_fan_speed gauge
redfish_thermal_fan_speed{chassisModel="dmtf-mock",chassisSerialNumber="437XR1138R2",name="BaseBoard System Fan"} 2100
redfish_thermal_fan_speed{chassisModel="dmtf-mock",chassisSerialNumber="437XR1138R2",name="BaseBoard System Fan Backup"} 2050
# HELP redfish_thermal_fan_status Current fan status 1 = OK, 0 = BAD
# TYPE redfish_thermal_fan_status gauge
redfish_thermal_fan_status{chassisModel="dmtf-mock",chassisSerialNumber="437XR1138R2",name="BaseBoard System Fan"} 1
redfish_thermal_fan_status{chassisModel="dmtf-mock",chassisSerialNumber="437XR1138R2",name="BaseBoard System Fan Backup"} 1
# HELP redfish_thermal_sensor_status Current sensor status 1 = OK, 0 = BAD
# TYPE redfish_thermal_sensor_status gauge
redfish_thermal_sensor_status{chassisModel="dmtf-mock",chassisSerialNumber="437XR1138R2",name="CPU1 Temp"} 1
redfish_thermal_sensor_status{chassisModel="dmtf-mock",chassisSerialNumber="437XR1138R2",name="Chassis Intake Temp"} 1
# HELP redfish_thermal_sensor_temperature Current sensor temperature reading in Celsius
# TYPE redfish_thermal_sensor_temperature gauge
redfish_thermal_sensor_temperature{chassisModel="dmtf-mock",chassisSerialNumber="437XR1138R2",name="CPU1 Temp"} 41
redfish_thermal_sensor_temperature{chassisModel="dmtf-mock",chassisSerialNumber="437XR1138R2",name="Chassis Intake Temp"} 25
# HELP redfish_up was the last scrape of fishymetrics successful.
# TYPE redfish_up gauge
redfish_up 1
```
