### PR TITLE
docs: replace discontinued go-neb with matrix-hookshot

### DIFF
--- a/docs/operating/integrations.md
+++ b/docs/operating/integrations.md
@@ -89,7 +89,6 @@ For notification mechanisms not natively supported by the Alertmanager, the
   * [iLert](https://docs.ilert.com/integrations/prometheus)
   * [IRC Bot](https://github.com/multimfi/bot)
   * [JIRAlert](https://github.com/free/jiralert)
-  * [Matrix](https://github.com/matrix-org/go-neb): Go-NEB bot (discontinued)
   * [Matrix](https://github.com/jaywink/matrix-alertmanager): sends Alertmanager notifications to Matrix rooms
   * [Matrix](https://github.com/hectorjsmith/matrix-hookshot): bridges webhooks to Matrix with rich formatting support
   * [Notion](https://github.com/cthtuf/alertmanager-to-notion): creates/updates record in a Notion database


### PR DESCRIPTION
Fixes #2366

Replaced the link to go-neb (which has been discontinued) with matrix-hookshot, the spiritual successor recommended in the go-neb repository for Matrix notifications.

<!--
    Please sign CNCF's Developer Certificate of Origin and sign-off your commits by adding the -s / --sign-off flag to `git commit`

    More information on both of those can be found at https://github.com/apps/dco

    If you are proposing a new integration, exporter, or client library, please include representative sample output.
 -->
