### PR TITLE
Fix duplicated words in docs

### DIFF
--- a/docs/specs/native_histograms.md
+++ b/docs/specs/native_histograms.md
@@ -1479,7 +1479,7 @@ simpler set of buckets for the new chunk.
 This in turn implies that there will never be a counter reset after the first
 sample in a chunk. Therefore, the only counter reset information that has to be
 persisted is that of the 1st histogram in a chunk. This happens in the
-so-called _histogram flags_, a single byte stored directly after the the number
+so-called _histogram flags_, a single byte stored directly after the number
 of samples in the chunk. This byte is currently only used for the counter reset
 information, but it may be used for other flags in the future. The counter
 reset information uses the first two bits. The four possible bit patterns are

--- a/docs/visualization/consoles.md
+++ b/docs/visualization/consoles.md
@@ -169,7 +169,7 @@ Valid options for the `yAxisFormatter` and `yHoverFormatter`:
 
 * `PromConsole.NumberFormatter.humanize`: Format using [metric prefixes](http://en.wikipedia.org/wiki/Metric_prefix).
 * `PromConsole.NumberFormatter.humanizeNoSmallPrefix`: For absolute values
-  greater than 1, format using using [metric prefixes](http://en.wikipedia.org/wiki/Metric_prefix).
+  greater than 1, format using [metric prefixes](http://en.wikipedia.org/wiki/Metric_prefix).
   For absolute values less than 1, format with 3 significant digits. This is
   useful to avoid units such as milliqueries per second that can be produced by
   `PromConsole.NumberFormatter.humanize`.


### PR DESCRIPTION
Removes two accidental duplicate words in the documentation:

- `docs/visualization/consoles.md`: `format using using` -> `format using`
- `docs/specs/native_histograms.md`: `after the the number` -> `after the number`

Both occur once in hand-authored prose; no meaning change.