### PR TITLE
feat(om1.1): follow up relaxed suffix rules

### DIFF
--- a/docs/specs/om/open_metrics_spec_1_1.md
+++ b/docs/specs/om/open_metrics_spec_1_1.md
@@ -877,7 +877,9 @@ It also ensures that there is a basic standard which is easy to implement. This 
 
 We want to allow monitoring systems to get usable information from an OpenMetrics exposition without undue burden. If one were to strip away all metadata and structure and just look at an OpenMetrics exposition as an unordered set of samples that should be usable on its own. As such, there are also no opaque binary types, such as sketches or t-digests which could not be expressed as a mix of gauges and counters as they would require custom parsing and handling.
 
-This principle is applied consistently throughout the standard. For example a MetricFamily's unit is duplicated in the name so that the unit is available for systems that don't understand the unit metadata. The "le" label is a normal label value, rather than getting its own special syntax, so that ingestors don't have to add special histogram handling code to ingest them. As a further example, there are no composite data types. For example, there is no geolocation type for latitude/longitude as this can be done with separate gauge metrics.
+This principle is applied consistently throughout the standard. For example it is encouraged that a MetricFamily's unit is duplicated in the name so that the unit is available for systems that don't understand the unit metadata.
+
+The "le" label is a normal label value, rather than getting its own special syntax, so that ingestors don't have to add special histogram handling code to ingest them. As a further example, there are no composite data types. For example, there is no geolocation type for latitude/longitude as this can be done with separate gauge metrics.
 
 ### Units and Base Units
 


### PR DESCRIPTION
I've scanned the "Design considerations" section of the doc and there's one place that talks about suffixes (unit) specifically. This commit updates the statement about unit suffix to be a recommendation not a rule.

