### PR TITLE
feat: add PromCon EU 2026 site announcement

### DIFF
--- a/docs-config.ts
+++ b/docs-config.ts
@@ -4,10 +4,10 @@ export default {
   siteUrl: "https://prometheus.io",
 
   announcement: {
-    text: "Do you use Prometheus and OpenTelemetry to monitor infrastructure and applications? Please answer our 3-minutes [survey](https://docs.google.com/forms/d/e/1FAIpQLSfDfT0Y7Y9ZzlXM9GFnei0B8rCaa4ctVD4nhpzzJY7cfzrOrw/viewform)!",
-    mobileText: "Prometheus+OTel infrastructure and applications monitoring [survey](https://docs.google.com/forms/d/e/1FAIpQLSfDfT0Y7Y9ZzlXM9GFnei0B8rCaa4ctVD4nhpzzJY7cfzrOrw/viewform)!",
-    startDate: "2026-04-23",
-    endDate: "2026-05-23",
+    text: "Join [PromCon EU 2026](https://promcon.io/2026-munich/), the Prometheus users conference, on October 7–8, 2026 in Munich. The [Call for Speakers](https://sessionize.com/promcon-eu-2026/) is open until July 19, 2026.",
+    mobileText: "[PromCon EU 2026](https://promcon.io/2026-munich/) — Oct 7–8, Munich. [CFP](https://sessionize.com/promcon-eu-2026/) open until July 19.",
+    startDate: "2026-07-17",
+    endDate: "2026-10-08",
   },
 
   kapa: {


### PR DESCRIPTION
Advertise the Munich conference dates and open Call for Speakers.

<!--
    Please sign CNCF's Developer Certificate of Origin and sign-off your commits by adding the -s / --sign-off flag to `git commit`

    More information on both of those can be found at https://github.com/apps/dco

    If you are proposing a new integration, exporter, or client library, please include representative sample output.
 -->
