### PR TITLE
Add freeipa-exporter to Prometheus Exporters list

### DIFF
--- a/docs/instrumenting/exporters.md
+++ b/docs/instrumenting/exporters.md
@@ -270,6 +270,7 @@ wide variety of JVM-based applications, for example [Kafka](http://kafka.apache.
    * [Unbound exporter](https://github.com/kumina/unbound_exporter)
    * [WireGuard exporter](https://github.com/MindFlavor/prometheus_wireguard_exporter)
    * [Xen exporter](https://github.com/lovoo/xenstats_exporter)
+   * [FreeIPA exporter](https://github.com/wwwlde/freeipa-exporter)
 
 
 When implementing a new Prometheus exporter, please follow the


### PR DESCRIPTION
Hello Prometheus Maintainers!

I’d like to propose adding my FreeIPA exporter to the official exporters list. Below are the details.

Summary:

This Python-based Prometheus exporter collects metrics from one or more FreeIPA servers over LDAP. It extends the logic of checkipaconsistency and provides structured metrics suitable for long-term monitoring and alerting.

Features:

- Collects detailed metrics about users, groups, hosts, services, DNS zones, replication, and more.
- Metrics exposed via /metrics, with optional caching to reduce load on FreeIPA.
- Labels include host, source, and target for replication metrics.
- Supports Docker (multi-arch image) and Kubernetes deployment, including manifests, ServiceMonitor, alerting rules, and Grafana dashboard.

Example Metrics:

```
# HELP ipa_users Active Users
# TYPE ipa_users gauge
ipa_users{host="freeipa-1"} 27.0
ipa_users{host="freeipa-2"} 27.0
# HELP ipa_susers Stage Users
# TYPE ipa_susers gauge
ipa_susers{host="freeipa-1"} 0.0
ipa_susers{host="freeipa-2"} 0.0
# HELP ipa_pusers Preserved Users
# TYPE ipa_pusers gauge
ipa_pusers{host="freeipa-1"} 0.0
ipa_pusers{host="freeipa-2"} 0.0
# HELP ipa_hosts Hosts
# TYPE ipa_hosts gauge
ipa_hosts{host="freeipa-1"} 2.0
ipa_hosts{host="freeipa-2"} 2.0
# HELP ipa_services Services
# TYPE ipa_services gauge
ipa_services{host="freeipa-1"} 6.0
ipa_services{host="freeipa-2"} 6.0
# HELP ipa_ugroups User Groups
# TYPE ipa_ugroups gauge
ipa_ugroups{host="freeipa-1"} 32.0
ipa_ugroups{host="freeipa-2"} 32.0
# HELP ipa_hgroups Host Groups
# TYPE ipa_hgroups gauge
ipa_hgroups{host="freeipa-1"} 1.0
ipa_hgroups{host="freeipa-2"} 1.0
# HELP ipa_ngroups Netgroups
# TYPE ipa_ngroups gauge
ipa_ngroups{host="freeipa-1"} 0.0
ipa_ngroups{host="freeipa-2"} 0.0
# HELP ipa_hbac HBAC Rules
# TYPE ipa_hbac gauge
ipa_hbac{host="freeipa-1"} 2.0
ipa_hbac{host="freeipa-2"} 2.0
# HELP ipa_sudo SUDO Rules
# TYPE ipa_sudo gauge
ipa_sudo{host="freeipa-1"} 0.0
ipa_sudo{host="freeipa-2"} 0.0
# HELP ipa_zones DNS Zones
# TYPE ipa_zones gauge
ipa_zones{host="freeipa-1"} 0.0
ipa_zones{host="freeipa-2"} 0.0
# HELP ipa_certs Certificates
# TYPE ipa_certs gauge
ipa_certs{host="freeipa-1"} 14.0
ipa_certs{host="freeipa-2"} 14.0
# HELP ipa_conflicts LDAP Conflicts
# TYPE ipa_conflicts gauge
ipa_conflicts{host="freeipa-1"} 0.0
ipa_conflicts{host="freeipa-2"} 0.0
# HELP ipa_ghosts Ghost Replicas
# TYPE ipa_ghosts gauge
ipa_ghosts{host="freeipa-1"} 0.0
ipa_ghosts{host="freeipa-2"} 0.0
# HELP ipa_bind Anonymous BIND (1=ON, 0=OFF)
# TYPE ipa_bind gauge
ipa_bind{host="freeipa-1"} 0.0
ipa_bind{host="freeipa-2"} 0.0
# HELP ipa_msdcs Microsoft ADTrust (1=True, 0=False)
# TYPE ipa_msdcs gauge
ipa_msdcs{host="freeipa-1"} 0.0
ipa_msdcs{host="freeipa-2"} 0.0
# HELP ipa_replication_status Replication status (0=OK, 1=Error)
# TYPE ipa_replication_status gauge
ipa_replication_status{source="freeipa-1",target="freeipa-2"} 0.0
ipa_replication_status{source="freeipa-2",target="freeipa-1"} 0.0
# HELP ipa_up Was the last scrape of this FreeIPA instance successful
# TYPE ipa_up gauge
ipa_up{host="freeipa-1"} 1.0
ipa_up{host="freeipa-2"} 1.0
```

Use Case:

Monitor FreeIPA infrastructure health and configuration drift in real-time, with alerting support (e.g. replication errors, anonymous bind enabled, conflicts, etc.).

Repo: https://github.com/wwwlde/freeipa-exporter

License: GPL-3.0 (inherited from upstream)

Thank you for considering this exporter! I’m happy to make any adjustments needed for inclusion.

Signed-off-by: Denys Lemeshko <62915566+wwwlde@users.noreply.github.com>
