### PR TITLE
docs: update outdated Java client code references

### DIFF
--- a/docs/instrumenting/writing_exporters.md
+++ b/docs/instrumenting/writing_exporters.md
@@ -345,7 +345,7 @@ in your `Collect()` method. For Python see
 [https://github.com/prometheus/client_python#custom-collectors](https://prometheus.github.io/client_python/collector/custom/)
 and for Java generate a `List<MetricFamilySamples>` in your collect
 method, see
-[StandardExports.java](https://github.com/prometheus/client_java/blob/master/simpleclient_hotspot/src/main/java/io/prometheus/client/hotspot/StandardExports.java)
+[JvmMetrics.java](https://github.com/prometheus/client_java/blob/main/prometheus-metrics-instrumentation-jvm/src/main/java/io/prometheus/metrics/instrumentation/jvm/JvmMetrics.java)
 for an example.
 
 The reason for this is two-fold. Firstly, two scrapes could happen at
@@ -388,7 +388,7 @@ the Prometheus ecosystem, such metrics should be dropped.
 In the Java world, many instrumentation frameworks expose process-level
 and JVM-level stats such as CPU and GC. The Java client and JMX exporter
 already include these in the preferred form via
-[DefaultExports.java](https://github.com/prometheus/client_java/blob/master/simpleclient_hotspot/src/main/java/io/prometheus/client/hotspot/DefaultExports.java),
+[JvmMetrics.java](https://github.com/prometheus/client_java/blob/main/prometheus-metrics-instrumentation-jvm/src/main/java/io/prometheus/metrics/instrumentation/jvm/JvmMetrics.java),
 so these should also be dropped.
 
 Similarly with other languages and frameworks.


### PR DESCRIPTION
Updated references from the deprecated simpleclient_hotspot module to the current prometheus-metrics-instrumentation-jvm module:

- StandardExports.java -> JvmMetrics.java
- DefaultExports.java -> JvmMetrics.java

The old simpleclient modules have been archived and replaced with the new prometheus-metrics structure. JvmMetrics.java provides equivalent functionality for JVM instrumentation.

<!--
    Please sign CNCF's Developer Certificate of Origin and sign-off your commits by adding the -s / --sign-off flag to `git commit`

    More information on both of those can be found at https://github.com/apps/dco

    If you are proposing a new integration, exporter, or client library, please include representative sample output.
 -->
