### PR TITLE
Update .NET / C# link to maintained alternative

### DIFF
--- a/docs/instrumenting/clientlibs.md
+++ b/docs/instrumenting/clientlibs.md
@@ -31,7 +31,7 @@ Unofficial third-party client libraries:
 * [Julia](https://github.com/fredrikekre/Prometheus.jl)
 * [Lua](https://github.com/knyar/nginx-lua-prometheus) for Nginx
 * [Lua](https://github.com/tarantool/metrics) for Tarantool
-* [.NET / C#](https://github.com/prometheus-net/prometheus-net)
+* [.NET / C#](https://learn.microsoft.com/en-us/dotnet/core/diagnostics/metrics-collection)
 * [Node.js](https://github.com/siimon/prom-client)
 * [OCaml](https://github.com/mirage/prometheus)
 * [Perl](https://metacpan.org/pod/Net::Prometheus)


### PR DESCRIPTION
Replace the link pointing to [prometheus-net](https://github.com/prometheus-net/prometheus-net) (which seems to be abandoned at this point in time, the last release was 3 years ago) with an official (language creator/maintainer-wise) documentation link on how to do it.

The tutorial itself shows screenshots of a working sample using both Prometheus and Grafana.

@RichiH