### PR TITLE
docs: improve node exporter download instructions

### DIFF
--- a/docs/guides/node-exporter.md
+++ b/docs/guides/node-exporter.md
@@ -17,11 +17,20 @@ The Prometheus Node Exporter is a single static binary that you can install [via
 
 ```bash
 # NOTE: Replace the URL with one from the above mentioned "downloads" page.
-# Download the appropriate bundle for your operating system and hardware architecture.
-# <VERSION>, <OS>, and <ARCH> are placeholders (e.g., linux-amd64, darwin-arm64, etc.).
-wget https://github.com/prometheus/node_exporter/releases/download/v<VERSION>/node_exporter-<VERSION>.<OS>-<ARCH>.tar.gz
-tar xvfz node_exporter-<VERSION>.<OS>-<ARCH>.tar.gz
-cd node_exporter-<VERSION>.<OS>-<ARCH>
+# Node Exporter is available for multiple OS targets and architectures.
+# Downloads are available at:
+# https://github.com/prometheus/node_exporter/releases/download/v<VERSION>/node_exporter-<VERSION>.<OS>-<ARCH>.tar.gz
+#
+# <VERSION>, <OS>, and <ARCH> are placeholders:
+# - <VERSION>: Release version (e.g., 1.10.2)
+# - <OS>: Operating system (e.g., linux, darwin, freebsd)
+# - <ARCH>: Architecture (e.g., amd64, arm64, 386)
+#
+# For this example, we will use Node Exporter version 1.10.2 for a Linux system with amd64 architecture.
+
+wget https://github.com/prometheus/node_exporter/releases/download/v1.10.2/node_exporter-1.10.2.linux-amd64.tar.gz
+tar xvfz node_exporter-1.10.2.linux-amd64.tar.gz
+cd node_exporter-1.10.2.linux-amd64
 ./node_exporter
 ```
 


### PR DESCRIPTION
Fixes #1896

Clarified download instructions for Node Exporter to help users:
- Select the appropriate bundle for their OS and architecture
- Added note about platform-specific downloads (linux-amd64, darwin-arm64, etc.)
- Made tar command more specific to match downloaded file pattern
- Improved clarity for new users

<!--
    Please sign CNCF's Developer Certificate of Origin and sign-off your commits by adding the -s / --sign-off flag to `git commit`

    More information on both of those can be found at https://github.com/apps/dco

    If you are proposing a new integration, exporter, or client library, please include representative sample output.
 -->
