### PR TITLE
docs: add ITOC360 Alertmanager webhook integration

### DIFF
--- a/docs/operating/integrations.md
+++ b/docs/operating/integrations.md
@@ -99,6 +99,7 @@ For notification mechanisms not natively supported by the Alertmanager, the
   * [Icinga2](https://github.com/vshn/signalilo)
   * [iLert](https://docs.ilert.com/integrations/prometheus)
   * [IRC Bot](https://github.com/multimfi/bot)
+  * [ITOC360](https://docs.itoc360.com/integrations/inbound-integrations/observability-and-apm/prometheus-integration): on-call & incident management.
   * [JIRAlert](https://github.com/free/jiralert)
   * [Matrix](https://github.com/jaywink/matrix-alertmanager): sends Alertmanager notifications to Matrix rooms
   * [Matrix](https://github.com/hectorjsmith/matrix-hookshot): bridges webhooks to Matrix with rich formatting support


### PR DESCRIPTION
This PR adds ITOC360 to the Alertmanager Webhook Receiver integrations list.

ITOC360 provides a Prometheus Alertmanager webhook integration for routing firing and resolved alerts into on-call and incident management workflows.

Documentation:
https://docs.itoc360.com/integrations/inbound-integrations/observability-and-apm/prometheus-integration