### PR TITLE
Remove 3.13 from ltsVersions

### DIFF
--- a/docs-config.ts
+++ b/docs-config.ts
@@ -46,7 +46,7 @@ export default {
 
   // Long-term support versions configuration.
   ltsVersions: {
-    prometheus: ["3.5", "3.13"],
+    prometheus: ["3.5"],
   },
 
   // Repositories for the downloads page. The order in this file is the


### PR DESCRIPTION
## Summary
- 3.13 is not released yet; listing it as an LTS version breaks CI in prometheus/prometheus.
- Reverts the `ltsVersions` half of #3014; the `release-cycle.md` table is left as-is (3.13 still listed as "Upcoming").

## Test plan
- [ ] Confirm prometheus/prometheus CI passes again once this merges.