### PR TITLE
docs: fix three typos in native_histograms spec (evalute / signifcantly / abitrary)

### DIFF
--- a/docs/specs/native_histograms.md
+++ b/docs/specs/native_histograms.md
@@ -377,7 +377,7 @@ For integer histograms, the elements of the lists are signed 64-bit integers
 (short: int64), and each element represents the bucket population as a delta to
 the previous bucket in the list. The first bucket in each list contains an
 absolute population (which can also be seen as a delta relative to zero). The
-deltas MUST NOT evalute to a negative absolute bucket population.
+deltas MUST NOT evaluate to a negative absolute bucket population.
 
 To map buckets in the lists to the indices as defined in the previous section,
 there are two lists of so-called _spans_, one for the positive buckets and one
@@ -990,7 +990,7 @@ in 100 labeled histograms, the total cost will go up by a factor of 100. In
 case of a native histogram, the cost for the single histogram might already be
 lower if the classic histogram featured a high resolution. After partitioning,
 the total number of populated buckets in the labeled native histograms will be
-signifcantly smaller than 100 times the number of buckets in the original
+significantly smaller than 100 times the number of buckets in the original
 native histogram.)
 
 ### NHCB
@@ -1173,7 +1173,7 @@ While NHCBs support [automatic reconciliation between different bucket
 layouts](#compatibility-between-histograms), their mergeability is still
 fundamentally limited. The reconciliation only retains exact matches of bucket
 boundaries between the involved NHCBs. This yields useful results, if most
-bucket boundaries match. However, abitrary changes in the bucket layout can
+bucket boundaries match. However, arbitrary changes in the bucket layout can
 easily create a situation where none of the boundaries match, resulting in a
 histogram with only one bucket (the overflow bucket).
 


### PR DESCRIPTION
> **Dear maintainer** — this PR has a permanent home with methodology + [opt-out](https://github.com/adv0r/tokens-for-good/blob/main/MAINTAINER_REMOVAL.md) at [tokens-for-good](https://github.com/adv0r/tokens-for-good). A one-line "no thanks" → auto-close + blacklist. Sorry for the notification this edit caused.
>
> ---

> **Heads-up:** I realise this PR may not be welcome here. It was prepared
> by an AI agent (Cursor / Claude Opus 4.7) running unattended under
> @adv0r as a small personal token-burn initiative. I deliberately
> picked a low-impact, easy-to-review, narrowly-scoped change so a
> maintainer can either land it in a minute or close it with zero
> guilt. No hard feelings either way — just trying to be useful while
> spending some leftover Cursor credits before the billing cycle ends.

## What

Fix three spelling typos in `docs/specs/native_histograms.md`:

- `evalute` → `evaluate` (line 380)
- `signifcantly` → `significantly` (line 993)
- `abitrary` → `arbitrary` (line 1176)

## Why

Spec-doc cleanup. All three are obvious misspellings with a single right answer; none change semantics.

## How verified

Single-file edit. Read the surrounding paragraph for each change to confirm the corrected word still parses naturally in context.

## Maintainer note

Feel free to close if not worth the review cycle.
