### PR TITLE
om1: Update release date

### DIFF
--- a/docs/specs/om/open_metrics_spec.md
+++ b/docs/specs/om/open_metrics_spec.md
@@ -25,7 +25,7 @@ author:
 
 - Version: 1.0
 - Status: Published
-- Date: March 2022
+- Date: November 2020
 - Authors: Richard Hartmann, Ben Kochie, Brian Brazil, Rob Skillington
 
 Created in 2012, Prometheus has been the default for cloud-native observability since 2015. A central part of Prometheus' design is its text metric exposition format, called the Prometheus exposition format 0.0.4, stable since 2014. In this format, special care has been taken to make it easy to generate, to ingest, and to understand by humans. As of 2020, there are more than 700 publicly listed exporters, an unknown number of unlisted exporters, and thousands of native library integrations using this format. Dozens of ingestors from various projects and companies support consuming it.


### PR DESCRIPTION
OM seemed to be released around Nov 2020:
https://www.robustperception.io/openmetrics-is-released/

<!--
    Please sign CNCF's Developer Certificate of Origin and sign-off your commits by adding the -s / --sign-off flag to `git commit`

    More information on both of those can be found at https://github.com/apps/dco

    If you are proposing a new integration, exporter, or client library, please include representative sample output.
 -->
