### PR TITLE
Also use `navTitle` over `title` in prev/next buttons and breadcrumbs

### DIFF
--- a/src/app/docs/[...slug]/PrevNextEditButtons.tsx
+++ b/src/app/docs/[...slug]/PrevNextEditButtons.tsx
@@ -41,7 +41,7 @@ export default function PrevNextEditButtons({
                   whiteSpace: "normal",
                 }}
               >
-                {currentPage.prev.title}
+                {currentPage.prev.navTitle ?? currentPage.prev.title}
               </Text>
             </Stack>
           </Button>
@@ -100,7 +100,7 @@ export default function PrevNextEditButtons({
                   whiteSpace: "normal",
                 }}
               >
-                {currentPage.next.title}
+                {currentPage.next.navTitle ?? currentPage.next.title}
               </Text>
             </Stack>
           </Button>

--- a/src/app/docs/[...slug]/page.tsx
+++ b/src/app/docs/[...slug]/page.tsx
@@ -58,7 +58,7 @@ function resolveRelativeUrl(currentPath: string, relativeUrl: string): string {
 function pagefindBreadcrumbsTitle(currentPage: DocMetadata) {
   const titles: string[] = [];
   for (let node = currentPage; node; node = node.parent!) {
-    titles.unshift(node.title);
+    titles.unshift(node.navTitle ?? node.title);
   }
   return titles.join(" > ");
 }


### PR DESCRIPTION
We already use the shorter page title (if available) in the left nav, but we should also use it in other places where available space is limited, like the prev/next buttons and the breadcrumbs in the Pagefind search.

<!--
    Please sign CNCF's Developer Certificate of Origin and sign-off your commits by adding the -s / --sign-off flag to `git commit`

    More information on both of those can be found at https://github.com/apps/dco

    If you are proposing a new integration, exporter, or client library, please include representative sample output.
 -->
