### PR TITLE
Standardize H1 title use in local Markdown docs

### DIFF
--- a/docs/concepts/data_model.md
+++ b/docs/concepts/data_model.md
@@ -3,8 +3,6 @@ title: Data model
 sort_rank: 1
 ---
 
-# Data model
-
 Prometheus fundamentally stores all data as [_time
 series_](http://en.wikipedia.org/wiki/Time_series): streams of timestamped
 values belonging to the same metric and the same set of labeled dimensions.

--- a/docs/concepts/jobs_instances.md
+++ b/docs/concepts/jobs_instances.md
@@ -3,8 +3,6 @@ title: Jobs and instances
 sort_rank: 3
 ---
 
-# Jobs and instances
-
 In Prometheus terms, an endpoint you can scrape is called an _instance_,
 usually corresponding to a single process. A collection of instances with the same purpose, a process replicated for scalability or reliability for example, is called a _job_.
 

--- a/docs/concepts/metric_types.md
+++ b/docs/concepts/metric_types.md
@@ -3,8 +3,6 @@ title: Metric types
 sort_rank: 2
 ---
 
-# Metric types
-
 The Prometheus client libraries offer four core metric types. These are
 currently only differentiated in the client libraries (to enable APIs tailored
 to the usage of the specific types) and in the wire protocol. The Prometheus
@@ -13,7 +11,7 @@ untyped time series. This may change in the future.
 
 ## Counter
 
-A _counter_ is a cumulative metric that represents a single [monotonically 
+A _counter_ is a cumulative metric that represents a single [monotonically
 increasing counter](https://en.wikipedia.org/wiki/Monotonic_function) whose
 value can only increase or be reset to zero on restart. For example, you can
 use a counter to represent the number of requests served, tasks completed, or

--- a/docs/guides/basic-auth.md
+++ b/docs/guides/basic-auth.md
@@ -1,8 +1,7 @@
 ---
-title: Basic auth
+title: Securing Prometheus API and UI endpoints using basic auth
+nav_title: Basic auth
 ---
-
-# Securing Prometheus API and UI endpoints using basic auth
 
 Prometheus supports [basic authentication](https://en.wikipedia.org/wiki/Basic_access_authentication) (aka "basic auth") for connections to the Prometheus [expression browser](/docs/visualization/browser) and [HTTP API](/docs/prometheus/latest/querying/api).
 

--- a/docs/guides/cadvisor.md
+++ b/docs/guides/cadvisor.md
@@ -2,8 +2,6 @@
 title: Monitoring Docker container metrics using cAdvisor
 ---
 
-# Monitoring Docker container metrics using cAdvisor
-
 [cAdvisor](https://github.com/google/cadvisor) (short for **c**ontainer **Advisor**) analyzes and exposes resource usage and performance data from running containers. cAdvisor exposes Prometheus metrics out of the box. In this guide, we will:
 
 * create a local multi-container [Docker Compose](https://docs.docker.com/compose/) installation that includes containers running Prometheus, cAdvisor, and a [Redis](https://redis.io/) server, respectively

--- a/docs/guides/dockerswarm.md
+++ b/docs/guides/dockerswarm.md
@@ -3,8 +3,6 @@ title: Docker Swarm
 sort_rank: 1
 ---
 
-# Docker Swarm
-
 Prometheus can discover targets in a [Docker Swarm][swarm] cluster, as of
 v2.20.0. This guide demonstrates how to use that service discovery mechanism.
 

--- a/docs/guides/file-sd.md
+++ b/docs/guides/file-sd.md
@@ -2,8 +2,6 @@
 title: Use file-based service discovery to discover scrape targets
 ---
 
-# Use file-based service discovery to discover scrape targets
-
 Prometheus offers a variety of [service discovery options](https://github.com/prometheus/prometheus/tree/main/discovery) for discovering scrape targets, including [Kubernetes](/docs/prometheus/latest/configuration/configuration/#kubernetes_sd_config), [Consul](/docs/prometheus/latest/configuration/configuration/#consul_sd_config), and many others. If you need to use a service discovery system that is not currently supported, your use case may be best served by Prometheus' [file-based service discovery](/docs/prometheus/latest/configuration/configuration/#file_sd_config) mechanism, which enables you to list scrape targets in a JSON file (along with metadata about those targets).
 
 In this guide, we will:

--- a/docs/guides/go-application.md
+++ b/docs/guides/go-application.md
@@ -1,8 +1,7 @@
 ---
-title: Instrumenting a Go application
+title: Instrumenting a Go application for Prometheus
+nav_title: Instrumenting a Go application
 ---
-
-# Instrumenting a Go application for Prometheus
 
 Prometheus has an official [Go client library](https://github.com/prometheus/client_golang) that you can use to instrument Go applications. In this guide, we'll create a simple Go application that exposes Prometheus metrics via HTTP.
 

--- a/docs/guides/multi-target-exporter.md
+++ b/docs/guides/multi-target-exporter.md
@@ -2,8 +2,6 @@
 title: Understanding and using the multi-target exporter pattern
 ---
 
-# Understanding and using the multi-target exporter pattern
-
 This guide will introduce you to the multi-target exporter pattern. To achieve this we will:
 
 * describe the multi-target exporter pattern and why it is used,
@@ -102,7 +100,7 @@ process_virtual_memory_bytes 1.5609856e+07
 
 Those are metrics in the Prometheus [format](/docs/instrumenting/exposition_formats/#text-format-example). They come from the exporter’s [instrumentation](/docs/practices/instrumentation/) and tell us about the state of the exporter itself while it is running. This is called whitebox monitoring and very useful in daily ops practice. If you are curious, try out our guide on how to [instrument your own applications](https://prometheus.io/docs/guides/go-application/).
 
-For the second type of querying we need to provide a target and module as parameters in the HTTP GET Request. The target is a URI or IP and the module must defined in the exporter’s configuration. The blackbox exporter container comes with a meaningful default configuration.  
+For the second type of querying we need to provide a target and module as parameters in the HTTP GET Request. The target is a URI or IP and the module must defined in the exporter’s configuration. The blackbox exporter container comes with a meaningful default configuration.
 We will use the target `prometheus.io` and the predefined module `http_2xx`. It tells the exporter to make a GET request like a browser would if you go to `prometheus.io` and to expect a [200 OK](https://en.wikipedia.org/wiki/List_of_HTTP_status_codes#2xx_Success) response.
 
 You can now tell your blackbox exporter to query `prometheus.io` in the terminal with curl:
@@ -161,7 +159,7 @@ We could now either tell Docker to allow IPv6 or the blackbox exporter to use IP
 
 The modules are predefined in a file inside the docker container called `config.yml` which is a copy of [blackbox.yml](https://github.com/prometheus/blackbox_exporter/blob/master/blackbox.yml) in the github repo.
 
-We will copy this file, [adapt](https://github.com/prometheus/blackbox_exporter/blob/master/CONFIGURATION.md) it to our own needs and tell the exporter to use our config file instead of the one included in the container.  
+We will copy this file, [adapt](https://github.com/prometheus/blackbox_exporter/blob/master/CONFIGURATION.md) it to our own needs and tell the exporter to use our config file instead of the one included in the container.
 
 First download the file using curl or your browser:
 
@@ -181,7 +179,7 @@ modules:
       method: POST
 ```
 
-[YAML](https://en.wikipedia.org/wiki/YAML) uses whitespace indentation to express hierarchy, so you can recognise that two `modules` named `http_2xx` and `http_post_2xx` are defined, and that they both have a prober `http` and for one the method value is specifically set to `POST`.  
+[YAML](https://en.wikipedia.org/wiki/YAML) uses whitespace indentation to express hierarchy, so you can recognise that two `modules` named `http_2xx` and `http_post_2xx` are defined, and that they both have a prober `http` and for one the method value is specifically set to `POST`.
 You will now change the module `http_2xx` by setting the `preferred_ip_protocol` of the prober `http` explicitly to the string `ip4`.
 
 ```yaml
@@ -198,7 +196,7 @@ modules:
 
 If you want to know more about the available probers and options check out the [documentation](https://github.com/prometheus/blackbox_exporter/blob/master/CONFIGURATION.md).
 
-Now we need to tell the blackbox exporter to use our freshly changed file. You can do that with the flag `--config.file="blackbox.yml"`. But because we are using Docker, we first must make this file [available](https://docs.docker.com/storage/bind-mounts/) inside the container using the `--mount` command.  
+Now we need to tell the blackbox exporter to use our freshly changed file. You can do that with the flag `--config.file="blackbox.yml"`. But because we are using Docker, we first must make this file [available](https://docs.docker.com/storage/bind-mounts/) inside the container using the `--mount` command.
 
 NOTE: If you are using macOS you first need to allow the Docker daemon to access the directory in which your `blackbox.yml` is. You can do that by clicking on the little Docker whale in menu bar and then on `Preferences`->`File Sharing`->`+`. Afterwards press `Apply & Restart`.
 
@@ -288,12 +286,12 @@ probe_success 1
 probe_tls_version_info{version="TLS 1.3"} 1
 ```
 
-You can see that the probe was successful and get many useful metrics, like latency by phase, status code, ssl status or certificate expiry in [Unix time](https://en.wikipedia.org/wiki/Unix_time).  
+You can see that the probe was successful and get many useful metrics, like latency by phase, status code, ssl status or certificate expiry in [Unix time](https://en.wikipedia.org/wiki/Unix_time).
 The blackbox exporter also offers a tiny web interface at [localhost:9115](http://localhost:9115) for you to check out the last few probes, the loaded config and debug information. It even offers a direct link to probe `prometheus.io`. Handy if you are wondering why something does not work.
 
 ## Querying multi-target exporters with Prometheus
 
-So far, so good. Congratulate yourself. The blackbox exporter works and you can manually tell it to query a remote target. You are almost there. Now you need to tell Prometheus to do the queries for us.  
+So far, so good. Congratulate yourself. The blackbox exporter works and you can manually tell it to query a remote target. You are almost there. Now you need to tell Prometheus to do the queries for us.
 
 Below you find a minimal prometheus config. It is telling Prometheus to scrape the exporter itself as we did [before](#query-exporter) using `curl 'localhost:9115/metrics'`:
 

--- a/docs/guides/node-exporter.md
+++ b/docs/guides/node-exporter.md
@@ -2,8 +2,6 @@
 title: Monitoring Linux host metrics with the Node Exporter
 ---
 
-# Monitoring Linux host metrics with the Node Exporter
-
 The Prometheus [**Node Exporter**](https://github.com/prometheus/node_exporter) exposes a wide variety of hardware- and kernel-related metrics.
 
 In this guide, you will:

--- a/docs/guides/opentelemetry.md
+++ b/docs/guides/opentelemetry.md
@@ -1,8 +1,7 @@
 ---
-title: OpenTelemetry
+title: Using Prometheus as your OpenTelemetry backend
+nav_title: OpenTelemetry
 ---
-
-# Using Prometheus as your OpenTelemetry backend
 
 Prometheus supports [OTLP](https://opentelemetry.io/docs/specs/otlp) (aka "OpenTelemetry Protocol") ingestion through [HTTP](https://opentelemetry.io/docs/specs/otlp/#otlphttp).
 

--- a/docs/guides/query-log.md
+++ b/docs/guides/query-log.md
@@ -1,9 +1,8 @@
 ---
-title: Query Log
+title: Using the Prometheus query log
+nav_title: Query log
 sort_rank: 1
 ---
-
-# Using the Prometheus query log
 
 Prometheus has the ability to log all the queries run by the engine to a log
 file, as of 2.16.0. This guide demonstrates how to use that log file, which

--- a/docs/guides/tls-encryption.md
+++ b/docs/guides/tls-encryption.md
@@ -1,9 +1,8 @@
 ---
-title: TLS encryption
+title: Securing Prometheus API and UI endpoints using TLS encryption
+nav_title: TLS encryption
 sort_rank: 1
 ---
-
-# Securing Prometheus API and UI endpoints using TLS encryption
 
 Prometheus supports [Transport Layer Security](https://en.wikipedia.org/wiki/Transport_Layer_Security) (TLS) encryption for connections to Prometheus instances (i.e. to the expression browser or [HTTP API](/docs/prometheus/latest/querying/api/)). If you would like to enforce TLS for those connections, you would need to create a specific web configuration file.
 

--- a/docs/guides/utf8.md
+++ b/docs/guides/utf8.md
@@ -2,7 +2,7 @@
 title: UTF-8 in Prometheus
 ---
 
-# Introduction
+## Introduction
 
 Versions of Prometheus before 3.0 required that metric and label names adhere to
 a strict set of character requirements. With Prometheus 3.0, all UTF-8 strings
@@ -15,7 +15,7 @@ does not yet support UTF-8.
 
 This document guides you through the UTF-8 transition details.
 
-# Go Instrumentation
+## Go Instrumentation
 
 Currently, metrics created by the official Prometheus [client_golang library](https://github.com/prometheus/client_golang) will reject UTF-8 names
 by default. It is necessary to change the default validation scheme to allow
@@ -36,12 +36,12 @@ scheme to `LegacyValidation`.
 Setting the validation scheme must be done before the instantiation of metrics
 and can be set on the fly if desired.
 
-## Instrumenting in other languages
+### Instrumenting in other languages
 
 Other client libraries may have similar requirements to set the validation
 scheme. Check the documentation for the library you are using.
 
-# Configuring Name Validation during Scraping
+## Configuring Name Validation during Scraping
 
 By default, Prometheus 3.0 accepts all UTF-8 strings as valid metric and label
 names. It is possible to override this behavior for scraped targets and reject
@@ -64,7 +64,7 @@ scrape_configs:
 
 Scrape config settings override the global setting.
 
-## Scrape Content Negotiation for UTF-8 escaping
+### Scrape Content Negotiation for UTF-8 escaping
 
 At scrape time, the scraping system **must** pass `escaping=allow-utf-8` in the
 Accept header in order to be served UTF-8 names. If scrape target does not see
@@ -91,12 +91,12 @@ their end. The choice of exact name translation strategy is up to the metrics
 producer. The requirement is that when Prometheus requests an escaping scheme
 other than allow-utf-8, the producer convert the names in the manner requested.
 
-## Remote Write 2.0
+### Remote Write 2.0
 
 Remote Write 2.0 automatically accepts all UTF-8 names in Prometheus 3.0. There
 is no way to enforce the legacy character set validation with Remote Write 2.0.
 
-# OTLP Metrics
+## OTLP Metrics
 
 OTLP receiver in Prometheus 3.0 still normalizes all names to Prometheus format by default. You can change this in `otlp` section of the Prometheus configuration as follows:
 
@@ -109,7 +109,7 @@ OTLP receiver in Prometheus 3.0 still normalizes all names to Prometheus format 
 See [OpenTelemetry guide](/docs/guides/opentelemetry) for more details.
 
 
-# Querying
+## Querying
 
 
 Querying for metrics with UTF-8 names will require a slightly different syntax

--- a/docs/instrumenting/clientlibs.md
+++ b/docs/instrumenting/clientlibs.md
@@ -3,8 +3,6 @@ title: Client libraries
 sort_rank: 1
 ---
 
-# Client libraries
-
 Before you can monitor your services, you need to add instrumentation to their
 code via one of the Prometheus client libraries. These implement the Prometheus
 [metric types](/docs/concepts/metric_types/).

--- a/docs/instrumenting/content_negotiation.md
+++ b/docs/instrumenting/content_negotiation.md
@@ -1,9 +1,8 @@
 ---
-title: Content negotiation
+title: Scrape protocol content negotiation
+nav_title: Content negotiation
 sort_rank: 8
 ---
-
-# Scrape protocol content negotiation
 
 ## Abstract
 

--- a/docs/instrumenting/escaping_schemes.md
+++ b/docs/instrumenting/escaping_schemes.md
@@ -1,9 +1,8 @@
 ---
-title: UTF-8 escaping schemes
+title: UTF-8 metric and label name escaping schemes
+nav_title: UTF-8 escaping schemes
 sort_rank: 7
 ---
-
-# UTF-8 metric and label name escaping schemes
 
 ## Abstract
 

--- a/docs/instrumenting/exporters.md
+++ b/docs/instrumenting/exporters.md
@@ -3,8 +3,6 @@ title: Exporters and integrations
 sort_rank: 4
 ---
 
-# Exporters and integrations
-
 There are a number of libraries and servers which help in exporting existing
 metrics from third-party systems as Prometheus metrics. This is useful for
 cases where it is not feasible to instrument a given system with Prometheus

--- a/docs/instrumenting/exposition_formats.md
+++ b/docs/instrumenting/exposition_formats.md
@@ -3,8 +3,6 @@ title: Exposition formats
 sort_rank: 6
 ---
 
-# Exposition formats
-
 Metrics can be exposed to Prometheus using a simple [text-based](#text-based-format)
 exposition format. There are various [client libraries](/docs/instrumenting/clientlibs/)
 that implement this format for you. If your preferred language doesn't have a client

--- a/docs/instrumenting/pushing.md
+++ b/docs/instrumenting/pushing.md
@@ -3,8 +3,6 @@ title: Pushing metrics
 sort_rank: 3
 ---
 
-# Pushing metrics
-
 Occasionally you will need to monitor components which cannot be scraped. The
 [Prometheus Pushgateway](https://github.com/prometheus/pushgateway) allows you
 to push time series from [short-lived service-level batch

--- a/docs/instrumenting/writing_clientlibs.md
+++ b/docs/instrumenting/writing_clientlibs.md
@@ -3,8 +3,6 @@ title: Writing client libraries
 sort_rank: 2
 ---
 
-# Writing client libraries
-
 This document covers what functionality and API Prometheus client libraries
 should offer, with the aim of consistency across libraries, making the easy use
 cases easy and avoiding offering functionality that may lead users down the
@@ -77,7 +75,7 @@ this structure as much as is practical.
 
 Client libraries SHOULD follow function/method/class names mentioned in this
 document, keeping in mind the naming conventions of the language they’re
-working in. For example, `set_to_current_time()` is good for a method name in 
+working in. For example, `set_to_current_time()` is good for a method name in
 Python, but `SetToCurrentTime()` is better in Go and `setToCurrentTime()` is
 the convention in Java. Where names differ for technical reasons (e.g. not
 allowing function overloading), documentation/help strings SHOULD point users

--- a/docs/instrumenting/writing_exporters.md
+++ b/docs/instrumenting/writing_exporters.md
@@ -3,8 +3,6 @@ title: Writing exporters
 sort_rank: 5
 ---
 
-# Writing exporters
-
 If you are instrumenting your own code, the [general rules of how to
 instrument code with a Prometheus client
 library](/docs/practices/instrumentation/) should be followed. When

--- a/docs/introduction/comparison.md
+++ b/docs/introduction/comparison.md
@@ -3,8 +3,6 @@ title: Comparison to alternatives
 sort_rank: 4
 ---
 
-# Comparison to alternatives
-
 ## Prometheus vs. Graphite
 
 ### Scope
@@ -132,16 +130,16 @@ boundaries like products, services, datacenters, or similar aspects.
 Independent servers (which can be run redundantly in parallel) may also give
 you better reliability and failure isolation.
 
-Kapacitor's open-source release has no built-in distributed/redundant options for 
-rules,  alerting, or notifications.  The open-source release of Kapacitor can 
+Kapacitor's open-source release has no built-in distributed/redundant options for
+rules,  alerting, or notifications.  The open-source release of Kapacitor can
 be scaled via manual sharding by the user, similar to Prometheus itself.
-Influx offers [Enterprise Kapacitor](https://docs.influxdata.com/enterprise_kapacitor), which supports an 
+Influx offers [Enterprise Kapacitor](https://docs.influxdata.com/enterprise_kapacitor), which supports an
 HA/redundant alerting system.
 
-Prometheus and the Alertmanager by contrast offer a fully open-source redundant 
-option via running redundant replicas of Prometheus and using the Alertmanager's 
+Prometheus and the Alertmanager by contrast offer a fully open-source redundant
+option via running redundant replicas of Prometheus and using the Alertmanager's
 [High Availability](https://github.com/prometheus/alertmanager#high-availability)
-mode. 
+mode.
 
 ### Summary
 
@@ -183,10 +181,10 @@ The same scope differences as in the case of
 
 OpenTSDB's data model is almost identical to Prometheus's: time series are
 identified by a set of arbitrary key-value pairs (OpenTSDB tags are
-Prometheus labels). All data for a metric is 
+Prometheus labels). All data for a metric is
 [stored together](http://opentsdb.net/docs/build/html/user_guide/writing/index.html#time-series-cardinality),
 limiting the cardinality of metrics. There are minor differences though: Prometheus
-allows arbitrary characters in label values, while OpenTSDB is more restrictive. 
+allows arbitrary characters in label values, while OpenTSDB is more restrictive.
 OpenTSDB also lacks a full query language, only allowing simple aggregation and math via its API.
 
 ### Storage
@@ -213,8 +211,8 @@ good choice.
 
 ### Scope
 
-Nagios is primarily about alerting based on the exit codes of scripts. These are 
-called “checks”. There is silencing of individual alerts, however no grouping, 
+Nagios is primarily about alerting based on the exit codes of scripts. These are
+called “checks”. There is silencing of individual alerts, however no grouping,
 routing or deduplication.
 
 There are a variety of plugins. For example, piping the few kilobytes of
@@ -250,7 +248,7 @@ environment, then Prometheus is a good choice.
 
 ### Scope
 
-Sensu is an observability pipeline that focuses on processing and alerting of observability data as a stream of [Events](https://docs.sensu.io/sensu-go/latest/observability-pipeline/observe-events/events/). It provides an extensible framework for event [filtering](https://docs.sensu.io/sensu-go/latest/observability-pipeline/observe-filter/), aggregation, [transformation](https://docs.sensu.io/sensu-go/latest/observability-pipeline/observe-transform/), and [processing](https://docs.sensu.io/sensu-go/latest/observability-pipeline/observe-process/) – including sending alerts to other systems and storing events in third-party systems. Sensu's event processing capabilities are similar in scope to Prometheus alerting rules and Alertmanager. 
+Sensu is an observability pipeline that focuses on processing and alerting of observability data as a stream of [Events](https://docs.sensu.io/sensu-go/latest/observability-pipeline/observe-events/events/). It provides an extensible framework for event [filtering](https://docs.sensu.io/sensu-go/latest/observability-pipeline/observe-filter/), aggregation, [transformation](https://docs.sensu.io/sensu-go/latest/observability-pipeline/observe-transform/), and [processing](https://docs.sensu.io/sensu-go/latest/observability-pipeline/observe-process/) – including sending alerts to other systems and storing events in third-party systems. Sensu's event processing capabilities are similar in scope to Prometheus alerting rules and Alertmanager.
 
 ### Data model
 
@@ -258,26 +256,26 @@ Sensu [Events](https://docs.sensu.io/sensu-go/latest/observability-pipeline/obse
 
 ### Storage
 
-Sensu stores current and recent event status information and real-time inventory data in an embedded database (etcd) or an external RDBMS (PostgreSQL). 
+Sensu stores current and recent event status information and real-time inventory data in an embedded database (etcd) or an external RDBMS (PostgreSQL).
 
 ### Architecture
 
-All components of a Sensu deployment can be clustered for high availability and improved event-processing throughput. 
+All components of a Sensu deployment can be clustered for high availability and improved event-processing throughput.
 
 ### Summary
 
 Sensu and Prometheus have a few capabilities in common, but they take very different approaches to monitoring. Both offer extensible discovery mechanisms for dynamic cloud-based environments and ephemeral compute platforms, though the underlying mechanisms are quite different. Both provide support for collecting multi-dimensional metrics via labels and annotations. Both have extensive integrations, and Sensu natively supports collecting metrics from all Prometheus exporters. Both are capable of forwarding observability data to third-party data platforms (e.g. event stores or TSDBs). Where Sensu and Prometheus differ the most is in their use cases.
 
-Where Sensu is better: 
+Where Sensu is better:
 
 - If you're collecting and processing hybrid observability data (including metrics _and/or_ events)
 - If you're consolidating multiple monitoring tools and need support for metrics _and_ Nagios-style plugins or check scripts
 - More powerful event-processing platform
 
-Where Prometheus is better: 
+Where Prometheus is better:
 
 - If you're primarily collecting and evaluating metrics
 - If you're monitoring homogeneous Kubernetes infrastructure (if 100% of the workloads you're monitoring are in K8s, Prometheus offers better K8s integration)
-- More powerful query language, and built-in support for historical data analysis 
+- More powerful query language, and built-in support for historical data analysis
 
 Sensu is maintained by a single commercial company following the open-core business model, offering premium features like closed-source event correlation and aggregation, federation, and support. Prometheus is a fully open source and independent project, maintained by a number of companies and individuals, some of whom also offer commercial services and support.

--- a/docs/introduction/design-doc.md
+++ b/docs/introduction/design-doc.md
@@ -1,16 +1,14 @@
 ---
-title: Design Documents
+title: Design documents
 sort_rank: 7
 ---
-
-# Design Documents
 
 See the [github.com/prometheus/proposals](https://github.com/prometheus/proposals)
 repository to see all the past and current proposals for the Prometheus Ecosystem.
 
 If you are interested in creating a new proposal, read our [proposal process](https://github.com/prometheus/proposals#proposal-process).
 
-# Problem statements and exploratory documents
+## Problem statements and exploratory documents
 
 Sometimes we're looking even further into potential futures. The documents in
 this section are largely exploratory. They should be taken as informing our

--- a/docs/introduction/faq.md
+++ b/docs/introduction/faq.md
@@ -1,10 +1,8 @@
 ---
-title: FAQ
+title: Frequently asked questions
+nav_title: FAQ
 sort_rank: 5
-toc: full-width
 ---
-
-# Frequently Asked Questions
 
 ## General
 
@@ -37,7 +35,7 @@ There are always trade-offs to make when running services, and Prometheus values
 Yes, run identical Prometheus servers on two or more separate machines.
 Identical alerts will be deduplicated by the [Alertmanager](https://github.com/prometheus/alertmanager).
 
-Alertmanager supports [high availability](https://github.com/prometheus/alertmanager#high-availability) by interconnecting multiple Alertmanager instances to build an Alertmanager cluster. Instances of a cluster communicate using a gossip protocol managed via [HashiCorp's Memberlist](https://github.com/hashicorp/memberlist) library. 
+Alertmanager supports [high availability](https://github.com/prometheus/alertmanager#high-availability) by interconnecting multiple Alertmanager instances to build an Alertmanager cluster. Instances of a cluster communicate using a gossip protocol managed via [HashiCorp's Memberlist](https://github.com/hashicorp/memberlist) library.
 
 ### I was told Prometheus “doesn't scale”.
 

--- a/docs/introduction/first_steps.md
+++ b/docs/introduction/first_steps.md
@@ -1,9 +1,8 @@
 ---
-title: First steps
+title: First steps with Prometheus
+nav_title: First steps
 sort_rank: 3
 ---
-
-# First steps with Prometheus
 
 Welcome to Prometheus! Prometheus is a monitoring platform that collects metrics from monitored targets by scraping metrics HTTP endpoints on these targets. This guide will show you how to install, configure and monitor our first resource with Prometheus. You'll download, install and run Prometheus. You'll also download and install an exporter, tools that expose time series data on hosts and services. Our first exporter will be Prometheus itself, which provides a wide variety of host-level metrics about memory usage, garbage collection, and more.
 

--- a/docs/introduction/glossary.md
+++ b/docs/introduction/glossary.md
@@ -3,9 +3,6 @@ title: Glossary
 sort_rank: 9
 ---
 
-# Glossary
-
-
 ### Alert
 
 An alert is the outcome of an alerting rule in Prometheus that is

--- a/docs/introduction/media.md
+++ b/docs/introduction/media.md
@@ -3,8 +3,6 @@ title: Media
 sort_rank: 8
 ---
 
-# Media
-
 There is a [subreddit](https://www.reddit.com/r/prometheusmonitoring)
 collecting all Prometheus-related resources on the internet.
 

--- a/docs/introduction/overview.md
+++ b/docs/introduction/overview.md
@@ -3,8 +3,6 @@ title: Overview
 sort_rank: 1
 ---
 
-# Overview
-
 ## What is Prometheus?
 
 [Prometheus](https://github.com/prometheus) is an open-source systems

--- a/docs/introduction/release-cycle.md
+++ b/docs/introduction/release-cycle.md
@@ -1,9 +1,7 @@
 ---
-title: Long-Term Support
+title: Long-term support
 sort_rank: 10
 ---
-
-# Long Term Support
 
 Prometheus LTS are selected releases of Prometheus that receive bugfixes for an
 extended period of time.

--- a/docs/introduction/roadmap.md
+++ b/docs/introduction/roadmap.md
@@ -3,8 +3,6 @@ title: Roadmap
 sort_rank: 6
 ---
 
-# Roadmap
-
 The following is only a selection of some of the major features we plan to
 implement in the near future. To get a more complete overview of planned
 features and current work, see the issue trackers for the various repositories,
@@ -24,7 +22,7 @@ in Prometheus and provide it via an experimental API endpoint.
 The OpenMetrics working group is developing a new standard for metric exposition.
 We plan to support this format in our client libraries and Prometheus itself.
 
-### Retroactive rule evaluations		
+### Retroactive rule evaluations
 
 Add support for retroactive rule evaluations making use of backfill.
 

--- a/docs/operating/integrations.md
+++ b/docs/operating/integrations.md
@@ -3,8 +3,6 @@ title: Integrations
 sort_rank: 5
 ---
 
-# Integrations
-
 In addition to [client libraries](/docs/instrumenting/clientlibs/) and
 [exporters and related libraries](/docs/instrumenting/exporters/), there are
 numerous other generic integration points in Prometheus. This page lists some

--- a/docs/operating/security.md
+++ b/docs/operating/security.md
@@ -1,5 +1,6 @@
 ---
-title: Security
+title: Security model
+nav_title: Security
 sort_rank: 4
 ---
 
@@ -13,8 +14,6 @@ endpoint of instrumented binaries, the various API endpoints of server
 components, and the `/pprof` endpoint of server components implemented in Go.
 Furthermore, it is easily possible to overload and ultimately DoS servers with
 requests to these endpoints.
-
-# Security Model
 
 Prometheus is a sophisticated system with many components and many integrations
 with other systems. It can be deployed in a variety of trusted and untrusted

--- a/docs/practices/alerting.md
+++ b/docs/practices/alerting.md
@@ -3,8 +3,6 @@ title: Alerting
 sort_rank: 5
 ---
 
-# Alerting
-
 We recommend that you read [My Philosophy on Alerting](https://docs.google.com/a/boxever.com/document/d/199PqyG3UsyXlwieHaqbGiWVa8eMWi8zzAn0YfcApr8Q/edit)
 based on Rob Ewaschuk's observations at Google.
 

--- a/docs/practices/consoles.md
+++ b/docs/practices/consoles.md
@@ -3,8 +3,6 @@ title: Consoles and dashboards
 sort_rank: 3
 ---
 
-# Consoles and dashboards
-
 It can be tempting to display as much data as possible on a dashboard, especially
 when a system like Prometheus offers the ability to have such rich
 instrumentation of your applications. This can lead to consoles that are

--- a/docs/practices/histograms.md
+++ b/docs/practices/histograms.md
@@ -7,8 +7,6 @@ NOTE: This document predates native histograms (added as an experimental
 feature in Prometheus v2.40). Once native histograms are closer to becoming a
 stable feature, this document will be thoroughly updated.
 
-# Histograms and summaries
-
 Histograms and summaries are more complex metric types. Not only does
 a single histogram or summary create a multitude of time series, it is
 also more difficult to use these metric types correctly. This section

--- a/docs/practices/instrumentation.md
+++ b/docs/practices/instrumentation.md
@@ -3,8 +3,6 @@ title: Instrumentation
 sort_rank: 3
 ---
 
-# Instrumentation
-
 This page provides an opinionated set of guidelines for instrumenting your code.
 
 ## How to instrument

--- a/docs/practices/naming.md
+++ b/docs/practices/naming.md
@@ -3,8 +3,6 @@ title: Metric and label naming
 sort_rank: 1
 ---
 
-# Metric and label naming
-
 The metric and label conventions presented in this document are not required
 for using Prometheus, but can serve as both a style-guide and a collection of
 best practices. Individual organizations may want to approach some of these
@@ -44,7 +42,7 @@ A metric name...
   * <code>prometheus\_tsdb\_head\_truncations\_established\_total</code>
   * <code>prometheus\_tsdb\_head\_truncations\_failed\_total</code>
   * <code>prometheus\_tsdb\_head\_truncations\_total</code><br/>
-  The following examples are also valid, but are following a different trade-off. They are easier to read individually, but unrelated metrics like <code>prometheus\_tsdb\_head\_series</code> might get sorted in between.  
+  The following examples are also valid, but are following a different trade-off. They are easier to read individually, but unrelated metrics like <code>prometheus\_tsdb\_head\_series</code> might get sorted in between.
   * <code>prometheus\_tsdb\_head\_closed\_truncations\_total</code>
   * <code>prometheus\_tsdb\_head\_established\_truncations\_total</code>
   * <code>prometheus\_tsdb\_head\_failed\_truncations\_total</code>
@@ -65,18 +63,18 @@ queue with the current number of elements in the queue is not.
 
 Some metric naming conventions (e.g. OpenTelemetry) do not recommend or even do not allow
 including information about a metric unit and type in the metric name. A common
-argument is that those pieces of information are already defined somewhere else (e.g. schema, 
+argument is that those pieces of information are already defined somewhere else (e.g. schema,
 metadata, other labels, etc.).
 
 Prometheus strongly recommends including unit and type in a metric name, even if you store that
 information elsewhere, because of the following practical reasons:
 
-* **Metric consumption reliability and UX**: When interacting with a modern UI to 
+* **Metric consumption reliability and UX**: When interacting with a modern UI to
 use such a metric in PromQL, it's possible to display rich information about the metric's type and unit
 (autocompletion, overlays, pop-ups). Unfortunately, interactive, adhoc querying in a powerful UI is not
 the only way that users interact with metrics. Metric consumption ecosystem is vast. Majority
 of the consumption comes in a form of the plain YAML configuration for variety of observability tools like
-alerting, recording, autoscaling, dashboards, analysis, processing, etc. It's **critical**, especially 
+alerting, recording, autoscaling, dashboards, analysis, processing, etc. It's **critical**, especially
 during monitoring/SRE incident practices to look on PromQL expressions in plain YAML and understand
 the underlying metric type and unit you work with.
 * **Metric collisions**: With growing adoption and metric changes over time, there are cases where lack

--- a/docs/practices/pushing.md
+++ b/docs/practices/pushing.md
@@ -3,8 +3,6 @@ title: When to use the Pushgateway
 sort_rank: 7
 ---
 
-# When to use the Pushgateway
-
 The Pushgateway is an intermediary service which allows you to push metrics
 from jobs which cannot be scraped. For details, see [Pushing metrics](/docs/instrumenting/pushing/).
 

--- a/docs/practices/remote_write.md
+++ b/docs/practices/remote_write.md
@@ -3,8 +3,6 @@ title: Remote write tuning
 sort_rank: 8
 ---
 
-# Remote write tuning
-
 Prometheus implements sane defaults for remote write, but many users have
 different requirements and would like to optimize their remote settings.
 

--- a/docs/practices/rules.md
+++ b/docs/practices/rules.md
@@ -3,15 +3,13 @@ title: Recording rules
 sort_rank: 6
 ---
 
-# Recording rules
-
 A consistent naming scheme for [recording rules](/docs/prometheus/latest/configuration/recording_rules/)
 makes it easier to interpret the meaning of a rule at a glance. It also avoids
 mistakes by making incorrect or meaningless calculations stand out.
 
 This page documents proper naming conventions and aggregation for recording rules.
 
-## Naming 
+## Naming
 
 * Recording rules should be of the general form `level:metric:operations`.
 * `level` represents the aggregation level and labels of the rule output.

--- a/docs/specs/native_histograms.md
+++ b/docs/specs/native_histograms.md
@@ -3,8 +3,6 @@ title: Native Histograms [EXPERIMENTAL]
 sort_rank: 1
 ---
 
-# Native Histograms
-
 Native histograms were introduced as an experimental feature in November 2022.
 They are a concept that touches almost every part of the Prometheus stack. The
 first version of the Prometheus server supporting native histograms was

--- a/docs/specs/om/open_metrics_spec.md
+++ b/docs/specs/om/open_metrics_spec.md
@@ -23,8 +23,6 @@ author:
   email: rob.skillington@gmail.com
 ---
 
-# OpenMetrics
-
 - Version: 1.0
 - Status: Published
 - Date: March 2022

--- a/docs/specs/om/open_metrics_spec_2_0.md
+++ b/docs/specs/om/open_metrics_spec_2_0.md
@@ -25,8 +25,6 @@ author:
   email: rob.skillington@gmail.com
 ---
 
-# OpenMetrics
-
 - Version: 2.0
 - Status: Draft
 - Date: TBD

--- a/docs/specs/prw/remote_write_spec.md
+++ b/docs/specs/prw/remote_write_spec.md
@@ -1,10 +1,8 @@
 ---
-title: "Remote Write 1.0"
+title: "Prometheus Remote-Write 1.0 specification"
 nav_title: "1.0"
 sort_rank: 1
 ---
-
-# Prometheus Remote-Write Specification
 
 - Version: 1.0
 - Status: Published

--- a/docs/specs/prw/remote_write_spec_2_0.md
+++ b/docs/specs/prw/remote_write_spec_2_0.md
@@ -1,10 +1,8 @@
 ---
-title: "Remote Write 2.0 [EXPERIMENTAL]"
+title: "Prometheus Remote-Write 2.0 specification [EXPERIMENTAL]"
 nav_title: "2.0"
 sort_rank: 2
 ---
-
-# Prometheus Remote-Write Specification
 
 * Version: 2.0-rc.3
 * Status: **Experimental**

--- a/docs/tutorials/alerting_based_on_metrics.md
+++ b/docs/tutorials/alerting_based_on_metrics.md
@@ -1,9 +1,7 @@
 ---
-title: Alerting based on metrics.
+title: Alerting based on metrics
 sort_rank: 5
 ---
-
-# Alerting based on metrics
 
 In this tutorial we will create alerts on the `ping_request_count` metric that we instrumented earlier in the
 [Instrumenting HTTP server written in Go](./instrumenting_http_server_in_go.md) tutorial.

--- a/docs/tutorials/getting_started.md
+++ b/docs/tutorials/getting_started.md
@@ -1,18 +1,19 @@
 ---
-title: Getting Started with Prometheus
+title: Getting started with Prometheus
 sort_rank: 1
 ---
 
-# What is Prometheus ?
+## What is Prometheus ?
 
 Prometheus is a system monitoring and alerting system. It was opensourced by SoundCloud in 2012 and is the second project both to join and to graduate within Cloud Native Computing Foundation after Kubernetes. Prometheus stores all metrics data as time series, i.e metrics information is stored along with the timestamp at which it was recorded, optional key-value pairs called as labels can also be stored along with metrics.
-# What are metrics and why is it important?
+
+## What are metrics and why is it important?
 
 Metrics in layperson terms is a standard for measurement. What we want to measure depends from application to application. For a web server it can be request times, for a database it can be CPU usage or number of active connections etc.
 
 Metrics play an important role in understanding why your application is working in a certain way. If you run a web application and someone comes up to you and says that the application is slow, you will need some information to find out what is happening with your application. For example the application can become slow when the number of requests are high. If you have the request count metric you can spot the reason and increase the number of servers to handle the heavy load. Whenever you are defining the metrics for your application you must put on your detective hat and ask this question **what all information will be important for me to debug if any issue occurs in my application?**
 
-# Basic Architecture of Prometheus
+## Basic Architecture of Prometheus
 
 The basic components of a Prometheus setup are:
 
@@ -50,7 +51,7 @@ A simple Line chart created on the Request Count metric will look like this
 
 One can scrape multiple useful metrics to understand what is happening in the application and create multiple charts on them. Group the charts into a dashboard and use it to get an overview of the application.
 
-# Show me how it is done
+## Show me how it is done
 
 Let’s get our hands dirty and setup Prometheus. Prometheus is written using [Go](https://golang.org/) and all you need is the binary compiled for your operating system. Download the binary corresponding to your operating system from [here](https://prometheus.io/download/) and add the binary to your path.
 

--- a/docs/tutorials/understanding_metric_types.md
+++ b/docs/tutorials/understanding_metric_types.md
@@ -3,13 +3,12 @@ title: Understanding metric types
 sort_rank: 2
 ---
 
-# Types of metrics.
+Prometheus supports four types of metrics:
 
-Prometheus supports four types of metrics, which are
-    - Counter
-    - Gauge
-    - Histogram
-    - Summary
+* Counter
+* Gauge
+* Histogram
+* Summary
 
 ## Counter
 

--- a/docs/tutorials/visualizing_metrics_using_grafana.md
+++ b/docs/tutorials/visualizing_metrics_using_grafana.md
@@ -3,8 +3,6 @@ title: Visualizing metrics using Grafana
 sort_rank: 4
 ---
 
-# Visualizing metrics.
-
 In this tutorial we will create a simple dashboard using [Grafana](https://github.com/grafana/grafana) to visualize the `ping_request_count` metric that we instrumented in the [previous tutorial](./instrumenting_http_server_in_go.md).
 
 If you are wondering why one should use a tool like Grafana when one can query and see the graphs using Prometheus, the answer is that the graph that we see when we run queries on Prometheus is to run ad-hoc queries.

--- a/docs/visualization/browser.md
+++ b/docs/visualization/browser.md
@@ -3,8 +3,6 @@ title: Expression browser
 sort_rank: 1
 ---
 
-# Expression browser
-
 The expression browser is available at `/graph` on the Prometheus server, allowing you
 to enter any expression and see its result either in a table or graphed over time.
 

--- a/docs/visualization/consoles.md
+++ b/docs/visualization/consoles.md
@@ -3,8 +3,6 @@ title: Console templates
 sort_rank: 3
 ---
 
-# Console templates
-
 Console templates allow for creation of arbitrary consoles using the [Go
 templating language](http://golang.org/pkg/text/template/). These are served
 from the Prometheus server.

--- a/docs/visualization/grafana.md
+++ b/docs/visualization/grafana.md
@@ -1,9 +1,8 @@
 ---
-title: Grafana
+title: Grafana support for Prometheus
+nav_title: Grafana
 sort_rank: 2
 ---
-
-# Grafana support for Prometheus
 
 [Grafana](http://grafana.com/) supports querying Prometheus.
 The Grafana data source for Prometheus is included since Grafana 2.5.0 (2015-10-28).

--- a/src/app/docs/[...slug]/page.tsx
+++ b/src/app/docs/[...slug]/page.tsx
@@ -4,9 +4,8 @@ import PromMarkdown, { isAbsoluteUrl } from "@/components/PromMarkdown";
 import docsConfig from "../../../../docs-config";
 import { getPageMetadata } from "@/page-metadata";
 import VersionWarning from "./VersionWarning";
-import { Divider } from "@mantine/core";
+import { Divider, Title } from "@mantine/core";
 import PrevNextEditButtons from "./PrevNextEditButtons";
-import { HTMLAttributes } from "react";
 import path from "path";
 import { DocMetadata } from "@/docs-collection-types";
 
@@ -86,49 +85,53 @@ export default async function DocsPage({
   return (
     <>
       <VersionWarning currentPage={docMeta} />
-      <PromMarkdown
-        wrapperProps={
-          {
-            "data-pagefind-body": pagefindShouldIndex ? "true" : undefined,
-            "data-pagefind-meta": `breadcrumbs:${pagefindBreadcrumbsTitle(
-              docMeta
-            )}`,
-          } as HTMLAttributes<HTMLDivElement>
-        }
-        normalizeHref={(href: string | undefined) => {
-          if (!href) {
-            return href;
-          }
-
-          // Do some postprocessing on the hrefs to make sure they point to the right place.
-          if (href.startsWith(docsConfig.siteUrl)) {
-            // Remove the "https://prometheus.io" from links that start with it.
-            return href.slice(docsConfig.siteUrl.length);
-          } else if (href.startsWith("/") && docMeta.type === "repo-doc") {
-            // Turn "/<path>" into e.g. "https://github.com/prometheus/prometheus/blob/release-3.3/<path>"
-            return `https://github.com/${docMeta.owner}/${docMeta.repo}/blob/release-${docMeta.version}${href}`;
-          } else if (href.includes(".md") && !isAbsoluteUrl(href)) {
-            // Turn relative links like "d.md" in "docs/a/b/c.md" into full paths like "/docs/a/b/d/".
-            return resolveRelativeUrl(`/docs/${docMeta.slug}`, href);
-          }
-          return href;
-        }}
-        normalizeImgSrc={(src: string | Blob | undefined) => {
-          // Leave anything alone that doesn't look like a normal relative URL.
-          if (
-            src &&
-            typeof src === "string" &&
-            !isAbsoluteUrl(src) &&
-            docMeta.type === "repo-doc"
-          ) {
-            return `${docMeta.assetsRoot}/${src}`;
-          }
-
-          return src;
+      <div
+        {...{
+          "data-pagefind-body": pagefindShouldIndex ? "true" : undefined,
+          "data-pagefind-meta": `breadcrumbs:${pagefindBreadcrumbsTitle(
+            docMeta
+          )}`,
         }}
       >
-        {markdown}
-      </PromMarkdown>
+        {docMeta.type === "local-doc" && (
+          <Title order={1}>{docMeta.title}</Title>
+        )}
+        <PromMarkdown
+          normalizeHref={(href: string | undefined) => {
+            if (!href) {
+              return href;
+            }
+
+            // Do some postprocessing on the hrefs to make sure they point to the right place.
+            if (href.startsWith(docsConfig.siteUrl)) {
+              // Remove the "https://prometheus.io" from links that start with it.
+              return href.slice(docsConfig.siteUrl.length);
+            } else if (href.startsWith("/") && docMeta.type === "repo-doc") {
+              // Turn "/<path>" into e.g. "https://github.com/prometheus/prometheus/blob/release-3.3/<path>"
+              return `https://github.com/${docMeta.owner}/${docMeta.repo}/blob/release-${docMeta.version}${href}`;
+            } else if (href.includes(".md") && !isAbsoluteUrl(href)) {
+              // Turn relative links like "d.md" in "docs/a/b/c.md" into full paths like "/docs/a/b/d/".
+              return resolveRelativeUrl(`/docs/${docMeta.slug}`, href);
+            }
+            return href;
+          }}
+          normalizeImgSrc={(src: string | Blob | undefined) => {
+            // Leave anything alone that doesn't look like a normal relative URL.
+            if (
+              src &&
+              typeof src === "string" &&
+              !isAbsoluteUrl(src) &&
+              docMeta.type === "repo-doc"
+            ) {
+              return `${docMeta.assetsRoot}/${src}`;
+            }
+
+            return src;
+          }}
+        >
+          {markdown}
+        </PromMarkdown>
+      </div>
       <Divider my="xl" />
       <PrevNextEditButtons currentPage={docMeta} />
     </>

--- a/src/components/PromMarkdown.tsx
+++ b/src/components/PromMarkdown.tsx
@@ -50,11 +50,9 @@ const h = (order: 1 | 2 | 3 | 4 | 5 | 6) => {
 
 export default async function PromMarkdown({
   children,
-  wrapperProps = {},
   normalizeHref = (href: string | undefined) => href,
   normalizeImgSrc = (src: string | Blob | undefined) => src,
 }: PropsWithChildren<{
-  wrapperProps?: HTMLAttributes<HTMLDivElement>;
   normalizeHref?: (href: string | undefined) => string | undefined;
   normalizeImgSrc?: (
     src: string | Blob | undefined
@@ -65,7 +63,7 @@ export default async function PromMarkdown({
   }
 
   return (
-    <div className="markdown-content" {...wrapperProps}>
+    <div className="markdown-content">
       <MarkdownAsync
         remarkPlugins={[remarkFrontmatter, remarkGfm]}
         rehypePlugins={[


### PR DESCRIPTION
See https://groups.google.com/g/prometheus-developers/c/cwL3cM66Em8

In addition, I took the editorial liberty to make slight other modifications to some of the titles, where it seemed necessary. Also had to adjust deeper header levels further into the doc when the page started off with the wrong one.

And I fixed one completely broken list that was close to a title :P

The PR also fixes up the React code to already handle the new titling scheme for local docs outside of the Markdown content.

<!--
    Please sign CNCF's Developer Certificate of Origin and sign-off your commits by adding the -s / --sign-off flag to `git commit`

    More information on both of those can be found at https://github.com/apps/dco

    If you are proposing a new integration, exporter, or client library, please include representative sample output.
 -->
