### PR TITLE
Add Last9 remote storage to integration doc

### DIFF
--- a/docs/operating/integrations.md
+++ b/docs/operating/integrations.md
@@ -62,6 +62,7 @@ data volumes.
   * [Instana](https://www.instana.com/docs/ecosystem/prometheus/#remote-write): write
   * [IRONdb](https://github.com/circonus-labs/irondb-prometheus-adapter): read and write
   * [Kafka](https://github.com/Telefonica/prometheus-kafka-adapter): write
+  * [Last9](https://last9.io/docs/integrations/observability/prometheus/): write
   * [M3DB](https://m3db.io/docs/integrations/prometheus/): read and write
   * [Mezmo](https://docs.mezmo.com/telemetry-pipelines/prometheus-remote-write-pipeline-source): write
   * [New Relic](https://docs.newrelic.com/docs/set-or-remove-your-prometheus-remote-write-integration): write


### PR DESCRIPTION
Adds [Last9](https://last9.io/docs/integrations/observability/prometheus/), a managed Prometheus-compatible TSDB, as a remote write endpoint.

@RichiH @juliusv

<!--
    Please sign CNCF's Developer Certificate of Origin and sign-off your commits by adding the -s / --sign-off flag to `git commit`

    More information on both of those can be found at https://github.com/apps/dco

    If you are proposing a new integration, exporter, or client library, please include representative sample output.
 -->
