### PR TITLE
Add NetBird exporter to the exporters list in documentation

### DIFF
--- a/docs/instrumenting/exporters.md
+++ b/docs/instrumenting/exporters.md
@@ -242,6 +242,7 @@ wide variety of JVM-based applications, for example [Kafka](http://kafka.apache.
    * [Meteor JS web framework exporter](https://atmospherejs.com/sevki/prometheus-exporter)
    * [Minecraft exporter module](https://github.com/Baughn/PrometheusIntegration)
    * [Minecraft exporter](https://github.com/dirien/minecraft-prometheus-exporter)
+   * [NetBird exporter](https://github.com/matanbaruch/netbird-api-exporter)
    * [Nomad exporter](https://gitlab.com/yakshaving.art/nomad-exporter)
    * [nftables exporter](https://github.com/Intrinsec/nftables_exporter)
    * [OpenStack exporter](https://github.com/openstack-exporter/openstack-exporter)


### PR DESCRIPTION
This pull request includes a small addition to the `docs/instrumenting/exporters.md` file. The change adds a new entry for the NetBird exporter to the list of available exporters.