### PR TITLE
docs: remove broken prom.lib link

### DIFF
--- a/docs/visualization/consoles.md
+++ b/docs/visualization/consoles.md
@@ -120,8 +120,7 @@ Valid output formats for the third argument to `prom_query_drilldown`:
   This is usually used with `B` as the second argument to produce units such as `KiB` and `MiB`.
 * `printf.3g`: Display 3 significant digits.
 
-Custom formats can be defined. See
-[prom.lib](https://github.com/prometheus/prometheus/blob/main/console_libraries/prom.lib) for examples.
+Custom formats can be defined.
 
 ## Graph Library
 


### PR DESCRIPTION
Fixes #2649

The link to console_libraries/prom.lib returns 404 as the console_libraries directory has been removed from the prometheus/prometheus repository. Removed the broken link while keeping the informational text about custom formats.

<!--
    Please sign CNCF's Developer Certificate of Origin and sign-off your commits by adding the -s / --sign-off flag to `git commit`

    More information on both of those can be found at https://github.com/apps/dco

    If you are proposing a new integration, exporter, or client library, please include representative sample output.
 -->
