### PR TITLE
feat(om2.0): allow float histograms

### DIFF
--- a/docs/specs/om/open_metrics_spec_2_0.md
+++ b/docs/specs/om/open_metrics_spec_2_0.md
@@ -250,7 +250,7 @@ Histograms measure distributions of discrete events. Common examples are the lat
 
 A Histogram MetricPoint MUST contain Count and Sum values.
 
-The Count value MUST be equal to the number of measurements taken by the Histogram. The Count is a counter semantically. The Count SHOULD be an integer. The Count MUST NOT be +Inf, NaN, or negative.
+The Count value MUST be equal to the number of measurements taken by the Histogram. The Count is a counter semantically. The Count SHOULD be an integer. The Count MUST NOT be negative. The Count SHOULD NOT be +Inf, NaN.
 
 Float Count is allowed to make it possible to expose results of arithmetic operations on histograms, such as addition that may result in values beyond the range of integers.
 
@@ -258,7 +258,7 @@ The Sum value MUST be equal to the sum of all the measured event values. The Sum
 
 A Histogram MUST measure values that are not NaN in either [Classic Buckets](#classic-buckets) or [Native Buckets](#native-buckets) or both. Measuring NaN is different for Classic and Native Buckets, see in their respective sections.
 
-Every Bucket MUST have well-defined boundaries and a value. The bucket value is called the bucket count colloquially. Boundaries of a Bucket MUST NOT be NaN. Bucket values SHOULD be integers. Semantically, bucket values are counters so MUST NOT be +Inf, NaN, or negative.
+Every Bucket MUST have well-defined boundaries and a value. The bucket value is called the bucket count colloquially. Boundaries of a Bucket MUST NOT be NaN. Bucket values are counters semantically. Bucket values SHOULD be integers. Bucket values MUST NOT be negative. Bucket values SHOULD NOT be +Inf, NaN.
 
 Float bucket values are allowed to make it possible to expose results of arithmetic operations on histograms, such as addition that may result in values beyond the range of integers.
 
@@ -341,7 +341,7 @@ GaugeHistograms measure current distributions. Common examples are how long item
 
 A GaugeHistogram MetricPoint MUST contain Gcount, Gsum values.
 
-The GCount value MUST be equal to the number of measurements currently in the GaugeHistogram. The GCount is a gauge semantically. The GCount SHOULD be and integer. The GCount MUST NOT be -Inf, +Inf, or NAN. The GCount SHOULD NOT be negative.
+The GCount value MUST be equal to the number of measurements currently in the GaugeHistogram. The GCount is a gauge semantically. The GCount SHOULD be and integer. The GCount SHOULD NOT be -Inf, +Inf, NAN, or negative.
 
 Float and negative GCount is allowed to make it possible to expose results of arithmetic operations on GaugeHistograms, such as the rate of change of a Histogram over time.
 
@@ -511,7 +511,7 @@ complex-value = nativehistogram
 nativehistogram = nh-count "," nh-sum "," nh-schema "," nh-zero-threshold "," nh-zero-count [ "," nh-negative-spans "," nh-negative-buckets ] [ "," nh-positive-spans "," nh-positive-buckets ]
 
 ; count:x
-nh-count = %d99.111.117.110.116 ":" realnumber
+nh-count = %d99.111.117.110.116 ":" number
 ; sum:f allows real numbers and +-Inf and NaN
 nh-sum = %d115.117.109 ":" number
 ; schema:i
@@ -519,7 +519,7 @@ nh-schema = %d115.99.104.101.109.97 ":" integer
 ; zero_threshold:f
 nh-zero-threshold = %d122.101.114.111 "_" %d116.104.114.101.115.104.111.108.100 ":" realnumber
 ; zero_count:x
-nh-zero-count = %d122.101.114.111 "_" %d99.111.117.110.116 ":" realnumber
+nh-zero-count = %d122.101.114.111 "_" %d99.111.117.110.116 ":" number
 ; negative_spans:[1:2,3:4] and negative_spans:[]
 nh-negative-spans = %d110.101.103.97.116.105.118.101 "_" %d115.112.97.110.115 ":" "[" [nh-spans] "]"
 nh-positive-spans = %d112.111.115.105.116.105.118.101 "_" %d115.112.97.110.115 ":" "[" [nh-spans] "]"
@@ -533,7 +533,7 @@ nh-span = non-negative-integer ":" positive-integer
 nh-negative-buckets = %d110.101.103.97.116.105.118.101 "_" %d98.117.99.107.101.116.115 ":" "[" [nh-buckets] "]"
 nh-positive-buckets = %d112.111.115.105.116.105.118.101 "_" %d98.117.99.107.101.116.115 ":" "[" [nh-buckets] "]"
 
-nh-buckets = realnumber *("," realnumber)
+nh-buckets = number *("," number)
 
 integer = [SIGN] 1*"0" / [SIGN] positive-integer
 non-negative-integer = ["+"] 1*"0" / ["+"] positive-integer


### PR DESCRIPTION
Fixes: https://github.com/prometheus/OpenMetrics/issues/309

OM1.0 said that count and bucket values are integers, which disallowed NaN and +-Inf and float values implicitly. Allowing floats means we have to explicitly say if we want to disallow NaN or +-Inf.

After this PR:

The semantics still require counter like (monotonic until reset) behavior for Histograms.

There are some issues with float precision: we require Count be equal to bucket values added together , but that might not be possible due to precision issues. I'm glossing over this. Same for requirement that difference between the two is equal to number of NaN when using Native Buckets.

The semantics still prohibit negative values for Count and bucket values for Histograms, but not anymore for GaugeHistograms. The ABNF doesn't care.

The semantics now allow NaN in the Count and bucket values for both Histograms and GaugeHistograms. The ABNF also allows NaN.

The semantics now allow +-Inf in the Count and bucket values. The ABNF also allows +-Inf value.

Notes:

We did consider separate ABNF definitions for integer and float histograms and special rules for making sure we can tell from the `count` field if the native histogram is going to be all integers or not. However the fact that Prometheus stores integer and float valued histograms separately is just an optimization. In fact during PromQL evaluation, all integers are converted to floats anyway.

From https://github.com/prometheus/OpenMetrics/issues/309#issuecomment-3718621952 :
> Since the most expensive operation is always the memory allocations (and histograms have a main body + 2x spans, 2x buckets potentially), we could simply do two passes:

> -   first (opt: find the boundaries of the values and) check if the counter/zero counter/bucket values are all integer or not, while also count spans and buckets
> -   allocate the correct type and correctly sized spans and bucket arrays and fill in the values

> This would avoid complicated switchover from integer to float type and also resizing buffers. My guess is that the histogram sample complex value (excluding exemplars) will probably fit into CPU L1 cache, so these two passes will be very fast.
