### PR TITLE
Add alternative Haskell client library

### DIFF
--- a/docs/instrumenting/clientlibs.md
+++ b/docs/instrumenting/clientlibs.md
@@ -27,8 +27,8 @@ Unofficial third-party client libraries:
 * [Delphi](https://github.com/marcobreveglieri/prometheus-client-delphi)
 * [Elixir](https://github.com/deadtrickster/prometheus.ex)
 * [Erlang](https://github.com/deadtrickster/prometheus.erl)
-* Haskell: [prometheus-client](https://hackage.haskell.org/package/prometheus-client)
-* Haskell: [prometheus](https://hackage.haskell.org/package/prometheus)
+* Haskell: [prometheus-client](https://github.com/fimad/prometheus-haskell)
+* Haskell: [prometheus](https://github.com/bitnomial/prometheus)
 * [Julia](https://github.com/fredrikekre/Prometheus.jl)
 * [Lua](https://github.com/knyar/nginx-lua-prometheus) for Nginx
 * [Lua](https://github.com/tarantool/metrics) for Tarantool

--- a/docs/instrumenting/clientlibs.md
+++ b/docs/instrumenting/clientlibs.md
@@ -27,13 +27,11 @@ Unofficial third-party client libraries:
 * [Delphi](https://github.com/marcobreveglieri/prometheus-client-delphi)
 * [Elixir](https://github.com/deadtrickster/prometheus.ex)
 * [Erlang](https://github.com/deadtrickster/prometheus.erl)
-* Haskell
-    * [prometheus-client](https://hackage.haskell.org/package/prometheus-client)
-    * [prometheus](https://hackage.haskell.org/package/prometheus)
+* Haskell: [prometheus-client](https://hackage.haskell.org/package/prometheus-client)
+* Haskell: [prometheus](https://hackage.haskell.org/package/prometheus)
 * [Julia](https://github.com/fredrikekre/Prometheus.jl)
-* Lua
-    * [For Nginx](https://github.com/knyar/nginx-lua-prometheus)
-    * [For Tarantool](https://github.com/tarantool/metrics)
+* [Lua](https://github.com/knyar/nginx-lua-prometheus) for Nginx
+* [Lua](https://github.com/tarantool/metrics) for Tarantool
 * [.NET / C#](https://learn.microsoft.com/en-us/dotnet/core/diagnostics/metrics-collection)
 * [Node.js](https://github.com/siimon/prom-client)
 * [OCaml](https://github.com/mirage/prometheus)

--- a/docs/instrumenting/clientlibs.md
+++ b/docs/instrumenting/clientlibs.md
@@ -27,10 +27,13 @@ Unofficial third-party client libraries:
 * [Delphi](https://github.com/marcobreveglieri/prometheus-client-delphi)
 * [Elixir](https://github.com/deadtrickster/prometheus.ex)
 * [Erlang](https://github.com/deadtrickster/prometheus.erl)
-* [Haskell](https://github.com/fimad/prometheus-haskell)
+* Haskell
+    * [prometheus-client](https://hackage.haskell.org/package/prometheus-client)
+    * [prometheus](https://hackage.haskell.org/package/prometheus)
 * [Julia](https://github.com/fredrikekre/Prometheus.jl)
-* [Lua](https://github.com/knyar/nginx-lua-prometheus) for Nginx
-* [Lua](https://github.com/tarantool/metrics) for Tarantool
+* Lua
+    * [For Nginx](https://github.com/knyar/nginx-lua-prometheus)
+    * [For Tarantool](https://github.com/tarantool/metrics)
 * [.NET / C#](https://learn.microsoft.com/en-us/dotnet/core/diagnostics/metrics-collection)
 * [Node.js](https://github.com/siimon/prom-client)
 * [OCaml](https://github.com/mirage/prometheus)


### PR DESCRIPTION
`prometheus` is another popular client library for Prometheus; this documentation should probably not take a stance on which one is recommended