### PR TITLE
fix: fix build by allowing README file in blog dir

### DIFF
--- a/blog-posts/README.md
+++ b/blog-posts/README.md
@@ -30,7 +30,7 @@ So, there are no rigid rules around style. But here a few formatting guidelines 
 `[Prometheus documentation](https://prometheus.io/docs/introduction/overview/)`.
 
 - **Images and diagrams:** Always include alt text so the content is accessible to everyone.
-  Store images in the `assets` folder (instead of linking from external sites) and reference them in your post.
+  Store images in the `<repo_root>/public/assets` folder (instead of linking from external sites) and reference them in your post.
 
 > [!NOTE]
 > See the general [Markdown Documentation Formatting Guide](../markdown-guide.md) for more formatting rules.

--- a/blog-posts/assets/.gitkeep
+++ b/blog-posts/assets/.gitkeep
@@ -1,1 +1,0 @@
-This folder stores images for blog posts.

--- a/src/blog-helpers.ts
+++ b/src/blog-helpers.ts
@@ -35,7 +35,7 @@ export const getPostFilePath = (params: {
 };
 
 export const getAllPostFileNames = () => {
-  return fs.readdirSync(blogPostsDir);
+  return fs.readdirSync(blogPostsDir).filter((f) => f !== "README.md");
 };
 
 export const getAllPostParams = () => {


### PR DESCRIPTION
Looks like we accidentally merged https://github.com/prometheus/docs/pull/2713 without seeing the CI failures.

Fixing the root cause, fixed assets dir bug - I think we have assets in public/assets

cc @nwanduka