### PR TITLE
Update exporters.md

### DIFF
--- a/docs/instrumenting/exporters.md
+++ b/docs/instrumenting/exporters.md
@@ -242,6 +242,7 @@ wide variety of JVM-based applications, for example [Kafka](http://kafka.apache.
    * [Meteor JS web framework exporter](https://atmospherejs.com/sevki/prometheus-exporter)
    * [Minecraft exporter module](https://github.com/Baughn/PrometheusIntegration)
    * [Minecraft exporter](https://github.com/dirien/minecraft-prometheus-exporter)
+   * [Multipass exporter](https://github.com/Abuelodelanada/multipass-exporter)
    * [NetBird exporter](https://github.com/matanbaruch/netbird-api-exporter)
    * [Nomad exporter](https://gitlab.com/yakshaving.art/nomad-exporter)
    * [nftables exporter](https://github.com/Intrinsec/nftables_exporter)


### PR DESCRIPTION

A Prometheus exporter for [Multipass](https://multipass.run/) that exposes metrics about your Multipass instances added.

<!--
    Please sign CNCF's Developer Certificate of Origin and sign-off your commits by adding the -s / --sign-off flag to `git commit`

    More information on both of those can be found at https://github.com/apps/dco

    If you are proposing a new integration, exporter, or client library, please include representative sample output.
 -->
 
Metrics exposed

 ```
# HELP multipass_instances_total Total number of Multipass instances
# TYPE multipass_instances_total gauge
multipass_instances_total 8

# HELP multipass_instances_running Total number of Multipass running instances
# TYPE multipass_instances_running gauge
multipass_instances_running 6

# HELP multipass_instances_stopped Total number of Multipass stopped instances
# TYPE multipass_instances_stopped gauge
multipass_instances_stopped 1

# HELP multipass_instances_deleted Total number of Multipass deleted instances
# TYPE multipass_instances_deleted gauge
multipass_instances_deleted 1

# HELP multipass_instances_suspended Total number of Multipass suspended instances
# TYPE multipass_instances_suspended gauge
multipass_instances_suspended 0

# HELP multipass_instance_memory_bytes Memory usage of Multipass instances in bytes
# TYPE multipass_instance_memory_bytes gauge
multipass_instance_memory_bytes{name="charm-dev-36",release="Ubuntu 24.04.3 LTS"} 3.388157952e+09
multipass_instance_memory_bytes{name="coslite",release="Ubuntu 22.04.2 LTS"} 2.986962944e+09
multipass_instance_memory_bytes{name="edp",release="Ubuntu 23.10"} 1.530298368e+09

# HELP multipass_error Error collecting metrics from Multipass
# TYPE multipass_error gauge
multipass_error 0
 ```
