### PR TITLE
List alertmanager-graphmail-forwarder in integrations.md

### DIFF
--- a/docs/operating/integrations.md
+++ b/docs/operating/integrations.md
@@ -90,6 +90,7 @@ For notification mechanisms not natively supported by the Alertmanager, the
   * [IRC Bot](https://github.com/multimfi/bot)
   * [JIRAlert](https://github.com/free/jiralert)
   * [Matrix](https://github.com/matrix-org/go-neb)
+  * [Microsoft Graph SendMail](https://gitlab.timtrense.com/tim/alertmanager-graphmail-forwarder)
   * [Notion](https://github.com/cthtuf/alertmanager-to-notion): creates/updates record in a Notion database
   * [Phabricator / Maniphest](https://github.com/knyar/phalerts)
   * [prom2teams](https://github.com/idealista/prom2teams): forwards notifications to Microsoft Teams


### PR DESCRIPTION
<!--
    Please sign CNCF's Developer Certificate of Origin and sign-off your commits by adding the -s / --sign-off flag to `git commit`

    More information on both of those can be found at https://github.com/apps/dco

    If you are proposing a new integration, exporter, or client library, please include representative sample output.
 -->


# Preamble

Thank you, Prometheus-Team, for creating this cool software.
I want to contribute something back to the community, so I want to share my own alertmanager receiver implementation.

# Architecture

```txt
alertmanager ---webhook---> [this app] ---REST---> Microsoft Graph API ---Mail---> Recipient
```

The app is a python/Flask web server that receives alertmanager webhooks and forwards them via [SendMail](https://learn.microsoft.com/en-us/graph/api/user-sendmail) to the recipients.

The reason for having this integration is that Alertmanager cannot authenticate SMTP using SASL/XOAuth (OAuth2) when connecting with the server. Thus, integration with modern enterprise mail servers (such as MS Exchange) is no longer possible using their default configuration (with disabled SMTP BasicAuth). This integration bridges that gap for EntraID+Exchange users.

# Example usage

```bash
docker run --rm -it -p $PORT:$PORT \
    -e "TO=someone@example.com,another@example.com" \
    -e "FROM=prometheus@example.com" \
    -e "CLIENT_ID=prometheus" \
    -e "TENANT_ID=$TENANT_ID" \
    -e "CLIENT_SECRET=$CLIENT_SECRET" \
    -e "AUTH_TOKEN=$AUTH_TOKEN" \
    docker-registry.timtrense.com/tim/alertmanager-graphmail-forwarder:latest
```