### PR TITLE
Update native_histograms.md

### DIFF
--- a/content/docs/specs/native_histograms.md
+++ b/content/docs/specs/native_histograms.md
@@ -1565,7 +1565,7 @@ trigger the detection of a spurious counter reset).
 
 The counter reset information of the synthetic zero sample is always set to
 `CounterReset`. (TODO: Currently, Prometheus probably sets it to
-`UnknownCounterReset` for the first sample of a series, which is not wrong, but
+`CounterResetHint` for the first sample of a series, which is not wrong, but
 I think setting it to `CounterReset` makes more sense.)
 
 ### Exemplars


### PR DESCRIPTION
The CounterResetHint should ideally be set to CounterReset rather than UnknownCounterReset.

<!--
    Please sign CNCF's Developer Certificate of Origin and sign-off your commits by adding the -s / --sign-off flag to `git commit`

    More information on both of those can be found at https://github.com/apps/dco

    If you are proposing a new integration, exporter, or client library, please include representative sample output.
 -->
#issue 
Native histograms: zero sample of created timestamp should have counter reset hint 

#close #16575
