### PR TITLE
docs(integrations): fix incorrect path for http_sd_config link

### DIFF
--- a/docs/operating/integrations.md
+++ b/docs/operating/integrations.md
@@ -29,7 +29,7 @@ For service discovery mechanisms not natively supported by Prometheus,
 
 ## HTTP Service Discovery
 
-The [HTTP service discovery](/docs/configuration/configuration/#http_sd_config) allows fetching targets from an HTTP endpoint.
+The [HTTP service discovery](/docs/operating/configuration/#http_sd_config) allows fetching targets from an HTTP endpoint.
 
 * [fastly-exporter](https://github.com/fastly/fastly-exporter#service-discovery): Supports discovering Fastly services.
 * [ns1_exporter](https://github.com/tjhop/ns1_exporter#http-service-discovery): Supports discovering NS1 zones.


### PR DESCRIPTION
Hi @RichiH,

I noticed an incorrect link in `docs/operating/integrations.md`. 

The link for **HTTP service discovery** was pointing to `/docs/configuration/configuration/`, which is an invalid path. I have updated it to the correct location: `/docs/operating/configuration/`.

### Changes:
- Fixed the internal documentation link for `http_sd_config`.

### Checklist:
- [x] I have signed off my commits to agree to the DCO.
- [x] This is a trivial fix/improvement.

Thank you!