### PR TITLE
docs: add sponsor requirement to blog contribution process

### DIFF
--- a/blog/README.md
+++ b/blog/README.md
@@ -82,12 +82,16 @@ In some cases, these might be done by different people, but often one reviewer c
 
 If you’d like to write for the blog, the process is simple:  
 
-1. Open a **“Blog Post Proposal” issue** in the `prometheus/docs` repo to share your idea.  
-2. Wait for feedback from maintainers or editors to confirm it’s a good fit.  
-3. Draft your post in Markdown and submit it as a pull request.  
-4. Go through the review process, where we’ll help refine the draft together.  
-5. Once it’s approved, we’ll merge and publish it on the blog. 🎉
-6. Share your post on your socials and feel free to tag us so we can boost it too. 
+1. Open a **“Blog Post Proposal” issue** in the `prometheus/docs` repo to share your idea.
+2. In your issue, include the following details:
+    - Title of your proposed post
+    - Short description and outline of what the post will cover
+    - Sponsor — a [maintainer](https://github.com/prometheus/prometheus/blob/main/MAINTAINERS.md) with expertise in your topic area who will review your post PR for technical accuracy. 
+3. Wait for feedback from maintainers or editors to confirm it’s a good fit.  
+4. Draft your post in Markdown and submit it as a pull request.  
+5. Go through the review process, where we’ll help refine the draft together.  
+6. Once it’s approved, we’ll merge and publish it on the blog. 🎉
+7. Share your post on your socials and feel free to tag us so we can boost it too. 
 
 
 ## Why contribute?

--- a/blog/README.md
+++ b/blog/README.md
@@ -76,21 +76,17 @@ First, let's get Prometheus installed on your system...
 If you’d like to write for the blog, the process is simple:  
 
 0. Find a sponsor (a [maintainer](https://github.com/prometheus/prometheus/blob/main/MAINTAINERS.md) with expertise 
-in your topic area), discuss your post idea with them, and see if they can to sponsor your post.
+in your topic area), discuss your post idea with them, and see if they can sponsor your post.
   > [!IMPORTANT]
   > **For Sponsors:**
   > By agreeing to sponsor a post, you are committing to reviewing the post PR for technical accuracy and
   > merging it once you are satisfied it meets the required standard.
-2. Open a **“Blog Post Proposal” issue** in the `prometheus/docs` repo to share your idea.
-3. In your issue, include the following details:
-    - Title of your proposed post
-    - Short description and outline of what the post will cover
-    - Sponsor 
-4. Wait for feedback from maintainers or editors to confirm it’s a good fit.  
-5. Draft your post in Markdown and submit it as a pull request.  
-6. Go through the review process, where we’ll help refine the draft together.  
-7. Once it’s approved, we’ll merge and publish it on the blog. 🎉
-8. Share your post on your socials and feel free to tag us so we can boost it too.
+1. Create an issue in the `prometheus/docs` repo using the [Blog Post Proposal template](https://github.com/prometheus/docs/issues/new?template=blog-post-proposal.yml).
+2. Wait for feedback from maintainers or editors to confirm it’s a good fit.
+3. Draft your post in Markdown and submit it as a pull request.
+4. Go through the review process, where we’ll help refine the draft together.
+5. Once it’s approved, we’ll merge and publish it on the blog. 🎉
+6. Share your post on your socials and feel free to tag us so we can boost it too.
 
 
 ## Review process

--- a/blog/README.md
+++ b/blog/README.md
@@ -70,28 +70,35 @@ setting up your first metrics endpoint and understanding what Prometheus collect
 First, let's get Prometheus installed on your system...
 ```
 
+
+## How to contribute
+
+If you’d like to write for the blog, the process is simple:  
+
+0. Find a sponsor (a [maintainer](https://github.com/prometheus/prometheus/blob/main/MAINTAINERS.md) with expertise 
+in your topic area), discuss your post idea with them, and see if they can to sponsor your post.
+  > [!IMPORTANT]
+  > **For Sponsors:**
+  > By agreeing to sponsor a post, you are committing to reviewing the post PR for technical accuracy and
+  > merging it once you are satisfied it meets the required standard.
+2. Open a **“Blog Post Proposal” issue** in the `prometheus/docs` repo to share your idea.
+3. In your issue, include the following details:
+    - Title of your proposed post
+    - Short description and outline of what the post will cover
+    - Sponsor 
+4. Wait for feedback from maintainers or editors to confirm it’s a good fit.  
+5. Draft your post in Markdown and submit it as a pull request.  
+6. Go through the review process, where we’ll help refine the draft together.  
+7. Once it’s approved, we’ll merge and publish it on the blog. 🎉
+8. Share your post on your socials and feel free to tag us so we can boost it too.
+
+
 ## Review process
 
 Every post should be reviewed before it goes live.
 Whoever reviews the pull request will check for both technical accuracy and editorial quality. 
 This ensures that the content is both correct and accessible. 
 In some cases, these might be done by different people, but often one reviewer can cover both.
-
-
-## How to contribute
-
-If you’d like to write for the blog, the process is simple:  
-
-1. Open a **“Blog Post Proposal” issue** in the `prometheus/docs` repo to share your idea.
-2. In your issue, include the following details:
-    - Title of your proposed post
-    - Short description and outline of what the post will cover
-    - Sponsor — a [maintainer](https://github.com/prometheus/prometheus/blob/main/MAINTAINERS.md) with expertise in your topic area who will review your post PR for technical accuracy. 
-3. Wait for feedback from maintainers or editors to confirm it’s a good fit.  
-4. Draft your post in Markdown and submit it as a pull request.  
-5. Go through the review process, where we’ll help refine the draft together.  
-6. Once it’s approved, we’ll merge and publish it on the blog. 🎉
-7. Share your post on your socials and feel free to tag us so we can boost it too. 
 
 
 ## Why contribute?


### PR DESCRIPTION
<!--
    Please sign CNCF's Developer Certificate of Origin and sign-off your commits by adding the -s / --sign-off flag to `git commit`

    More information on both of those can be found at https://github.com/apps/dco

    If you are proposing a new integration, exporter, or client library, please include representative sample output.
 -->
In keeping with [this consensus at the dev summit meeting](https://docs.google.com/document/d/1uurQCi5iVufhYHGlBZ8mJMK_freDFKPG0iYBQqJ9fvA/edit?tab=t.0#bookmark=id.jvf5azelkoxa), this PR updates the blog content guide to require community contributors to identify a technical sponsor who will review their blog post PR before starting to write a post.