### PR TITLE
Fix exporters link path in writing_exporters.md

### DIFF
--- a/docs/instrumenting/writing_exporters.md
+++ b/docs/instrumenting/writing_exporters.md
@@ -529,4 +529,4 @@ port allocations.
 
 Once you’re ready to announce your exporter to the world, email the
 mailing list and send a PR to add it to [the list of available
-exporters](https://github.com/prometheus/docs/blob/main/content/docs/instrumenting/exporters.md).
+exporters](https://github.com/prometheus/docs/blob/main/docs/instrumenting/exporters.md).


### PR DESCRIPTION
## Description

This PR fixes a broken link in the writing_exporters.md documentation.

## Changes

- Fixed the link to the exporters list by removing the incorrect 'content/' prefix
- Link now correctly points to `docs/instrumenting/exporters.md` instead of `content/docs/instrumenting/exporters.md`

## Testing

- [x] Verified the link now points to the correct path
- [x] No other changes were made to the file

## Type of Change

- [x] Documentation fix
- [x] Link correction