### PR TITLE
docs: use set up verb in Docker Swarm guide

### DIFF
--- a/docs/guides/dockerswarm.md
+++ b/docs/guides/dockerswarm.md
@@ -29,7 +29,7 @@ NOTE: The rest of this post assumes that you have a Swarm running.
 
 ## Setting up Prometheus
 
-For this guide, you need to [setup Prometheus][setup]. We will assume that
+For this guide, you need to [set up Prometheus][setup]. We will assume that
 Prometheus runs on a Docker Swarm manager node and has access to the Docker
 socket at `/var/run/docker.sock`.
 


### PR DESCRIPTION
## Summary
- Change link text from "setup Prometheus" to "set up Prometheus"

Part of #2878

## Test plan
- [x] Markdown-only