### PR TITLE
Add sip-exporter to the exporters list

### DIFF
--- a/docs/instrumenting/exporters.md
+++ b/docs/instrumenting/exporters.md
@@ -275,6 +275,7 @@ wide variety of JVM-based applications, for example [Kafka](http://kafka.apache.
    * [Scraparr](https://github.com/thecfu/scraparr)
    * [Script exporter](https://github.com/adhocteam/script_exporter)
    * [Shield exporter](https://github.com/cloudfoundry-community/shield_exporter)
+   * [sip-exporter](https://github.com/aibudaevv/sip-exporter)
    * [Slurm exporter](https://github.com/sckyzo/slurm_exporter)
    * [Smokeping prober](https://github.com/SuperQ/smokeping_prober)
    * [SMTP/Maildir MDA blackbox prober](https://github.com/cherti/mailexporter)


### PR DESCRIPTION
  Summary

- add sip-exporter to Third-party exporters / Miscellaneous
- preserve the existing alphabetical order

Announcement: submitted to Prometheus Developers; pending new-member moderation. The public thread URL will be added when available.

Stable release: https://github.com/aibudaevv/sip-exporter/releases/tag/v1.11.0
Maintainer disclosure: I maintain sip-exporter and am submitting my own project.

cc @RichiH
