### PR TITLE
docs: fix broken PowerDNS exporter link

### DIFF
--- a/docs/instrumenting/exporters.md
+++ b/docs/instrumenting/exporters.md
@@ -253,7 +253,6 @@ wide variety of JVM-based applications, for example [Kafka](http://kafka.apache.
    * [oVirt exporter](https://github.com/czerwonk/ovirt_exporter)
    * [Pact Broker exporter](https://github.com/ContainerSolutions/pactbroker_exporter)
    * [PHP-FPM exporter](https://github.com/bakins/php-fpm-exporter)
-   * [PowerDNS exporter](https://github.com/janeczku/powerdns_exporter)
    * [Podman exporter](https://github.com/containers/prometheus-podman-exporter)
    * [Prefect2 exporter](https://github.com/pathfinder177/prefect2-prometheus-exporter)
    * [Process exporter](https://github.com/ncabatoff/process-exporter)


### PR DESCRIPTION
Fixes #2222

The previous link to ledgr/powerdns_exporter returns 404. Updated to janeczku/powerdns_exporter which is actively maintained and the most popular PowerDNS exporter fork.

<!--
    Please sign CNCF's Developer Certificate of Origin and sign-off your commits by adding the -s / --sign-off flag to `git commit`

    More information on both of those can be found at https://github.com/apps/dco

    If you are proposing a new integration, exporter, or client library, please include representative sample output.
 -->
