### PR TITLE
Fix broken prom.lib link in console docs

### DIFF
--- a/docs/visualization/consoles.md
+++ b/docs/visualization/consoles.md
@@ -120,8 +120,9 @@ Valid output formats for the third argument to `prom_query_drilldown`:
   This is usually used with `B` as the second argument to produce units such as `KiB` and `MiB`.
 * `printf.3g`: Display 3 significant digits.
 
-Custom formats can be defined. See
-[prom.lib](https://github.com/prometheus/prometheus/blob/main/console_libraries/prom.lib) for examples.
+Custom formats can be defined in your own console libraries; see the example
+templates shipped in the `console_libraries` directory of the Prometheus
+release artifacts for reference.
 
 ## Graph Library
 


### PR DESCRIPTION
## Summary
- replace the dead prom.lib link with a reference to the console_libraries examples shipped in Prometheus release artifacts

## Rationale
- prom.lib was removed upstream, so the existing link 404s; this keeps the guidance without pointing to a missing file.

## Testing
- not run (docs-only change)

Fixes #2649