### PR TITLE
Fix flickering dropdown, clean up popover state handling

### DIFF
--- a/src/components/Header.tsx
+++ b/src/components/Header.tsx
@@ -37,7 +37,8 @@ const links = [
 
 export const Header = () => {
   const path = usePathname();
-  const [burgerOpened, { toggle: toggleBurger }] = useDisclosure(false);
+  const [burgerOpened, { toggle: toggleBurger, close: closeBurger }] =
+    useDisclosure(false);
 
   const items = links.map((link) => (
     <Link
@@ -48,11 +49,7 @@ export const Header = () => {
         path.startsWith(link.activeBasePath || link.link) ? "page" : undefined
       }
       // Close burger menu when clicking a link.
-      onClick={() => {
-        if (burgerOpened) {
-          toggleBurger();
-        }
-      }}
+      onClick={closeBurger}
     >
       {link.label}
     </Link>
@@ -165,12 +162,15 @@ export const Header = () => {
                 />
                 {actionIcons}
               </Group>
+
+              {/* Mobile version of the nav */}
               <Popover
                 opened={burgerOpened}
-                onChange={toggleBurger}
+                onDismiss={closeBurger}
                 position="bottom"
                 withArrow
                 shadow="md"
+                hideDetached={false}
               >
                 <Popover.Target>
                   <Burger


### PR DESCRIPTION
The main change here is the detaching / hiding of the dropdown when the target element (the burger icon) is hidden from the screen. This can happen when opening the dropdown at a screen width where the burger is shown, then changing the screen width (e.g. by rotating your phone) to a width where the burger is hidden, and then rotating back to where it's shown. Then the popup would flicker around wildly after that, and a page reload would be required to use the burger normally again. With this change, the dropdown simply stays open (until dismissed) even if the burger disappears.

Before:

https://github.com/user-attachments/assets/867afd41-cdcc-462a-a826-a5d6a1ed942d

After:

https://github.com/user-attachments/assets/1769f7b8-6c99-4a15-b2e6-7e00e44ae2f1

<!--
    Please sign CNCF's Developer Certificate of Origin and sign-off your commits by adding the -s / --sign-off flag to `git commit`

    More information on both of those can be found at https://github.com/apps/dco

    If you are proposing a new integration, exporter, or client library, please include representative sample output.
 -->
