### PR TITLE
Add banner for Prom exporter vs Collector receiver survey

### DIFF
--- a/docs-config.ts
+++ b/docs-config.ts
@@ -4,8 +4,8 @@ export default {
   siteUrl: "https://prometheus.io",
 
   announcement: {
-    text: "Do you use Prometheus and OpenTelemetry to monitor infrastructure? Please answer our 5m [survey](https://docs.google.com/forms/d/e/1FAIpQLSfDfT0Y7Y9ZzlXM9GFnei0B8rCaa4ctVD4nhpzzJY7cfzrOrw/viewform)!",
-    mobileText: "Prometheus+OTel infrastructure monitoring [survey](https://docs.google.com/forms/d/e/1FAIpQLSfDfT0Y7Y9ZzlXM9GFnei0B8rCaa4ctVD4nhpzzJY7cfzrOrw/viewform)!",
+    text: "Do you use Prometheus and OpenTelemetry to monitor infrastructure and applications? Please answer our 3-minutes [survey](https://docs.google.com/forms/d/e/1FAIpQLSfDfT0Y7Y9ZzlXM9GFnei0B8rCaa4ctVD4nhpzzJY7cfzrOrw/viewform)!",
+    mobileText: "Prometheus+OTel infrastructure and applications monitoring [survey](https://docs.google.com/forms/d/e/1FAIpQLSfDfT0Y7Y9ZzlXM9GFnei0B8rCaa4ctVD4nhpzzJY7cfzrOrw/viewform)!",
     startDate: "2026-04-23",
     endDate: "2026-05-23",
   },

--- a/docs-config.ts
+++ b/docs-config.ts
@@ -4,10 +4,10 @@ export default {
   siteUrl: "https://prometheus.io",
 
   announcement: {
-    text: "Do you use Prometheus and OpenTelemetry to monitor infrastructure? Please answer our 5m [survey](https://todo)!",
-    mobileText: "Prometheus+OTel infrastructure monitoring [survey](https://todo)!",
-    startDate: "2026-04-22", // TBD
-    endDate: "2026-05-22", // TBD
+    text: "Do you use Prometheus and OpenTelemetry to monitor infrastructure? Please answer our 5m [survey](https://docs.google.com/forms/d/e/1FAIpQLSfDfT0Y7Y9ZzlXM9GFnei0B8rCaa4ctVD4nhpzzJY7cfzrOrw/viewform)!",
+    mobileText: "Prometheus+OTel infrastructure monitoring [survey](https://docs.google.com/forms/d/e/1FAIpQLSfDfT0Y7Y9ZzlXM9GFnei0B8rCaa4ctVD4nhpzzJY7cfzrOrw/viewform)!",
+    startDate: "2026-04-23",
+    endDate: "2026-05-23",
   },
 
   kapa: {

--- a/docs-config.ts
+++ b/docs-config.ts
@@ -4,11 +4,10 @@ export default {
   siteUrl: "https://prometheus.io",
 
   announcement: {
-    text: "Take the [Prometheus User Survey (Edition 03.2026)](https://forms.gle/uuEsawKm7u9wCT4T8) and help the community prioritize future development!",
-    mobileText:
-      "[Prometheus User Survey (Edition 03.2026)](https://forms.gle/uuEsawKm7u9wCT4T8)",
-    startDate: "2026-03-24",
-    endDate: "2026-04-07",
+    text: "Do you use Prometheus and OpenTelemetry to monitor infrastructure? Please answer our 5m [survey](https://todo)!",
+    mobileText: "Prometheus+OTel infrastructure monitoring [survey](https://todo)!",
+    startDate: "2026-04-22", // TBD
+    endDate: "2026-05-22", // TBD
   },
 
   kapa: {


### PR DESCRIPTION
Adds a banner promoting the survey we're doing in collaboration with OTel's End User SIG.

Here's the link for the doc we're using to organize the survey: https://docs.google.com/document/d/1gfE8UmeHaAmFG6ZjRiVDO2Phi-5Vk3mLpMU3YJQ58PU/edit?tab=t.0#heading=h.zbk80121fq6r

Leaving this as a draft until we have the sibling PR opened in OTel's website :)