### PR TITLE
docs: add Apache APISIX to software exposing Prometheus metrics

### DIFF
--- a/docs/instrumenting/exporters.md
+++ b/docs/instrumenting/exporters.md
@@ -302,7 +302,7 @@ Some third-party software exposes metrics in the Prometheus format, so no
 separate exporters are needed:
 
    * [Ansible Automation Platform Automation Controller (AWX)](https://docs.ansible.com/automation-controller/latest/html/administration/metrics.html)
-   * [Apache APISIX](https://apisix.apache.org/docs/apisix/plugins/prometheus/) (**direct**)
+   * [Apache APISIX](https://apisix.apache.org/docs/apisix/plugins/prometheus/)
    * [App Connect Enterprise](https://github.com/ot4i/ace-docker)
    * [Ballerina](https://ballerina.io/)
    * [BFE](https://github.com/baidu/bfe)

--- a/docs/instrumenting/exporters.md
+++ b/docs/instrumenting/exporters.md
@@ -302,6 +302,7 @@ Some third-party software exposes metrics in the Prometheus format, so no
 separate exporters are needed:
 
    * [Ansible Automation Platform Automation Controller (AWX)](https://docs.ansible.com/automation-controller/latest/html/administration/metrics.html)
+   * [Apache APISIX](https://apisix.apache.org/docs/apisix/plugins/prometheus/) (**direct**)
    * [App Connect Enterprise](https://github.com/ot4i/ace-docker)
    * [Ballerina](https://ballerina.io/)
    * [BFE](https://github.com/baidu/bfe)


### PR DESCRIPTION
### Summary

- add Apache APISIX to the list of software exposing Prometheus metrics;
- link to the maintained Apache APISIX Prometheus plugin reference; and
- mark it as directly instrumented with a Prometheus client library.

Apache APISIX registers gateway metrics through its bundled
`nginx-lua-prometheus-api7` client library and exposes them from its
first-party `prometheus` plugin, so no separate exporter is required. The
entry is placed in the same section as other software with directly
instrumented Prometheus endpoints.

Representative output from Apache APISIX 3.17.0:

```text
# HELP apisix_http_latency HTTP request latency in milliseconds per service in APISIX
# TYPE apisix_http_latency histogram
apisix_http_latency_count{type="request",route="checkout-route",service="checkout",consumer="",node="172.18.0.2",request_type="traditional_http",request_llm_model="",llm_model=""} 4

# HELP apisix_http_status HTTP status codes per service in APISIX
# TYPE apisix_http_status counter
apisix_http_status{code="200",route="checkout-route",matched_uri="/status/*",matched_host="",service="checkout",consumer="",node="172.18.0.2",request_type="traditional_http",request_llm_model="",llm_model="",response_source="upstream"} 2
```

Validation:

- the sample was captured from a version-pinned Apache APISIX 3.17.0 Docker
  environment after requests reached a test upstream
- `promtool 3.13.2 check metrics` reports that the existing
  `apisix_http_status` counter does not use the recommended `_total` suffix
- `apisix_http_latency` reports milliseconds, while Prometheus recommends base
  units and unit suffixes for metric names

These are existing APISIX metric-convention gaps. This directory change does
not modify the metric surface or claim full compliance with Prometheus naming
guidance.

Disclosure: I am an Apache APISIX Committer.

@RichiH, could you review this small integrations-directory addition when you
have time?
