### PR TITLE
Add Duplicacy exporter to Storage section

### DIFF
--- a/docs/instrumenting/exporters.md
+++ b/docs/instrumenting/exporters.md
@@ -115,6 +115,7 @@ wide variety of JVM-based applications, for example [Kafka](http://kafka.apache.
 ### Storage
    * [Ceph exporter](https://github.com/digitalocean/ceph_exporter)
    * [Ceph RADOSGW exporter](https://github.com/blemmenes/radosgw_usage_exporter)
+   * [Duplicacy exporter](https://github.com/GeiserX/duplicacy-exporter)
    * [Gluster exporter](https://github.com/ofesseler/gluster_exporter)
    * [GPFS exporter](https://github.com/treydock/gpfs_exporter)
    * [Hadoop HDFS FSImage exporter](https://github.com/marcelmay/hadoop-hdfs-fsimage-exporter)


### PR DESCRIPTION
Add [Duplicacy exporter](https://github.com/GeiserX/duplicacy-exporter) to the third-party exporters list under the Storage section.

Duplicacy exporter is a real-time Prometheus exporter for [Duplicacy](https://duplicacy.com/) backups, exposing live speed, progress, and completion metrics via a webhook receiver.

Signed-off-by: GeiserX <9169332+GeiserX@users.noreply.github.com>