### PR TITLE
Redirect top level spec/<proj> dir to the latest version

### DIFF
--- a/public/_redirects
+++ b/public/_redirects
@@ -26,6 +26,11 @@
 /docs/specs/remote_write_spec /docs/specs/prw/remote_write_spec
 /docs/specs/remote_write_spec_2_0 /docs/specs/prw/remote_write_spec_2_0
 
+# Per spec sub dirs should point the currently "latest" version.
+# E.g. https://openmetrics.io redirects to https://prometheus.io/docs/specs/om
+/docs/specs/om /docs/specs/om/open_metrics_spec
+/docs/specs/prw /docs/specs/prw/remote_write_spec_2_0
+
 # Redirect for HTTP SD docs, which briefly lived in the wrong category / repo.
 /docs/instrumenting/http_sd/ /docs/prometheus/latest/http_sd/
 


### PR DESCRIPTION
This is to allow redirect of openmetrics.io domain to https://prometheus.io/docs/specs/om/ on CNCF side and then be able to dynamically switch latest on our side, also convenience.

Perhaps the domain hosting CNCF uses allows HTTP redirects something like that. If not we could play with some netlify redirection 🤔 

