### PR TITLE
Add nomad-state-metrics to third-party exporters 

### DIFF
--- a/docs/instrumenting/exporters.md
+++ b/docs/instrumenting/exporters.md
@@ -281,6 +281,7 @@ wide variety of JVM-based applications, for example [Kafka](http://kafka.apache.
    * [WireGuard exporter](https://github.com/MindFlavor/prometheus_wireguard_exporter)
    * [Xen exporter](https://github.com/lovoo/xenstats_exporter)
    * [ZLMediaKit exporter](https://github.com/guohuachan/ZLMediaKit_exporter)
+   * [nomad-state-metrics](https://github.com/bhope/nomad-state-metrics)
 
 
 When implementing a new Prometheus exporter, please follow the


### PR DESCRIPTION
[nomad-state-metrics](https://github.com/bhope/nomad-state-metrics) is a Prometheus exporter that exposes HashiCorp Nomad object state as metrics - covering jobs, allocations, nodes, deployments, and evaluations. It fills the observability gap between host-level metrics (node_exporter) and Nomad's built-in process metrics (/v1/metrics) by exposing workload object state as Prometheus gauges.

Inspired by kube-state-metrics.

nomad-state-metrics is also now listed on official Hashicorp Nomad community tools page: https://developer.hashicorp.com/nomad/tools