### PR TITLE
Add OpenObserve remote storage integration

### DIFF
--- a/docs/operating/integrations.md
+++ b/docs/operating/integrations.md
@@ -66,6 +66,7 @@ data volumes.
   * [M3DB](https://m3db.io/docs/integrations/prometheus/): read and write
   * [Mezmo](https://docs.mezmo.com/telemetry-pipelines/prometheus-remote-write-pipeline-source): write
   * [New Relic](https://docs.newrelic.com/docs/set-or-remove-your-prometheus-remote-write-integration): write
+  * [OpenObserve](https://openobserve.ai/docs/ingestion/metrics/prometheus/): write
   * [OpenTSDB](https://github.com/prometheus/prometheus/tree/main/documentation/examples/remote_storage/remote_storage_adapter): write
   * [QuasarDB](https://doc.quasardb.net/master/user-guide/integration/prometheus.html): read and write
   * [SignalFx](https://github.com/signalfx/metricproxy#prometheus): write


### PR DESCRIPTION
## What changed

Add OpenObserve to the Remote Endpoints and Storage integrations as a Prometheus remote-write destination.

## Why

OpenObserve natively accepts Prometheus remote-write samples, but it is not currently listed among the compatible remote storage endpoints.

The entry links directly to the OpenObserve Prometheus ingestion documentation, which includes a representative `remote_write` configuration and endpoint.

## Validation

- Ran `make check`
- Ran `git diff --check`
- Verified the linked documentation returns HTTP 200

@RichiH @juliusv
