### PR TITLE
om2: Update authors; update intro

### DIFF
--- a/docs/specs/om/open_metrics_spec_2_0.md
+++ b/docs/specs/om/open_metrics_spec_2_0.md
@@ -17,15 +17,15 @@ author:
 - ins: D. Ashpole
   name: David Ashpole
   organization: Google
-  email: TODO
+  email: dashpole@google.com
 - ins: G. Krajcsovits
   name: György Krajcsovits
   organization: Grafana Labs
-  email: TODO
+  email: krajo@prometheus.io
 - ins: O. Williams
   name: Owen Williams
   organization: Grafana Labs
-  email: TODO
+  email: owen.williams@grafana.com
 - ins: R. Hartmann
   name: Richard Hartmann
   organization: Grafana Labs


### PR DESCRIPTION
As agreed during the last meeting of [the OM 2.0 WG](https://docs.google.com/document/d/1FCD-38Xz1-9b3ExgHOeDTQUKUatzgj5KbCND9t-abZY/edit?tab=t.lvx6fags1fga#heading=h.fao8kq58l0va) I updated the authors for 2.0.

I also emailed 1.0 authors for their preference on how they want to be listed (currently "emeritus").
