### PR TITLE
add 'read more' marker instruction to blog guidelines

### DIFF
--- a/blog/README.md
+++ b/blog/README.md
@@ -46,8 +46,29 @@ and 1500 words (like [this long deep dive](https://prometheus.io/blog/2021/11/16
 If you include code snippets or configuration examples, please make sure they work as written.
 Diagrams or screenshots are also great additions if they help readers grasp complex ideas more quickly.  
 
-When multiple people contribute to a post, we’ll make sure everyone is credited at the end.  
+When multiple people contribute to a post, we’ll make sure everyone is credited at the end.
 
+> [!IMPORTANT]
+> After your introductory section, add a `<!-- more -->` marker on its own line. 
+This marker indicates where the preview cuts off on https://prometheus.io/blog/. See the example below.
+
+**Example structure:**
+```markdown
+---
+title: "Getting Started with Prometheus"
+author: Your Name (@yourgithubusername)
+date: 2025-11-02
+---
+
+Prometheus makes it easy to collect and query metrics from your applications. In this post, we'll walk through
+setting up your first metrics endpoint and understanding what Prometheus collects.
+
+<!-- more -->
+
+## Installing Prometheus
+
+First, let's get Prometheus installed on your system...
+```
 
 ## Review process
 


### PR DESCRIPTION
<!--
    Please sign CNCF's Developer Certificate of Origin and sign-off your commits by adding the -s / --sign-off flag to `git commit`

    More information on both of those can be found at https://github.com/apps/dco

    If you are proposing a new integration, exporter, or client library, please include representative sample output.
 -->
@juliusv I've added the information about the more marker in the blog guidelines like we talked about [here](https://github.com/prometheus/docs/pull/2765#issuecomment-3474729794). Kindly review. Thanks 😊