### PR TITLE
Move some new docs from "Concepts" to "Instrumenting", fix up titles

### DIFF
--- a/docs/instrumenting/content_negotiation.md
+++ b/docs/instrumenting/content_negotiation.md
@@ -1,9 +1,9 @@
 ---
-title: Prometheus Scraping Protocol Content Negotiation
-sort_rank: 5
+title: Content negotiation
+sort_rank: 8
 ---
 
-# Prometheus Scraping Protocol Content Negotiation
+# Scrape protocol content negotiation
 
 ## Abstract
 

--- a/docs/instrumenting/escaping_schemes.md
+++ b/docs/instrumenting/escaping_schemes.md
@@ -1,9 +1,9 @@
 ---
-title: Prometheus Metric and Label Name Escaping Schemes
-sort_rank: 4
+title: UTF-8 escaping schemes
+sort_rank: 7
 ---
 
-# Prometheus Metric and Label Name Escaping Schemes
+# UTF-8 metric and label name escaping schemes
 
 ## Abstract
 


### PR DESCRIPTION
See https://github.com/prometheus/docs/pull/2653#issuecomment-2913952990

Also change the titles:

* "Prometheus" is redundant in the context of Prometheus, let's make it more about UTF-8
* Make the nav titles shorter so they fit nicer into the nav (title on the page itself can still be long)
* We don't use title casing (at least in the "Instrumenting" section), so lower-casing the titles

<!--
    Please sign CNCF's Developer Certificate of Origin and sign-off your commits by adding the -s / --sign-off flag to `git commit`

    More information on both of those can be found at https://github.com/apps/dco

    If you are proposing a new integration, exporter, or client library, please include representative sample output.
 -->
