### PR TITLE
Add Dagster exporter to list of miscellaneous exporters

### DIFF
--- a/docs/instrumenting/exporters.md
+++ b/docs/instrumenting/exporters.md
@@ -227,6 +227,7 @@ wide variety of JVM-based applications, for example [Kafka](http://kafka.apache.
    * [Cachet exporter](https://github.com/ContaAzul/cachet_exporter)
    * [ccache exporter](https://github.com/virtualtam/ccache_exporter)
    * [c-lightning exporter](https://github.com/lightningd/plugins/tree/master/prometheus)
+   * [Dagster exporter](https://github.com/HirofumiTsuda/dagster-prometheus-exporter)
    * [DHCPD leases exporter](https://github.com/DRuggeri/dhcpd_leases_exporter)
    * [Dovecot exporter](https://github.com/kumina/dovecot_exporter)
    * [Dnsmasq exporter](https://github.com/google/dnsmasq_exporter)


### PR DESCRIPTION
Adds the [Dagster exporter](https://github.com/HirofumiTsuda/dagster-prometheus-exporter) to the Miscellaneous section, in alphabetical order (between c-lightning exporter and DHCPD leases exporter).

It polls Dagster's GraphQL API directly and exposes run-state metrics (active runs, completed runs, latest run status) as Prometheus metrics, avoiding the blind spots of Dagster's official Pushgateway-based integration (e.g. crashed/queued runs that never get a chance to push).

Sample output:
```
dagster_active_runs{job_name="heavy_job",location="dev-dagster-workspace",status="queued"} 0
dagster_active_runs{job_name="heavy_job",location="dev-dagster-workspace",status="started"} 1
dagster_active_runs{job_name="heavy_job",location="dev-dagster-workspace",status="starting"} 0

dagster_completed_runs_total{job_name="heavy_job",location="dev-dagster-workspace",status="failure"} 0
dagster_completed_runs_total{job_name="heavy_job",location="dev-dagster-workspace",status="success"} 12
dagster_completed_runs_total{job_name="failing_job",location="dev-dagster-workspace",status="failure"} 3

dagster_last_run_info{job_name="heavy_job",location="dev-dagster-workspace",status="success"} 1
dagster_last_run_info{job_name="failing_job",location="dev-dagster-workspace",status="failure"} 1
```

License: MIT