### PR TITLE
Add Veeam Backup & Replication exporter to Storage exporters

### DIFF
--- a/docs/instrumenting/exporters.md
+++ b/docs/instrumenting/exporters.md
@@ -126,6 +126,8 @@ wide variety of JVM-based applications, for example [Kafka](http://kafka.apache.
    * [ScaleIO exporter](https://github.com/syepes/sio2prom)
    * [Tivoli Storage Manager/IBM Spectrum Protect exporter](https://github.com/treydock/tsm_exporter)
    * [IBM Storage Scale metrics exporter](https://github.com/IBM/ibm-spectrum-scale-bridge-for-grafana)
+   * [Veeam Backup & Replication exporter](https://github.com/negatic/veeambackup-exporter)
+
 
 ### HTTP
    * [Apache exporter](https://github.com/Lusitaniae/apache_exporter)


### PR DESCRIPTION
## Summary

Add a Prometheus exporter for Veeam Backup & Replication to the Storage exporters section.

## Exporter

Name: Veeam Backup & Replication exporter

Repository:
https://github.com/negatic/veeambackup-exporter

## Description

This exporter exposes metrics from Veeam Backup & Replication, including backup job status, backup session results, repository capacity and utilization, replication status, and other operational metrics for monitoring Veeam environments with Prometheus and Grafana.

## Why

Veeam is widely used for enterprise backup and disaster recovery workloads. Listing this exporter will help Prometheus users discover and monitor Veeam infrastructure using native Prometheus metrics.

## Checklist

- [x] Open source repository
- [x] Exporter exposes Prometheus metrics
- [x] Documentation included
- [x] Actively maintained