### PR TITLE
docs: fix stale explanation in instrumenting HTTP server tutorial

### DIFF
--- a/docs/tutorials/instrumenting_http_server_in_go.md
+++ b/docs/tutorials/instrumenting_http_server_in_go.md
@@ -84,9 +84,9 @@ func main() {
 }
 ```
 
-The `prometheus.MustRegister` function registers the pingCounter with the default registry.
+The `promauto.With(reg).NewCounter()` function creates the counter and registers it with the custom registry.
 To expose the metrics, the Go Prometheus client library provides the promhttp package.
-`promhttp.Handler()` provides an `http.Handler` which exposes the metrics registered in the default registry.
+`promhttp.HandlerFor(reg, promhttp.HandlerOpts{})` provides an `http.Handler` which exposes the metrics registered in the given registry.
 
 The sample code is now:
 
@@ -111,7 +111,7 @@ func newMetrics(reg prometheus.Registerer) *metrics {
 		pingCounter: promauto.With(reg).NewCounter(
 			prometheus.CounterOpts{
 				Name: "ping_request_count",
-				Help: "No of request handled by Ping handler",
+				Help: "No of requests handled by Ping handler",
 			}),
 	}
 	return m
@@ -147,7 +147,7 @@ Now hit the localhost:8090/ping endpoint a couple of times and then send a reque
 
 Here, the `ping_request_count` shows that the `/ping` endpoint was called 3 times.
 
-The default registry comes with a collector for Go runtime metrics, and that is why we see other metrics like `go_threads`, `go_goroutines`, etc.
+The code above uses a custom registry (`prometheus.NewRegistry()`), which does not include Go runtime metrics by default. To also collect Go runtime metrics, register `prometheus.NewGoCollector()` with the registry.
 
 We have built our first metric exporter. Let’s update our Prometheus config to scrape the metrics from our server.
 


### PR DESCRIPTION
## Problem

The explanation paragraph in the Go instrumenting tutorial still references
`MustRegister`, `promhttp.Handler()`, and the "default registry" — none of
which appear in the code. The code was changed to use `prometheus.NewRegistry()`
(custom registry) in Nov 2022 (commit 292bc326), but the surrounding prose was
never updated. Subsequent grammar fixes (PR #2824, merged) cleaned up style but
left the stale API references intact.

Additionally:
- The Help text says "No of request" in the full sample code but "No of
  requests" in the incremental code block above.
- The text claims Go runtime metrics appear because "the default registry comes
  with a collector," but the code uses a custom registry that does not include
  them.

Partially addresses #2815 (PR #2824 fixed grammar but these correctness issues
remained).

## Fix

- Update the explanation paragraph to reference `promauto.With(reg)`,
  `promhttp.HandlerFor(reg, ...)`, and "custom registry" — matching the
  actual code.
- Fix the Help text inconsistency: "No of request" → "No of requests" in
  the full sample code.
- Replace the misleading Go runtime metrics claim with an accurate note that
  the custom registry does not include them by default and how to add them.

## Verification

- Diff read against `upstream/main` (12e2edf8).
- Verified all changed prose references functions and patterns that exist in
  the code blocks on the same page.
- Cross-checked the git history: commit 292bc326 (Nov 2022) introduced the
  custom registry code but left the old prose untouched.

## Notes

- The screenshot showing Go runtime metrics (`go_threads`, `go_goroutines`)
  predates the custom-registry change and is now slightly misleading. An
  updated screenshot would be ideal but is out of scope for this text-only fix.