### PR TITLE
exporters: add OpenChainBench blockchain RPC exporter

### DIFF
--- a/docs/instrumenting/exporters.md
+++ b/docs/instrumenting/exporters.md
@@ -255,6 +255,7 @@ wide variety of JVM-based applications, for example [Kafka](http://kafka.apache.
    * [Nomad exporter](https://gitlab.com/yakshaving.art/nomad-exporter)
    * [nftables exporter](https://github.com/Intrinsec/nftables_exporter)
    * [Open OnDemand exporter](https://github.com/OSC/ondemand_exporter)
+   * [OpenChainBench blockchain RPC exporter](https://github.com/ChainBench/OpenChainBench)
    * [OpenClaw exporter](https://github.com/SammyLin/openclaw-exporter)
    * [OpenStack exporter](https://github.com/openstack-exporter/openstack-exporter)
    * [OpenStack blackbox exporter](https://github.com/infraly/openstack_client_exporter)


### PR DESCRIPTION
Adds OpenChainBench to the Miscellaneous exporters list, placed alphabetically between Open OnDemand and OpenClaw.

**What it exports:** blockchain RPC provider health metrics — request latency (p50/p95/p99), reliability classification, stale-block detection, and gas oracle accuracy across 22 EVM chains and Solana. Each harness is a Go binary exposing a standard `/metrics` endpoint built with `github.com/prometheus/client_golang`.

**Repo:** https://github.com/ChainBench/OpenChainBench (Apache-2.0)

**Sample metric names:** `ocb_rpc_latency_seconds`, `ocb_rpc_reliability_class`, `ocb_stale_block_lag_blocks`, `ocb_gas_oracle_error_ratio`.

**Disclosure:** I contribute to the project. Happy to reword the entry, drop it, or move it to the "Software exposing Prometheus metrics" section if that fits better — the harnesses are also runnable as a hosted service that exposes `/metrics` directly.