### PR TITLE
Update the URL to Dovecot's metrics endpoint documentation

### DIFF
--- a/docs/instrumenting/exporters.md
+++ b/docs/instrumenting/exporters.md
@@ -297,7 +297,7 @@ separate exporters are needed:
    * [Diffusion](https://docs.pushtechnology.com/docs/latest/manual/html/administratorguide/systemmanagement/r_statistics.html)
    * [Docker Daemon](https://docs.docker.com/engine/reference/commandline/dockerd/#daemon-metrics)
    * [Doorman](https://github.com/youtube/doorman) (**direct**)
-   * [Dovecot](https://doc.dovecot.org/configuration_manual/stats/openmetrics/)
+   * [Dovecot](https://doc.dovecot.org/main/core/config/statistics.html#openmetrics)
    * [Envoy](https://www.envoyproxy.io/docs/envoy/latest/operations/admin.html#get--stats?format=prometheus)
    * [Etcd](https://github.com/coreos/etcd) (**direct**)
    * [Flink](https://github.com/apache/flink)


### PR DESCRIPTION
The URL was dead, so here is a working one. I've linked to the docs on main instead of a specific version so the link doesn't become outdated as quickly.

Let me know if you need anything else from me!

