### PR TITLE
Add HP iLO exporter to exporters list

### DIFF
--- a/docs/instrumenting/exporters.md
+++ b/docs/instrumenting/exporters.md
@@ -85,7 +85,7 @@ wide variety of JVM-based applications, for example [Kafka](http://kafka.apache.
    * [Weathergoose Climate Monitor Exporter](https://github.com/branttaylor/watchdog-prometheus-exporter)
    * [Windows exporter](https://github.com/prometheus-community/windows_exporter)
    * [Intel® Optane™ Persistent Memory Controller Exporter](https://github.com/intel/ipmctl-exporter)
-   * - [HP iLO Exporter](https://github.com/imidevops/hp-ilo-exporter-prometheus) — Prometheus exporter for monitoring HP iLO hardware metrics (disks, RAID, power, temperature) with Grafana dashboard support.
+   * [HP iLO Exporter](https://github.com/imidevops/hp-ilo-exporter-prometheus) — Prometheus exporter for monitoring HP iLO hardware metrics (disks, RAID, power, temperature) with Grafana dashboard support.
 
 
 ### Issue trackers and continuous integration


### PR DESCRIPTION

### Exporter Name
HP iLO Exporter

### Description
Prometheus exporter for monitoring HPE iLO (Integrated Lights-Out) hardware metrics.  
It collects disk health, RAID status, power supply status, and temperature readings.  
Includes example Prometheus scrape configuration and Grafana dashboards.

### Repository
[hp-ilo-exporter-prometheus](https://github.com/imidevops/hp-ilo-exporter-prometheus)

### Sample Metrics Output
```text
# HELP disk_health Physical Disk Health Status
# TYPE disk_health gauge
disk_health{ip="10.15.168.157",slot="Slot 1"} 2
disk_health{ip="10.15.168.157",slot="Slot 2"} 2

# HELP disk_temperature Disk Temperature
# TYPE disk_temperature gauge
disk_temperature{ip="10.15.168.157",slot="Slot 1"} 36
disk_temperature{ip="10.15.168.157",slot="Slot 2"} 37

# HELP raid_status RAID Status
# TYPE raid_status gauge
raid_status{ip="10.15.168.157"} 2
