### PR TITLE
docs: add mixin definition to glossary

### DIFF
--- a/docs/introduction/glossary.md
+++ b/docs/introduction/glossary.md
@@ -51,6 +51,10 @@ An instance is a label that uniquely identifies a target in a job.
 
 A collection of targets with the same purpose, for example monitoring a group of like processes replicated for scalability or reliability, is called a job.
 
+### Mixin
+
+A mixin is a reusable and extensible set of Prometheus alerts, recording rules, and Grafana dashboards for a specific component or system. Mixins are typically packaged using [Jsonnet](https://jsonnet.org/) and can be combined to create comprehensive monitoring configurations. They enable standardized monitoring across similar infrastructure components.
+
 ### Notification
 
 A notification represents a group of one or more alerts, and is sent by the Alertmanager to email, Pagerduty, Slack etc.


### PR DESCRIPTION
Fixes #1806

Added definition for 'mixin' to the glossary, explaining it as a reusable set of Prometheus alerts, recording rules, and Grafana dashboards typically packaged using Jsonnet for standardized monitoring across infrastructure components.

<!--
    Please sign CNCF's Developer Certificate of Origin and sign-off your commits by adding the -s / --sign-off flag to `git commit`

    More information on both of those can be found at https://github.com/apps/dco

    If you are proposing a new integration, exporter, or client library, please include representative sample output.
 -->
