### PR TITLE
Use new frontmatter docs title schema for new Prometheus/Alertmanager docs

### DIFF
--- a/scripts/utils.ts
+++ b/scripts/utils.ts
@@ -10,6 +10,16 @@ export const compareFullVersion = (a: string, b: string) => {
   return compare(a.replace(/^v/, ""), b.replace(/^v/, ""));
 };
 
+// Compares two "<major>.<minor>" version strings., e.g. "3.4" vs "3.5".
+export const compareMajorMinor = (a: string, b: string) => {
+  const [aMajor, aMinor] = a.split(".").map(Number);
+  const [bMajor, bMinor] = b.split(".").map(Number);
+  if (aMajor === bMajor) {
+    return aMinor === bMinor ? 0 : aMinor > bMinor ? 1 : -1;
+  }
+  return aMajor > bMajor ? 1 : -1;
+};
+
 export function filterUnique(value: string, index: number, array: string[]) {
   return array.indexOf(value) === index;
 }

--- a/src/app/docs/[...slug]/page.tsx
+++ b/src/app/docs/[...slug]/page.tsx
@@ -8,6 +8,7 @@ import { Divider, Title } from "@mantine/core";
 import PrevNextEditButtons from "./PrevNextEditButtons";
 import path from "path";
 import { DocMetadata } from "@/docs-collection-types";
+import { compareMajorMinor } from "../../../../scripts/utils";
 
 // Next.js uses this function at build time to figure out which
 // docs pages it should statically generate.
@@ -82,6 +83,18 @@ export default async function DocsPage({
     (docMeta.version === docMeta.latestVersion &&
       !docMeta.slug.startsWith(docMeta.versionRoot));
 
+  // The Markdown format was changed in Prometheus >3.4 and Alertmanager >0.28
+  // to not include the H1 title in the Markdown content itself, so we need to
+  // externally render the title using the frontmatter `title` field instead..
+  const useFrontmatterTitle =
+    docMeta.type === "local-doc" ||
+    (docMeta.type === "repo-doc" &&
+      docMeta.owner === "prometheus" &&
+      ((docMeta.repo === "prometheus" &&
+        compareMajorMinor(docMeta.version, "3.4") === 1) ||
+        (docMeta.repo === "alertmanager" &&
+          compareMajorMinor(docMeta.version, "0.28") === 1)));
+
   return (
     <>
       <VersionWarning currentPage={docMeta} />
@@ -93,9 +106,7 @@ export default async function DocsPage({
           )}`,
         }}
       >
-        {docMeta.type === "local-doc" && (
-          <Title order={1}>{docMeta.title}</Title>
-        )}
+        {useFrontmatterTitle && <Title order={1}>{docMeta.title}</Title>}
         <PromMarkdown
           normalizeHref={(href: string | undefined) => {
             if (!href) {


### PR DESCRIPTION
The Prometheus PR for this is already merged (thus the current pre-release 3.5 docs are missing their titles on prometheus.io), while the PR for Alertmanager (https://github.com/prometheus/alertmanager/pull/4408) still needs to be merged. If someone wants to give that one a :+1: as well, it'd be appreciated.

<!--
    Please sign CNCF's Developer Certificate of Origin and sign-off your commits by adding the -s / --sign-off flag to `git commit`

    More information on both of those can be found at https://github.com/apps/dco

    If you are proposing a new integration, exporter, or client library, please include representative sample output.
 -->
