### PR TITLE
Add Synthetic Exporter to exporters documentation

### DIFF
--- a/docs/instrumenting/exporters.md
+++ b/docs/instrumenting/exporters.md
@@ -135,6 +135,7 @@ wide variety of JVM-based applications, for example [Kafka](http://kafka.apache.
    * [Nginx VTS exporter](https://github.com/sysulq/nginx-vts-exporter)
    * [Passenger exporter](https://github.com/stuartnelson3/passenger_exporter)
    * [Squid exporter](https://github.com/boynux/squid-exporter)
+   * [Synthetic Exporter](https://github.com/aizik-fridman/synthetic-exporter)
    * [Tinyproxy exporter](https://github.com/gmm42/tinyproxy_exporter)
    * [Varnish exporter](https://github.com/jonnenauha/prometheus_varnish_exporter)
    * [WebDriver exporter](https://github.com/mattbostock/webdriver_exporter)


### PR DESCRIPTION
Adding the `synthetic-exporter` to the official list of exporters.

**Description:**
An all-in-one synthetic monitoring exporter written in Go. It combines API HTTP status checks, absolute Unix timestamp SSL certificate expiration monitoring, and full multi-step headless browser UI user journeys using Playwright.

**CNCF & Prometheus Compliance:**
* **Port Allocation:** The default port has been properly registered in the Prometheus wiki (`10050`).
* **Metric Standards:** Base units and naming conventions are strictly followed (e.g., exposing absolute unix epoch via `synthetic_ssl_cert_expiry_timestamp_seconds`).
* **Architecture:** Uses a background worker pattern to decouple browser execution from the scrape path, preventing scrape timeouts and race conditions.

**Link:** https://github.com/aizik-fridman/synthetic-exporter

<!--
    Please sign CNCF's Developer Certificate of Origin and sign-off your commits by adding the -s / --sign-off flag to `git commit`

    More information on both of those can be found at https://github.com/apps/dco

    If you are proposing a new integration, exporter, or client library, please include representative sample output.
 -->
