### PR TITLE
Serve machine-readable download.json at site root

### DIFF
--- a/public/download.json
+++ b/public/download.json
@@ -1,0 +1,1 @@
+../generated/download.json

--- a/scripts/fetch-downloads-info.ts
+++ b/scripts/fetch-downloads-info.ts
@@ -4,6 +4,11 @@ import * as fs from "fs";
 import * as path from "path";
 import docsConfig from "../docs-config";
 import { Downloads, Release, Binary } from "@/downloads-metadata-types";
+import {
+  DownloadJSON,
+  DownloadRelease,
+  DownloadFile,
+} from "@/download-json-types";
 import { compareFullVersion, filterUnique, majorMinor } from "./utils";
 
 const OUTDIR = "./generated";
@@ -21,6 +26,8 @@ const downloads: Downloads = {
   architectures: [],
   releases: [],
 };
+
+const downloadJSON: DownloadJSON = {};
 
 const getBinaries = (r: OctokitRelease) => {
   const binaries = r.assets
@@ -155,6 +162,33 @@ for (const repoName of docsConfig.downloads.repos) {
     ),
   });
 
+  // Build the machine-readable download.json entries for this repo.
+  // shownReleases is sorted newest first, so the first non-prerelease is the
+  // latest stable release.
+  const latestStableID = shownReleases.find((r) => !r.prerelease)?.id;
+
+  downloadJSON[repoName] = shownReleases.map(
+    (r): DownloadRelease => ({
+      version: r.tag_name,
+      stable: !r.prerelease,
+      latest: r.id === latestStableID,
+      lts:
+        docsConfig.ltsVersions[repoName]?.includes(majorMinor(r.tag_name)) ??
+        false,
+      files: getBinaries(r).map(
+        (b): DownloadFile => ({
+          url: b.url,
+          os: b.os,
+          arch: b.arch,
+          version: r.tag_name,
+          sha256: b.checksum,
+          size: b.sizeBytes,
+          kind: "archive",
+        })
+      ),
+    })
+  );
+
   console.groupEnd();
 }
 
@@ -180,4 +214,10 @@ console.log(`Writing downloads metadata to ${OUTDIR}/downloads-metadata.json`);
 fs.writeFileSync(
   path.join(OUTDIR, "downloads-metadata.json"),
   JSON.stringify(downloads, null, 2)
+);
+
+console.log(`Writing download.json to ${OUTDIR}/download.json`);
+fs.writeFileSync(
+  path.join(OUTDIR, "download.json"),
+  JSON.stringify(downloadJSON, null, 2)
 );

--- a/src/download-json-types.ts
+++ b/src/download-json-types.ts
@@ -1,0 +1,31 @@
+// Types for the machine-readable download.json served at the site root.
+// The per-release shape intentionally mirrors Go's
+// https://go.dev/dl/?mode=json (version.json) so that tooling can consume it
+// in a familiar way, with Prometheus-specific "latest" and "lts" flags added.
+// The top level is keyed by repository name, exposing every repository shown
+// on the downloads page.
+
+export type DownloadJSON = {
+  [repo: string]: DownloadRelease[];
+};
+
+export type DownloadRelease = {
+  version: string;
+  // stable is true for non-prerelease versions.
+  stable: boolean;
+  // latest is true for the most recent stable release of the repository.
+  latest: boolean;
+  // lts is true for long-term support releases.
+  lts: boolean;
+  files: DownloadFile[];
+};
+
+export type DownloadFile = {
+  url: string;
+  os: string;
+  arch: string;
+  version: string;
+  sha256: string;
+  size: number;
+  kind: string;
+};


### PR DESCRIPTION
Add a download.json, served at https://prometheus.io/download.json, listing the releases of every repository shown on the downloads page. The per-release shape mirrors Go's version.json (version, stable, files with os/arch/sha256/ size), with Prometheus-specific "latest" and "lts" flags added.

The file is generated by fetch-downloads-info.ts into generated/ and exposed at the site root via a committed symlink in public/, matching the existing repo-docs-assets mechanism.

<!--
    Please sign CNCF's Developer Certificate of Origin and sign-off your commits by adding the -s / --sign-off flag to `git commit`

    More information on both of those can be found at https://github.com/apps/dco

    If you are proposing a new integration, exporter, or client library, please include representative sample output.
 -->
