### PR TITLE
Allow referrer info for outgoing links again

### DIFF
--- a/src/app/support-training/page.tsx
+++ b/src/app/support-training/page.tsx
@@ -51,7 +51,7 @@ const trainingProviders: ProviderCardProps[] = [
     name: "KodeKloud",
     logo: "/assets/commercial-support-logos/kodekloud-logo.svg",
     url: "https://kodekloud.com/courses/prometheus-certified-associate-pca/",
-  }
+  },
 ];
 
 const commercialSupportProviders: ProviderCardProps[] = [
@@ -165,7 +165,7 @@ function ProviderCard({
     <a
       href={url}
       target="_blank"
-      rel="noopener noreferrer"
+      rel="noopener"
       style={{ textDecoration: "none" }}
     >
       <Card

--- a/src/components/PromMarkdown.tsx
+++ b/src/components/PromMarkdown.tsx
@@ -139,7 +139,7 @@ export default async function PromMarkdown({
                 {...rest}
                 href={href}
                 target="_blank"
-                rel="noopener noreferrer"
+                rel="noopener"
               >
                 {/* Only add the icon if the first child is a string. This is to avoid
                 breaking the layout of other components like image links etc. */}


### PR DESCRIPTION
It can actually be nice to show other websites that they are getting traffic from prometheus.io. After deploying the new website, I noticed in my own Plausible tracking for training.promlabs.com that I (supposedly) wasn't getting traffic from prometheus.io anymore and was wondering for a second what was going on.

<!--
    Please sign CNCF's Developer Certificate of Origin and sign-off your commits by adding the -s / --sign-off flag to `git commit`

    More information on both of those can be found at https://github.com/apps/dco

    If you are proposing a new integration, exporter, or client library, please include representative sample output.
 -->
