### PR TITLE
Fix typo with broken link the instrumenting documentation

### DIFF
--- a/docs/instrumenting/writing_exporters.md
+++ b/docs/instrumenting/writing_exporters.md
@@ -529,4 +529,5 @@ port allocations.
 
 Once you’re ready to announce your exporter to the world, email the
 mailing list and send a PR to add it to [the list of available
-exporters](https://github.com/prometheus/docs/blob/main/docs/instrumenting/exporters.md).
+exporters](/docs/instrumenting/exporters/) by editing [this GitHub
+repository file](https://github.com/prometheus/docs/blob/main/docs/instrumenting/exporters.md).


### PR DESCRIPTION
<!--
    Please sign CNCF's Developer Certificate of Origin and sign-off your commits by adding the -s / --sign-off flag to `git commit`

    More information on both of those can be found at https://github.com/apps/dco

    If you are proposing a new integration, exporter, or client library, please include representative sample output.
 -->
The [Writing exporters](https://prometheus.io/docs/instrumenting/writing_exporters) documentation has a broken link in the [Announcing](https://prometheus.io/docs/instrumenting/writing_exporters/#announcing) section. Assuming it points to [Exporters and integrations](https://prometheus.io/docs/instrumenting/exporters/).

FYI: @juliusv
