### PR TITLE
Add a link to ioriver-exporter

### DIFF
--- a/docs/instrumenting/exporters.md
+++ b/docs/instrumenting/exporters.md
@@ -153,6 +153,7 @@ wide variety of JVM-based applications, for example [Kafka](http://kafka.apache.
    * [Gmail exporter](https://github.com/jamesread/prometheus-gmail-exporter/)
    * [GraphQL exporter](https://github.com/ricardbejarano/graphql_exporter)
    * [InstaClustr exporter](https://github.com/fcgravalos/instaclustr_exporter)
+   * [IO River exporter](https://github.com/ioriver/ioriver-exporter)
    * [Mozilla Observatory exporter](https://github.com/Jimdo/observatory-exporter)
    * [OpenWeatherMap exporter](https://github.com/RichiH/openweathermap_exporter)
    * [Pagespeed exporter](https://github.com/foomo/pagespeed_exporter)


### PR DESCRIPTION
<!--
    Please sign CNCF's Developer Certificate of Origin and sign-off your commits by adding the -s / --sign-off flag to `git commit`

    More information on both of those can be found at https://github.com/apps/dco

    If you are proposing a new integration, exporter, or client library, please include representative sample output.
 -->
Hello @juliusv,
IO River exporter is a simple tool to export traffic consumption metrics.
For more info you can check https://github.com/ioriver/ioriver-exporter/blob/master/README.md