### PR TITLE
Fix link for HeyOnCall Alert Manager Webhook Integration

### DIFF
--- a/docs/operating/integrations.md
+++ b/docs/operating/integrations.md
@@ -84,7 +84,7 @@ For notification mechanisms not natively supported by the Alertmanager, the
   * [GitLab](https://docs.gitlab.com/ee/operations/metrics/alerts.html#external-prometheus-instances)
   * [Gotify](https://github.com/DRuggeri/alertmanager_gotify_bridge)
   * [GELF](https://github.com/b-com-software-basis/alertmanager2gelf)
-  * [Heii On-Call](https://heiioncall.com/guides/prometheus-integration)
+  * [Heii On-Call](https://heyoncall.com/guides/prometheus-integration)
   * [Icinga2](https://github.com/vshn/signalilo)
   * [iLert](https://docs.ilert.com/integrations/prometheus)
   * [IRC Bot](https://github.com/multimfi/bot)


### PR DESCRIPTION
@RichiH HeyOnCall was formerly Heii On-Call, just updating the domain in the link to our prometheus integration documentation.

<!--
    Please sign CNCF's Developer Certificate of Origin and sign-off your commits by adding the -s / --sign-off flag to `git commit`

    More information on both of those can be found at https://github.com/apps/dco

    If you are proposing a new integration, exporter, or client library, please include representative sample output.
 -->
