### PR TITLE
Add dbx DriveRack PA2 exporter to hardware exporters

### DIFF
--- a/docs/instrumenting/exporters.md
+++ b/docs/instrumenting/exporters.md
@@ -65,6 +65,7 @@ wide variety of JVM-based applications, for example [Kafka](http://kafka.apache.
    * [BIG-IP exporter](https://github.com/ExpressenAB/bigip_exporter)
    * [Bosch Sensortec BMP/BME exporter](https://github.com/David-Igou/bsbmp-exporter)
    * [Collins exporter](https://github.com/soundcloud/collins_exporter)
+   * [dbx DriveRack PA2 exporter](https://github.com/TilmannF/pa2_exporter)
    * [Dell Hardware OMSA exporter](https://github.com/galexrt/dellhw_exporter)
    * [Disk usage exporter](https://github.com/dundee/disk_usage_exporter)
    * [Fortigate exporter](https://github.com/bluecmd/fortigate_exporter)


### PR DESCRIPTION
Adds [pa2_exporter](https://github.com/TilmannF/pa2_exporter) to the hardware
section, inserted alphabetically.

It exports metrics from the dbx DriveRack PA2, a loudspeaker management
processor used in live venues and installed sound systems: input and output
levels, limiter and compressor activity, mutes, crossover configuration, loaded
preset, and an audit trail of settings changed on the device. It speaks the
unit's own network control protocol and is strictly read-only — it never sends
a `set`, so it cannot alter what a room sounds like.

Written against the [guidelines on writing exporters](https://prometheus.io/docs/instrumenting/writing_exporters/):

- counters end in `_total`, gauges use base units (dB, seconds)
- a `pa2_up` metric reports whether the device session is established, and
  device-state series are withheld while it is down rather than reporting the
  last known value
- meters push far faster than a scrape interval, so level metrics carry a
  `stat` label with min/avg/max over a trailing window instead of aliasing to
  one arbitrary sample
- default port 10049, allocated on the [default port allocations wiki](https://github.com/prometheus/prometheus/wiki/Default-port-allocations)

MIT licensed, tested on Python 3.9–3.14, multi-arch images on GHCR and Docker
Hub. No trademark affiliation with Harman — the model name identifies the
compatible hardware only, as noted in the project's TRADEMARKS.md.