### PR TITLE
Include Google Analytics via Next.js instead of Netlify snippet

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -12,6 +12,7 @@
         "@mantine/core": "^8.0.2",
         "@mantine/hooks": "^8.0.2",
         "@mantine/spotlight": "^8.0.2",
+        "@next/third-parties": "^15.3.2",
         "@tabler/icons-react": "^3.31.0",
         "@types/semver": "^7.7.0",
         "dayjs": "^1.11.13",
@@ -1397,6 +1398,19 @@
       ],
       "engines": {
         "node": ">= 10"
+      }
+    },
+    "node_modules/@next/third-parties": {
+      "version": "15.3.2",
+      "resolved": "https://registry.npmjs.org/@next/third-parties/-/third-parties-15.3.2.tgz",
+      "integrity": "sha512-zE9xYkMKZ6gLbkP6lWt60yaeKB5r0A4eZhFKAhgik/eO+zzZPFkTy5K7+0ykgfB6MTkcend3BaDXZhz9KnDjYw==",
+      "license": "MIT",
+      "dependencies": {
+        "third-party-capital": "1.0.20"
+      },
+      "peerDependencies": {
+        "next": "^13.0.0 || ^14.0.0 || ^15.0.0",
+        "react": "^18.2.0 || 19.0.0-rc-de68d2f4-20241204 || ^19.0.0"
       }
     },
     "node_modules/@nodelib/fs.scandir": {
@@ -9013,6 +9027,12 @@
       "resolved": "https://registry.npmjs.org/tabbable/-/tabbable-6.2.0.tgz",
       "integrity": "sha512-Cat63mxsVJlzYvN51JmVXIgNoUokrIaT2zLclCXjRd8boZ0004U4KCs/sToJ75C6sdlByWxpYnb5Boif1VSFew==",
       "license": "MIT"
+    },
+    "node_modules/third-party-capital": {
+      "version": "1.0.20",
+      "resolved": "https://registry.npmjs.org/third-party-capital/-/third-party-capital-1.0.20.tgz",
+      "integrity": "sha512-oB7yIimd8SuGptespDAZnNkzIz+NWaJCu2RMsbs4Wmp9zSDUM8Nhi3s2OOcqYuv3mN4hitXc8DVx+LyUmbUDiA==",
+      "license": "ISC"
     },
     "node_modules/tinyglobby": {
       "version": "0.2.13",

--- a/package.json
+++ b/package.json
@@ -19,6 +19,7 @@
     "@mantine/core": "^8.0.2",
     "@mantine/hooks": "^8.0.2",
     "@mantine/spotlight": "^8.0.2",
+    "@next/third-parties": "^15.3.2",
     "@tabler/icons-react": "^3.31.0",
     "@types/semver": "^7.7.0",
     "dayjs": "^1.11.13",

--- a/src/app/layout.tsx
+++ b/src/app/layout.tsx
@@ -1,4 +1,4 @@
-// import type { Metadata } from "next";
+import { GoogleAnalytics } from "@next/third-parties/google";
 import { Inter } from "next/font/google";
 import { Lato } from "next/font/google";
 import {
@@ -99,6 +99,11 @@ export default function RootLayout({
           </AppShell>
         </MantineProvider>
       </body>
+      {/* The Google Analytics ID is not secret, but we want to keep it in an environment variable so that
+          people who clone and host this repo somewhere else don't accidentally pollute our GA4 stats */}
+      {process.env.NEXT_PUBLIC_GOOGLE_ANALYTICS_ID && (
+        <GoogleAnalytics gaId={process.env.NEXT_PUBLIC_GOOGLE_ANALYTICS_ID} />
+      )}
     </html>
   );
 }


### PR DESCRIPTION
Following the steps at https://nextjs.org/docs/app/guides/third-party-libraries#google-analytics

<!--
    Please sign CNCF's Developer Certificate of Origin and sign-off your commits by adding the -s / --sign-off flag to `git commit`

    More information on both of those can be found at https://github.com/apps/dco

    If you are proposing a new integration, exporter, or client library, please include representative sample output.
 -->
