### PR TITLE
Offboard @beorn7

### DIFF
--- a/src/app/governance/governance.md
+++ b/src/app/governance/governance.md
@@ -57,7 +57,6 @@ The current team members are:
 * Bartłomiej Płotka ([Google](https://www.google.com/))
 * Ben Kochie ([Reddit](https://www.redditinc.com/))
 * Ben Reedy ([Indue Ltd](https://www.indue.com.au))
-* Björn Rabenstein ([Grafana Labs](https://grafana.com/))
 * Bryan Boreham ([Grafana Labs](https://grafana.com/))
 * Callum Styan (independent)
 * Carrie Edwards ([Grafana Labs](https://grafana.com/))
@@ -103,6 +102,7 @@ The current team members are:
 
 Previous members:
 
+* Björn Rabenstein
 * Brian Brazil
 * Calle Pettersson
 * Conor Broderick


### PR DESCRIPTION
Beorn (i.e. me) has resigned effective 2026-05-13.

My cunning plan was to get lazily offboarded together with the dissolution of prometheus-team once the new governance is in effect. Given that the establishment of the steering committee will still last at least another month, maybe it's better to offboard me now and not leave me dangling for an extended amount of time. I also think I can mostly offboard myself. Here is a TODO list created from the offboarding checklist in the (old) governance. I'll work on it and ask for help where I cannot do the task myself.

- [x] Removed from the list of team members. _Will happen by merging this PR._
- [x] Removed from the GitHub organization and related organizations and repositories.
- [x] Removed from the team mailing list and demoted to a normal member of the other mailing lists, i.e -developers, -users, and -announce.
- [ ] Announced as removed to CNCF. _I guess this has to be done by somebody else, preferably by somebody who has done this before and knows how._
- [ ] Removed from the shared password storage. _I cannot do this myself!_
- [ ] Removed from GSuite. _I cannot do this myself!_
- [x] Removed from DockerHub group account.
- [x] Added to a list of previous members. _Will happen by merging this PR._
- [x] Leave Slack -team channel.

Note that I could not remove myself from the Digital Ocean group account (presumably) because the Prometheus team account is suspended as a whole on Digital Ocean. Given that we don't plan to revive it, that's probably OK.

I'm not aware of any other group accounts I have for Prometheus.