### PR TITLE
Adds another exporter for Azure Health

### DIFF
--- a/docs/instrumenting/exporters.md
+++ b/docs/instrumenting/exporters.md
@@ -140,7 +140,7 @@ wide variety of JVM-based applications, for example [Kafka](http://kafka.apache.
    * [AWS Health exporter](https://github.com/Jimdo/aws-health-exporter)
    * [AWS SQS exporter](https://github.com/jmal98/sqs_exporter)
    * [AWS SQS Prometheus exporter](https://github.com/jmriebold/sqs-prometheus-exporter)
-   * [Azure Health exporter](https://github.com/FXinnovation/azure-health-exporter)
+   * [Azure Health exporter](https://github.com/matzefriedrich/az-health-exporter)
    * [BigBlueButton](https://github.com/greenstatic/bigbluebutton-exporter)
    * [Cloudflare exporter](https://gitlab.com/gitlab-org/cloudflare_exporter)
    * [Cryptowat exporter](https://github.com/nbarrientos/cryptowat_exporter)


### PR DESCRIPTION
This PR replaces the currently listed Azure Health exporter, as the repository appears to be no longer available.

The exporter produces gauge metrics as follows:

```
# HELP azure_resource_health_status Azure resource health status (1 = healthy, 0 = unhealthy)
# TYPE azure_resource_health_status gauge
azure_resource_health_status{resource_id="...",resource_name="...",resource_type="...",availability_state="Available"} 1

# HELP azure_resource_health_last_check_timestamp Timestamp of last health check
# TYPE azure_resource_health_last_check_timestamp gauge
azure_resource_health_last_check_timestamp{resource_id="...",resource_name="..."} 1.6984752e+09
```