### PR TITLE
Clarify successfully written elements meaning

### DIFF
--- a/docs/specs/prw/remote_write_spec_2_0.md
+++ b/docs/specs/prw/remote_write_spec_2_0.md
@@ -144,7 +144,7 @@ The following subsections specify Sender and Receiver semantics around headers a
 <!---
 Rationales: https://github.com/prometheus/prometheus/issues/14359
 -->
-Upon a successful content negotiation, Receivers process (write) the received batch of data. Once completed (with success or failure) for each important piece of data (currently Samples, Histograms and Exemplars) Receivers MUST send a dedicated HTTP `X-Prometheus-Remote-Write-*-Written` response header with the precise number of successfully written elements.
+Upon a successful content negotiation, Receivers process (write) the received batch of data. Once completed (with success or failure) for each important piece of data (currently Samples, Histograms and Exemplars) Receivers MUST send a dedicated HTTP `X-Prometheus-Remote-Write-*-Written` response header with the precise number of successfully written elements. A successfully written element is eventually queryable.
 
 Each header value MUST be a single 64-bit integer. The header names MUST be as follows:
 


### PR DESCRIPTION
This proposal attempts to bring clarity without limiting any kind of implementation on what "successfully written" mean.  

I expect extensive discussion on my PR we are changing a spec :-), so please be brutal!

I feel the current remote write v2 spec's wording on reporting numbers for `X-Prometheus-Remote-Write-*-Written` is too ambiguous in terms of what "successfully written" really means; especially for distributed implementation of Prometheus like Mimir, Thanos, and Cortex. Does successful means written to majority? Or can it mean just 1 out of N? Of course, we can leave the spec as-is and argue that meaning of "successful" is up to implementation, but I feel this leave too much room for interpretation. 

In this PR, I attempt to precise  the definition of "successful", without sacrificing implementation flexibility by coming from a perspective of a normal user - if an element is successfully written, an user must be able to query/observe it at some time soon. I think this is intuitive. 

**Other thoughts** 
* I thought about adding the word "persistent" but decided to go against it because I can see in-memory Prometheus implementation for ultra high performance that allows an element to be only temporal queryable.
* I thought about the wording offrom write redundancy factor perspective, but realized it would be too implementation-specific; what if an implementation uses streaming? 
* I thought about just leave the spec as-is and let implementers use their best judgement on what "successfully written" mean, but the interpretation can be too bipolar -- either with "majority write required" or "as soon as our API return HTTP 2xx it's ok".





