### PR TITLE
Add meinberg_ltos_exporter to exporters list

### DIFF
--- a/docs/instrumenting/exporters.md
+++ b/docs/instrumenting/exporters.md
@@ -73,6 +73,7 @@ wide variety of JVM-based applications, for example [Kafka](http://kafka.apache.
    * [InfiniBand exporter](https://github.com/treydock/infiniband_exporter)
    * [IPMI exporter](https://github.com/soundcloud/ipmi_exporter)
    * [knxd exporter](https://github.com/RichiH/knxd_exporter)
+   * [Meinberg LANTIME OS exporter](https://github.com/raphaelthomas/meinberg_ltos_exporter)
    * [Modbus exporter](https://github.com/RichiH/modbus_exporter)
    * [Netgear Cable Modem Exporter](https://github.com/ickymettle/netgear_cm_exporter)
    * [Netgear Router exporter](https://github.com/DRuggeri/netgear_exporter)


### PR DESCRIPTION
Adds `meinberg_ltos_exporter`, a Prometheus exporter for Meinberg LANTIME OS (LTOS) devices (timekeeping appliances used as network time servers). It scrapes the device's REST API and exposes metrics on clock sync status, GNSS receiver state, NTP peer/system stats, and system health.

Sample metrics (see https://github.com/raphaelthomas/meinberg_ltos_exporter/blob/main/tests/testdata/m600-gps.metrics for the full sample output):

    # HELP meinberg_ltos_build_info Meinberg device build information as labels
    # TYPE meinberg_ltos_build_info gauge
    meinberg_ltos_build_info{api_version="20.05.013",firmware_version="fw_7.10.008",host="mbg1.time.example.com",target="http://localhost"} 1

    # HELP meinberg_ltos_clock_synchronized Meinberg clock synchronization status
    # TYPE meinberg_ltos_clock_synchronized gauge
    meinberg_ltos_clock_synchronized{clock_id="clk1",host="mbg1.time.example.com"} 1

    # HELP meinberg_ltos_clock_receiver_gnss_satellites_good Number of good satellites for the GNSS receiver
    # TYPE meinberg_ltos_clock_receiver_gnss_satellites_good gauge
    meinberg_ltos_clock_receiver_gnss_satellites_good{clock_id="clk1",host="mbg1.time.example.com"} 9

    # HELP meinberg_ltos_ntp_sys_stratum Meinberg NTP stratum level
    # TYPE meinberg_ltos_ntp_sys_stratum gauge
    meinberg_ltos_ntp_sys_stratum{host="mbg1.time.example.com",refid="GPS"} 1

    # HELP meinberg_ltos_system_info Meinberg system information as labels
    # TYPE meinberg_ltos_system_info gauge
    meinberg_ltos_system_info{host="mbg1.time.example.com",model="M600",serial_number="0123456789"} 1

    # HELP meinberg_ltos_up Indicates if the Meinberg LTOS device is reachable
    # TYPE meinberg_ltos_up gauge
    meinberg_ltos_up{target="http://localhost"} 1