### PR TITLE
docs: add egs-exporter to exporters list

### DIFF
--- a/docs/instrumenting/exporters.md
+++ b/docs/instrumenting/exporters.md
@@ -87,6 +87,9 @@ wide variety of JVM-based applications, for example [Kafka](http://kafka.apache.
    * [Windows exporter](https://github.com/prometheus-community/windows_exporter)
    * [Intel® Optane™ Persistent Memory Controller Exporter](https://github.com/intel/ipmctl-exporter)
 
+### Energy
+   * [EGS exporter](https://github.com/oerc-s/egs-exporter) Exports executable marginal energy gradients (ΔkW) via `/egs/v1/gradient` for autonomous allocation systems.
+
 ### Issue trackers and continuous integration
 
    * [Bamboo exporter](https://github.com/AndreyVMarkelov/bamboo-prometheus-exporter)


### PR DESCRIPTION
## Summary

Adds EGS exporter to the exporters documentation under a new **Energy** section.

## EGS Exporter

**Repository:** https://github.com/oerc-s/egs-exporter

**Description:** Exports executable marginal energy gradients (ΔkW) via `/egs/v1/gradient` for autonomous allocation systems.

## What is EGS?

EGS (Energy-Gradient Signaling) is a standard for exposing executable marginal energy capacity to autonomous systems.

Exposes:
- `marginal_capacity_kw` — available ΔkW
- `instantaneous_cost_index` — normalized cost
- `thermodynamic_priority` — thermal urgency
- Physical constraints (ramp rate, thermal headroom)

## Reference

- Standard: https://ear-standard.org
- OpenAPI: https://github.com/oerc-s/ear-standard/blob/master/openapi.yaml