### PR TITLE
Add MCP server for Prometheus docs

### DIFF
--- a/docs-config.ts
+++ b/docs-config.ts
@@ -15,6 +15,7 @@ export default {
     projectName: "Prometheus",
     projectColor: "#D86444",
     projectLogoPath: "/assets/prometheus-logo.svg",
+    mcpServerUrl: "https://prometheus.mcp.kapa.ai",
   },
 
   // Docs to load from repo-local files.

--- a/src/components/KapaWidget.tsx
+++ b/src/components/KapaWidget.tsx
@@ -19,7 +19,7 @@ export default function KapaWidget() {
     return null;
   }
 
-  const { websiteId, projectName, projectColor, projectLogoPath } =
+  const { websiteId, projectName, projectColor, projectLogoPath, mcpServerUrl } =
     docsConfig.kapa;
   const projectLogoUrl = new URL(
     projectLogoPath,
@@ -37,6 +37,8 @@ export default function KapaWidget() {
       data-project-logo={projectLogoUrl}
       data-button-hide="true"
       data-color-scheme-selector="[data-theme='dark']"
+      data-mcp-enabled={mcpServerUrl ? "true" : undefined}
+      data-mcp-server-url={mcpServerUrl}
     />
   );
 }

--- a/src/docs-config-types.ts
+++ b/src/docs-config-types.ts
@@ -15,6 +15,7 @@ export type KapaConfig = {
   projectName: string;
   projectColor: string;
   projectLogoPath: string;
+  mcpServerUrl?: string;
 };
 
 export type DocsConfig = {


### PR DESCRIPTION
The MCP server is already working and is hosted by Kapa, this PR just adds the button to our website so people are able to find it :) 

It looks like this

<img width="805" height="297" alt="image" src="https://github.com/user-attachments/assets/77bc91f4-2988-49c1-83b9-386e9fe71525" />
