### PR TITLE
feat(om2): exemplar timestamp MAY to SHOULD

### DIFF
--- a/docs/specs/om/open_metrics_spec_2_0.md
+++ b/docs/specs/om/open_metrics_spec_2_0.md
@@ -108,7 +108,7 @@ Each MetricPoint consists of a set of values, depending on the MetricFamily type
 
 Exemplars are references to data outside of the MetricSet. A common use case are IDs of program traces.
 
-Exemplars MUST consist of a LabelSet and a value, and MAY have a timestamp. They MAY each be different from the MetricPoints' LabelSet and timestamp.
+Exemplars MUST consist of a LabelSet and a value, and SHOULD have a timestamp. They MAY each be different from the MetricPoints' LabelSet and timestamp.
 
 The combined length of the label names and values of an Exemplar's LabelSet MUST NOT exceed 128 UTF-8 character code points. Other characters in the text rendering of an exemplar such as `",=` are not included in this limit for implementation simplicity and for consistency between the text and proto formats.
 


### PR DESCRIPTION
Make the exemplar timestamp a SHOULD in preparation for complex types having multiple exemplars at a time. 

Note:  the current Prometheus implementation can deal with one exemplar per time series without timestamp. Because at scrape if the exemplar doesn't have a timestamp than Prometheus will compare the exemplar's value to the last exemplar for the series. If the value and labels are the same, the exemplar is dropped. This strategy doesn't work for complex types as they get multiple exemplars and the current implementation cannot go back and figure out how many exemplars were in the last scrape.

<!--
    Please sign CNCF's Developer Certificate of Origin and sign-off your commits by adding the -s / --sign-off flag to `git commit`

    More information on both of those can be found at https://github.com/apps/dco

    If you are proposing a new integration, exporter, or client library, please include representative sample output.
 -->
