### PR TITLE
Add CCF HuaTuo exporter to the exporters list in documentation

### DIFF
--- a/docs/instrumenting/exporters.md
+++ b/docs/instrumenting/exporters.md
@@ -174,6 +174,7 @@ wide variety of JVM-based applications, for example [Kafka](http://kafka.apache.
    * [Alibaba Cloudmonitor exporter](https://github.com/aylei/aliyun-exporter)
    * [AWS CloudWatch exporter](https://github.com/prometheus/cloudwatch_exporter) (**official**)
    * [Azure Monitor exporter](https://github.com/RobustPerception/azure_metrics_exporter)
+   * [CCF HuaTuo exporter](https://github.com/ccfos/huatuo)
    * [Cloud Foundry Firehose exporter](https://github.com/cloudfoundry-community/firehose_exporter)
    * [Collectd exporter](https://github.com/prometheus/collectd_exporter) (**official**)
    * [Google Stackdriver exporter](https://github.com/frodenas/stackdriver_exporter)


### PR DESCRIPTION

exporter sample output：

huatuo_bamai_sockstat_FRAG_inuse{host="linux-dev",region="example"} 0
huatuo_bamai_sockstat_FRAG_memory{host="linux-dev",region="example"} 0
huatuo_bamai_sockstat_RAW_inuse{host="linux-dev",region="example"} 0
huatuo_bamai_sockstat_TCP_alloc{host="linux-dev",region="example"} 211
huatuo_bamai_sockstat_TCP_inuse{host="linux-dev",region="example"} 170
huatuo_bamai_sockstat_TCP_mem{host="linux-dev",region="example"} 0
huatuo_bamai_sockstat_TCP_mem_bytes{host="linux-dev",region="example"} 0
huatuo_bamai_sockstat_TCP_orphan{host="linux-dev",region="example"} 10
huatuo_bamai_sockstat_TCP_tw{host="linux-dev",region="example"} 591
huatuo_bamai_sockstat_UDPLITE_inuse{host="linux-dev",region="example"} 0
huatuo_bamai_sockstat_UDP_inuse{host="linux-dev",region="example"} 6
huatuo_bamai_sockstat_UDP_mem{host="linux-dev",region="example"} 1024
huatuo_bamai_sockstat_UDP_mem_bytes{host="linux-dev",region="example"} 4.194304e+06
huatuo_bamai_sockstat_container_FRAG_inuse{container_host="xxx",container_hostnamespace="kube-system",container_level="Burstable",container_name="coredns",container_type="Normal",host="linux-dev",region="example"} 0
huatuo_bamai_sockstat_container_FRAG_memory{container_host="xxx",container_hostnamespace="kube-system",container_level="Burstable",container_name="coredns",container_type="Normal",host="linux-dev",region="example"} 0
huatuo_bamai_sockstat_container_RAW_inuse{container_host="xxx",container_hostnamespace="kube-system",container_level="Burstable",container_name="coredns",container_type="Normal",host="linux-dev",region="example"} 0
huatuo_bamai_sockstat_container_TCP_alloc{container_host="xxx",container_hostnamespace="kube-system",container_level="Burstable",container_name="coredns",container_type="Normal",host="linux-dev",region="example"} 211
huatuo_bamai_sockstat_container_TCP_orphan{container_host="xxx",container_hostnamespace="kube-system",container_level="Burstable",container_name="coredns",container_type="Normal",host="linux-dev",region="example"} 10
huatuo_bamai_sockstat_container_TCP_tw{container_host="xxx",container_hostnamespace="kube-system",container_level="Burstable",container_name="coredns",container_type="Normal",host="linux-dev",region="example"} 77
huatuo_bamai_sockstat_container_UDPLITE_inuse{container_host="xxx",container_hostnamespace="kube-system",container_level="Burstable",container_name="coredns",container_type="Normal",host="linux-dev",region="example"} 0
huatuo_bamai_softirq_latency{cpuid="0",host="linux-dev",region="example",type="NET_RX",zone="0"} 2
huatuo_bamai_softirq_latency{cpuid="0",host="linux-dev",region="example",type="NET_RX",zone="1"} 0
huatuo_bamai_softirq_latency{cpuid="0",host="linux-dev",region="example",type="NET_RX",zone="2"} 0
huatuo_bamai_softirq_latency{cpuid="0",host="linux-dev",region="example",type="NET_RX",zone="3"} 0
huatuo_bamai_softirq_latency{cpuid="0",host="linux-dev",region="example",type="NET_TX",zone="0"} 0
huatuo_bamai_softirq_latency{cpuid="0",host="linux-dev",region="example",type="NET_TX",zone="1"} 0
huatuo_bamai_softirq_latency{cpuid="0",host="linux-dev",region="example",type="NET_TX",zone="2"} 0
huatuo_bamai_softirq_latency{cpuid="0",host="linux-dev",region="example",type="NET_TX",zone="3"} 0

Signed-off-by: Tonghao Zhang <tonghao@bamaicloud.com>