### PR TITLE
Fix banner build

### DIFF
--- a/src/app/docs/DocsMobileNav.tsx
+++ b/src/app/docs/DocsMobileNav.tsx
@@ -1,0 +1,39 @@
+"use client";
+
+import {
+  Button,
+  Popover,
+  PopoverDropdown,
+  PopoverTarget,
+  ScrollAreaAutosize,
+} from "@mantine/core";
+import { IconMenu2 } from "@tabler/icons-react";
+import LeftNav from "./LeftNav";
+
+export default function DocsMobileNav() {
+  return (
+    <Popover position="bottom" withArrow shadow="md">
+      <PopoverTarget>
+        <Button
+          hiddenFrom="sm"
+          variant="outline"
+          mb="lg"
+          leftSection={<IconMenu2 stroke={1.5} />}
+          color="light-dark(var(--mantine-color-gray-7), var(--mantine-color-gray-4))"
+          fw="normal"
+          bd="1px solid var(--mantine-color-gray-5)"
+        >
+          Show nav
+        </Button>
+      </PopoverTarget>
+      <PopoverDropdown mah="calc(100vh - var(--header-height) - var(--header-to-content-margin))">
+        <ScrollAreaAutosize
+          mah="calc(80vh - var(--header-height))"
+          type="never"
+        >
+          <LeftNav />
+        </ScrollAreaAutosize>
+      </PopoverDropdown>
+    </Popover>
+  );
+}

--- a/src/app/docs/layout.tsx
+++ b/src/app/docs/layout.tsx
@@ -2,16 +2,11 @@ import {
   Group,
   Box,
   ScrollArea,
-  Button,
-  Popover,
-  ScrollAreaAutosize,
-  PopoverDropdown,
-  PopoverTarget,
 } from "@mantine/core";
 import TOC from "@/components/TOC";
 import LeftNav from "./LeftNav";
-import { IconMenu2 } from "@tabler/icons-react";
 import { AnchorScroller } from "@/components/AnchorScroller";
+import DocsMobileNav from "./DocsMobileNav";
 
 export default function DocsLayout({
   children,
@@ -21,29 +16,7 @@ export default function DocsLayout({
   return (
     <>
       {/* The mobile main nav */}
-      <Popover position="bottom" withArrow shadow="md">
-        <PopoverTarget>
-          <Button
-            hiddenFrom="sm"
-            variant="outline"
-            mb="lg"
-            leftSection={<IconMenu2 stroke={1.5} />}
-            color="light-dark(var(--mantine-color-gray-7), var(--mantine-color-gray-4))"
-            fw="normal"
-            bd="1px solid var(--mantine-color-gray-5)"
-          >
-            Show nav
-          </Button>
-        </PopoverTarget>
-        <PopoverDropdown mah="calc(100vh - var(--header-height) - var(--header-to-content-margin))">
-          <ScrollAreaAutosize
-            mah="calc(80vh - var(--header-height))"
-            type="never"
-          >
-            <LeftNav />
-          </ScrollAreaAutosize>
-        </PopoverDropdown>
-      </Popover>
+      <DocsMobileNav />
       <Group wrap="nowrap" align="flex-start" gap={50}>
         {/* The left-hand side main docs nav */}
         <Box


### PR DESCRIPTION
Follow up to #2978 

The logs made me think that the problem was while rendering old release pages from the Prometheus repository, but after further investigation, the problem was indeed on the banner!

The banner was already broken before the changes in #2978, but the change to the active date finally caused the build to render it, whereas it had not been rendered before.

I'm definitely not a front-end developer, so I rely a lot on LLM tools to make the fixes here. Please let me know if you have better ways to fix this!

Logs for the build failure on main can be seen here: https://app.netlify.com/projects/prometheus-docs/deploys/69fb29ec6ee9e60008fe05f2

Root cause analysis from the LLM:
```
`src/app/docs/layout.tsx` was a Server Component that rendered Mantine's
`Popover`, `PopoverTarget`, and `PopoverDropdown` directly for the mobile docs
navigation. `PopoverTarget` clones its child and reads `child.props.className`.
That is safe in a Client Component, but brittle when this interactive Mantine
popover is rendered through the Server Component tree during static export.

The announcement commit exposed the issue because it activated a client-rendered
header branch for the first time in this date window. The fetched repository docs
were only where Next happened to be prerendering when the shared docs layout
crashed; they were not the cause.
```