### PR TITLE
docs: clarify basic auth wording

### DIFF
--- a/docs/guides/basic-auth.md
+++ b/docs/guides/basic-auth.md
@@ -79,7 +79,7 @@ $ prometheus --web.config.file=web.yml
 
 ## Testing
 
-You can use cURL to interact with your setup. Try this request:
+You can use cURL to interact with your configuration. Try this request:
 
 ```bash
 curl --head http://localhost:9090/graph

--- a/docs/guides/dockerswarm.md
+++ b/docs/guides/dockerswarm.md
@@ -29,7 +29,7 @@ NOTE: The rest of this post assumes that you have a Swarm running.
 
 ## Setting up Prometheus
 
-For this guide, you need to [setup Prometheus][setup]. We will assume that
+For this guide, you need to [set up Prometheus][setup]. We will assume that
 Prometheus runs on a Docker Swarm manager node and has access to the Docker
 socket at `/var/run/docker.sock`.
 

--- a/docs/guides/dockerswarm.md
+++ b/docs/guides/dockerswarm.md
@@ -29,7 +29,7 @@ NOTE: The rest of this post assumes that you have a Swarm running.
 
 ## Setting up Prometheus
 
-For this guide, you need to [set up Prometheus][setup]. We will assume that
+For this guide, you need to [set up Prometheus][setup]. We assume that
 Prometheus runs on a Docker Swarm manager node and has access to the Docker
 socket at `/var/run/docker.sock`.
 

--- a/docs/introduction/overview.md
+++ b/docs/introduction/overview.md
@@ -78,7 +78,7 @@ Prometheus is designed for reliability, to be the system you go to
 during an outage to allow you to quickly diagnose problems. Each Prometheus
 server is standalone, not depending on network storage or other remote services.
 You can rely on it when other parts of your infrastructure are broken, and
-you do not need to setup extensive infrastructure to use it.
+you do not need to set up extensive infrastructure to use it.
 
 ## When does it not fit?
 

--- a/docs/tutorials/alerting_based_on_metrics.md
+++ b/docs/tutorials/alerting_based_on_metrics.md
@@ -12,7 +12,7 @@ Download the latest release of Alertmanager for your operating system from [here
 
 Alertmanager supports various receivers like `email`, `webhook`, `pagerduty`, `slack` etc through which it can notify when an alert is firing. You can find the list of receivers and how to configure them [here](/docs/alerting/latest/configuration/). We will use `webhook` as a receiver for this tutorial, head over to [webhook.site](https://webhook.site) and copy the webhook URL which we will use later to configure the Alertmanager.
 
-First let's setup Alertmanager with the webhook receiver.
+First let's set up Alertmanager with the webhook receiver.
 
 > alertmanager.yml
 


### PR DESCRIPTION
Small docs-only cleanup in the basic auth guide. The sentence now talks about configuration instead of setup, which reads more naturally for the reader.