### PR TITLE
om2: remove typo in migration guide

### DIFF
--- a/docs/guides/open_metrics_2_0_migration.md
+++ b/docs/guides/open_metrics_2_0_migration.md
@@ -69,7 +69,7 @@ This means your exposer should continue serving 1.0 format by default and only s
 
 ### Protobuf format removed
 
-OM 2.0 no longer specifies an official protobuf format. You may continue to support the protobuf format for 1.0 (we d, but 2.0 does not contain a new or updated protobuf format.
+OM 2.0 no longer specifies an official protobuf format. You may continue to support the protobuf format for 1.0, but 2.0 does not contain a new or updated protobuf format.
 
 The Prometheus protobuf wire format is still important and maintain, see the [exposition formats documentation](https://prometheus.io/docs/instrumenting/exposition_formats).
 


### PR DESCRIPTION
I'm not sure if something got dropped, but I can't think of what the parenthetical might be so it seems fine to remove it

<!--
    Please sign CNCF's Developer Certificate of Origin and sign-off your commits by adding the -s / --sign-off flag to `git commit`

    More information on both of those can be found at https://github.com/apps/dco

    If you are proposing a new integration, exporter, or client library, please include representative sample output.
 -->
