### PR TITLE
Add Runframe integration to documentation

### DIFF
--- a/docs/operating/integrations.md
+++ b/docs/operating/integrations.md
@@ -108,6 +108,7 @@ For notification mechanisms not natively supported by the Alertmanager, the
   * [Phabricator / Maniphest](https://github.com/knyar/phalerts)
   * [prom2teams](https://github.com/idealista/prom2teams): forwards notifications to Microsoft Teams
   * [Rootly](https://docs.rootly.com/integrations/alertmanager): on-call & incident management
+  * [Runframe](https://runframe.io/integrations/prometheus): on-call, incident response, and status pages
   * [Ansible Tower](https://github.com/pja237/prom2tower): call Ansible Tower (AWX) API on alerts (launch jobs etc.)
   * [Robusta](https://docs.robusta.dev/master/configuration/alert-manager.html)
   * [Signal](https://github.com/dgl/alertmanager-webhook-signald)


### PR DESCRIPTION
Adds Runframe to the Alertmanager Webhook Receiver integrations list. Runframe supports Prometheus Alertmanager through the standard `webhook_configs` receiver. Alertmanager can send alert webhook payloads to Runframe to create incidents, route to on-call responders, and publish status updates.

Example Alertmanager receiver configuration:

```yaml
receivers:
  - name: runframe
    webhook_configs:
      - url: https://runframe.io/api/webhooks/<routing-key>
        send_resolved: true
```

Example Alertmanager webhook payload sent to Runframe:

```json
{
  "receiver": "runframe",
  "status": "firing",
  "alerts": [
    {
      "status": "firing",
      "labels": {
        "alertname": "HighErrorRate",
        "severity": "critical",
        "service": "api"
      },
      "annotations": {
        "summary": "High error rate on API service",
        "description": "The API service is returning 5xx responses above the configured threshold."
      },
      "generatorURL": "https://prometheus.example.com/graph?g0.expr=...",
      "fingerprint": "abc123"
    }
  ],
  "externalURL": "https://alertmanager.example.com"
}
```

Docs-only change.