### PR TITLE
docs(instrumenting): list ClickHouse among software exposing Prometheus metrics

### DIFF
--- a/docs/instrumenting/exporters.md
+++ b/docs/instrumenting/exporters.md
@@ -308,6 +308,7 @@ separate exporters are needed:
    * [BFE](https://github.com/baidu/bfe)
    * [Caddy](https://caddyserver.com/docs/metrics) (**direct**)
    * [Ceph](https://docs.ceph.com/en/latest/mgr/prometheus/)
+   * [ClickHouse](https://clickhouse.com/docs/concepts/features/interfaces/prometheus)
    * [CockroachDB](https://www.cockroachlabs.com/docs/stable/monitoring-and-alerting.html#prometheus-endpoint)
    * [Collectd](https://collectd.org/wiki/index.php/Plugin:Write_Prometheus)
    * [Concourse](https://concourse-ci.org/)


### PR DESCRIPTION
## What changed

docs/instrumenting/exporters.md: add ClickHouse to the "Software exposing Prometheus metrics" list, between Ceph and CockroachDB.

## Why

ClickHouse natively exposes Prometheus-format metrics via its built-in Prometheus endpoint (configured through the `<prometheus>` block, default port 9363 at `/metrics`), so no separate exporter is required. This follows the same proven lane as recent additions (Apache APISIX #3064, Meinberg #3046, OpenObserve #3042, SMSEagle #3041).

Additive only: the dedicated third-party [ClickHouse exporter](https://github.com/f1yegor/clickhouse_exporter) entry is intentionally left untouched. A 2021 PR (#1513) attempted to *replace* that entry with native support and was declined by @brian-brazil over completeness concerns; listing native support as its own entry avoids that issue entirely.

## How it was verified

- Link target verified live: https://clickhouse.com/docs/concepts/features/interfaces/prometheus (HTTP 200) — the official docs page documenting the native Prometheus endpoint.
- `npm run lint` — clean (pre-existing `PromMarkdown.tsx` unused-vars warning only).
- Diff limited to the single alphabetized line.
