### PR TITLE
update cadvisor doc to support inlini config

### DIFF
--- a/docs/guides/cadvisor.md
+++ b/docs/guides/cadvisor.md
@@ -103,15 +103,7 @@ version: '3.8'
 configs:
   prometheus_config:
     content: |
-      global:
-        scrape_interval: 15s
-        evaluation_interval: 15s
-
       scrape_configs:
-        - job_name: 'prometheus'
-          static_configs:
-            - targets: ['localhost:9090']
-
         - job_name: 'cadvisor'
           scrape_interval: 5s
           static_configs:


### PR DESCRIPTION
<!--
    Please sign CNCF's Developer Certificate of Origin and sign-off your commits by adding the -s / --sign-off flag to `git commit`

    More information on both of those can be found at https://github.com/apps/dco

    If you are proposing a new integration, exporter, or client library, please include representative sample output.
 -->
This PR addresses [#17613](https://github.com/prometheus/prometheus/issues/17613)

Added documentation for using inline Docker configs as an alternative to bind mounts when deploying Prometheus with Docker Compose.

This approach is particularly useful when deploying to remote Docker hosts, as it eliminates the need to manually manage configuration files on the host filesystem. All configuration is embedded in the `docker-compose.yml` file.

**Key additions:**
- Complete example using Docker's `configs` feature
- Required `uid`, `gid`, and `mode` parameters (with explanation of the error users encounter if omitted)
- Guidance on finding correct UID/GID values for different images
- Use cases for when this approach is beneficial
