### PR TITLE
Add Parny integration to Prometheus integrations list

### DIFF
--- a/docs/operating/integrations.md
+++ b/docs/operating/integrations.md
@@ -91,6 +91,7 @@ For notification mechanisms not natively supported by the Alertmanager, the
   * [JIRAlert](https://github.com/free/jiralert)
   * [Matrix](https://github.com/matrix-org/go-neb)
   * [Notion](https://github.com/cthtuf/alertmanager-to-notion): creates/updates record in a Notion database
+  * [Parny](https://parny.io/integrations/prometheus): AI-native on-call management, incident response, uptime monitoring, and real-time infrastructure visibility platform.
   * [Phabricator / Maniphest](https://github.com/knyar/phalerts)
   * [prom2teams](https://github.com/idealista/prom2teams): forwards notifications to Microsoft Teams
   * [Ansible Tower](https://github.com/pja237/prom2tower): call Ansible Tower (AWX) API on alerts (launch jobs etc.)


### PR DESCRIPTION
### Parny

**Description:**  
AI-native on-call management, incident response, uptime monitoring, and real-time infrastructure visibility platform.  

**Integration type:**  
Native integration with Prometheus via built-in data source and alert ingestion (Alertmanager compatible).

**Documentation:**  
[https://docs.parny.io/integrations/prometheus](https://docs.parny.io/integrations/prometheus)

<!--
    Please sign CNCF's Developer Certificate of Origin and sign-off your commits by adding the -s / --sign-off flag to `git commit`

    More information on both of those can be found at https://github.com/apps/dco

    If you are proposing a new integration, exporter, or client library, please include representative sample output.
 -->

Signed-off-by: Yağmur Uzun <[yagmur.uzun@parny.io](mailto:yagmur.uzun@parny.io)>