### PR TITLE
Add Webhook integration for Alertmanager to Notion Database

### DIFF
--- a/docs/operating/integrations.md
+++ b/docs/operating/integrations.md
@@ -90,7 +90,7 @@ For notification mechanisms not natively supported by the Alertmanager, the
   * [IRC Bot](https://github.com/multimfi/bot)
   * [JIRAlert](https://github.com/free/jiralert)
   * [Matrix](https://github.com/matrix-org/go-neb)
-  * [Notion](https://github.com/cthtuf/alertmanager-to-notion): creates\updates record in a Notion database
+  * [Notion](https://github.com/cthtuf/alertmanager-to-notion): creates/updates record in a Notion database
   * [Phabricator / Maniphest](https://github.com/knyar/phalerts)
   * [prom2teams](https://github.com/idealista/prom2teams): forwards notifications to Microsoft Teams
   * [Ansible Tower](https://github.com/pja237/prom2tower): call Ansible Tower (AWX) API on alerts (launch jobs etc.)

--- a/docs/operating/integrations.md
+++ b/docs/operating/integrations.md
@@ -90,6 +90,7 @@ For notification mechanisms not natively supported by the Alertmanager, the
   * [IRC Bot](https://github.com/multimfi/bot)
   * [JIRAlert](https://github.com/free/jiralert)
   * [Matrix](https://github.com/matrix-org/go-neb)
+  * [Notion](https://github.com/cthtuf/alertmanager-to-notion): creates\updates record in a Notion database
   * [Phabricator / Maniphest](https://github.com/knyar/phalerts)
   * [prom2teams](https://github.com/idealista/prom2teams): forwards notifications to Microsoft Teams
   * [Ansible Tower](https://github.com/pja237/prom2tower): call Ansible Tower (AWX) API on alerts (launch jobs etc.)


### PR DESCRIPTION
I propose a new [webhook integration](https://github.com/cthtuf/alertmanager-to-notion) for Notion, which creates or updates a record in a Notion database.
It works out of the box with [my Notion template](https://www.notion.com/templates/incidents-management) but is also compatible with any custom template. Fields requirements are described in the README.

The implementation uses Google Cloud Functions in the current repository. However, the Notion integration is implemented as a standalone class, making it easy to reuse in any Python-based project.