### PR TITLE
Add F5 BIG-IP exporter to the list of exporters

### DIFF
--- a/docs/instrumenting/exporters.md
+++ b/docs/instrumenting/exporters.md
@@ -67,6 +67,7 @@ wide variety of JVM-based applications, for example [Kafka](http://kafka.apache.
    * [Collins exporter](https://github.com/soundcloud/collins_exporter)
    * [Dell Hardware OMSA exporter](https://github.com/galexrt/dellhw_exporter)
    * [Disk usage exporter](https://github.com/dundee/disk_usage_exporter)
+   * [F5 BIG-IP exporter](https://github.com/Haameed/f5_bigip_exporter)
    * [Fortigate exporter](https://github.com/bluecmd/fortigate_exporter)
    * [IBM Z HMC exporter](https://github.com/zhmcclient/zhmc-prometheus-exporter)
    * [IoT Edison exporter](https://github.com/roman-vynar/edison_exporter)


### PR DESCRIPTION
This PR adds the F5 BIG-IP exporter to the list of third-party exporters.

- **Repository**: https://github.com/Haameed/f5_bigip_exporter
- **Port**: 11000 (registered in the [port allocation wiki](https://github.com/prometheus/prometheus/wiki/Default-port-allocations))
- **License**: MIT

It's a Prometheus exporter for F5 BIG-IP devices using the iControl REST API.
It follows the multi-target `/probe` pattern (like blackbox_exporter) and
supports monitoring multiple devices concurrently. Metrics cover virtual
servers, pools, system/CPU/memory, disk, SSL certificates, HA/sync status,
and global traffic.