### PR TITLE
Add a helpful not-found page

### DIFF
--- a/src/app/not-found.tsx
+++ b/src/app/not-found.tsx
@@ -1,0 +1,33 @@
+import { Button, Center, Stack, Text, Title } from "@mantine/core";
+import Link from "next/link";
+import { getPageMetadata } from "@/page-metadata";
+
+export const metadata = getPageMetadata({
+  pageTitle: "Page not found",
+  pageDescription: "The page you requested could not be found.",
+  pagePath: "/404",
+});
+
+export default function NotFound() {
+  return (
+    <Center mih="50vh">
+      <Stack align="center" gap="md" maw={600}>
+        <Title order={1} ta="center">
+          Page not found
+        </Title>
+        <Text c="dimmed" ta="center">
+          The page you requested does not exist or may have moved. Try the
+          latest Prometheus documentation or return to the home page.
+        </Text>
+        <Stack gap="xs" align="center">
+          <Button component={Link} href="/docs/introduction/overview">
+            Go to the latest documentation
+          </Button>
+          <Button component={Link} href="/" variant="subtle">
+            Return to Prometheus
+          </Button>
+        </Stack>
+      </Stack>
+    </Center>
+  );
+}


### PR DESCRIPTION
Fixes #1795\n\n## Summary\n- add a Next.js not-found page that keeps the existing site layout and navigation\n- link visitors to the latest documentation and the Prometheus home page\n- provide page metadata for the 404 route\n\n## Validation\n- npm run lint (passes with an existing unused-import warning in src/components/PromMarkdown.tsx)\n- npm run build-all compiled and passed type checking\n- the static export reached 290/582 pages before the temporary filesystem ran out of space (ENOSPC)