### PR TITLE
Add IBM Storage Scale exporter to the exporters list in documentation

### DIFF
--- a/docs/instrumenting/exporters.md
+++ b/docs/instrumenting/exporters.md
@@ -123,6 +123,7 @@ wide variety of JVM-based applications, for example [Kafka](http://kafka.apache.
    * [Pure Storage exporter](https://github.com/PureStorage-OpenConnect/pure-exporter)
    * [ScaleIO exporter](https://github.com/syepes/sio2prom)
    * [Tivoli Storage Manager/IBM Spectrum Protect exporter](https://github.com/treydock/tsm_exporter)
+   * [IBM Storage Scale metrics exporter](https://github.com/IBM/ibm-spectrum-scale-bridge-for-grafana)
 
 ### HTTP
    * [Apache exporter](https://github.com/Lusitaniae/apache_exporter)


### PR DESCRIPTION
This pull request includes a small addition to the docs/instrumenting/exporters.md file. The change adds a new entry for the IBM Storage Scale metrics exporter to the list of available exporters.
