### PR TITLE
Allow anonymous GitHub usage without GITHUB_TOKEN env variable

### DIFF
--- a/scripts/githubClient.ts
+++ b/scripts/githubClient.ts
@@ -4,5 +4,5 @@ import { Octokit } from "octokit";
 dotenv.config();
 
 export const octokit = new Octokit({
-  auth: `${process.env.GITHUB_TOKEN}`,
+  auth: process.env.GITHUB_TOKEN,
 });


### PR DESCRIPTION
In case the env var isn't present (like in a Netlify deploy without sensitive variables), this makes sure that "auth" is undefined rather than an invalid empty string.

<!--
    Please sign CNCF's Developer Certificate of Origin and sign-off your commits by adding the -s / --sign-off flag to `git commit`

    More information on both of those can be found at https://github.com/apps/dco

    If you are proposing a new integration, exporter, or client library, please include representative sample output.
 -->
