### PR TITLE
RW 2.0-rc.5: allow exemplar-only time series

### DIFF
--- a/docs/specs/prw/remote_write_spec_2_0.md
+++ b/docs/specs/prw/remote_write_spec_2_0.md
@@ -362,7 +362,7 @@ For every `TimeSeries` message:
 <!---
 Rationales: https://github.com/prometheus/proposals/blob/alexg/remote-write-20-proposal/proposals/2024-04-09_remote-write-20.md#partial-writes#samples-vs-native-histogram-samples
 -->
-* At least one element in `samples` or in `histograms` MUST be provided. A `TimeSeries` MUST NOT include both `samples` and `histograms`. For series which (rarely) would mix float and histogram samples, a separate `TimeSeries` message MUST be used.
+* At least one element in `samples`, in `histograms`, or in `exemplars` MUST be provided. A `TimeSeries` MUST NOT include both `samples` and `histograms`. For series which (rarely) would mix float and histogram samples, a separate `TimeSeries` message MUST be used. A `TimeSeries` carrying exemplars but neither samples nor histograms represents series-level exemplars for the series identified by `labels_refs`.
 
 <!---
 Rationales: https://github.com/prometheus/proposals/blob/alexg/remote-write-20-proposal/proposals/2024-04-09_remote-write-20.md#always-on-metadata
@@ -452,6 +452,8 @@ Rationales: https://github.com/prometheus/proposals/blob/alexg/remote-write-20-p
 -->
 * MAY contain labels e.g. referencing trace or request ID. If the exemplar references a trace it SHOULD use the `trace_id` label name, as a best practice.
 * MUST contain a timestamp. While exemplar timestamps are optional in Prometheus/Open Metrics exposition formats, the assumption is that a timestamp is assigned at scrape time in the same way a timestamp is assigned to the scrape sample. Receivers require exemplar timestamps to reliably handle (e.g. deduplicate) incoming exemplars.
+* MAY be sent in a `TimeSeries` that carries neither samples nor histograms. In that form the exemplars are associated with the series identified by `labels_refs`, rather than with a particular sample or histogram.
+* SHOULD be sent in the same request as the samples or histograms of the series they belong to, including when they are sent in a `TimeSeries` of their own.
 
 ## Out of Scope
 

--- a/docs/specs/prw/remote_write_spec_2_0.md
+++ b/docs/specs/prw/remote_write_spec_2_0.md
@@ -257,22 +257,23 @@ message TimeSeries {
   // or start timestamp.
   repeated uint32 labels_refs = 1;
 
-  // Timeseries messages can either specify samples or (native) histogram samples
-  // (histogram field), but not both. For a typical sender (real-time metric
-  // streaming), in healthy cases, there will be only one sample or histogram.
+  // TimeSeries messages must specify at least one float sample, native histogram sample
+  // or exemplar. Samples and histograms must not be specified at the same time.
+  // Exemplars may be specified without samples or histograms. For a typical sender
+  // (real-time metric streaming), in healthy cases, there will be only one sample or histogram.
   //
   // Samples and histograms are sorted by timestamp (older first).
   repeated Sample samples = 2;
   repeated Histogram histograms = 3;
 
-  // exemplars represents an optional set of exemplars attached to this series' samples.
+  // exemplars represents an optional set of exemplars for this series.
   repeated Exemplar exemplars = 4;
 
   // metadata represents the metadata associated with the given series' samples.
   Metadata metadata = 5;
 }
 
-// Exemplar is an additional information attached to some series' samples.
+// Exemplar contains additional information associated with a series.
 // It is typically used to attach an example trace or request ID associated with
 // the metric changes.
 message Exemplar {


### PR DESCRIPTION
This changes the 2.0 specification so that a `TimeSeries` carrying only exemplars is described rather than forbidden.

## Why the current wording does not cover what a sender produces

Prometheus stores exemplars per series, not per sample. `populateV2TimeSeries` in `storage/remote/queue_manager.go` writes one output `TimeSeries` per queue item, and for an exemplar item it appends only an exemplar, having already reset that entry's samples and histograms. So an exemplar can leave the sender in a `TimeSeries` of its own.

The specification currently says:

> At least one element in `samples` or in `histograms` MUST be provided. A `TimeSeries` MUST NOT include both `samples` and `histograms`.

That shape therefore has no wording behind it, and a receiver has nothing to rely on when it arrives.

## What this changes

Two normative sentences, plus the proto copy this document carries:

- the "at least one element" rule accepts `exemplars` as well, and says what a `TimeSeries` carrying only exemplars means;
- the `#### Exemplars` section says the same thing from the exemplar's side;
- the copied proto comments say the same as the rules above them, so the two do not disagree inside one document.

No field, field number or wire layout changes, and nothing is asked of a sender that was not asked before.

## What the first version also had

It added a SHOULD that exemplars travel in the same request as the samples or histograms of their series. That is a rule about how a sender batches rather than a statement about what the wire format allows, and it is the part of this change review is stuck on, so it is out as of 81c879af.

Co-location is still worth writing down somewhere. `QueueManager.Append` and `AppendExemplars` both enqueue on the series ref, and `shards.enqueue` picks the shard with `ref % len(queues)`, so a series' samples and its exemplars go into the same shard queue in order. They are usually in one request and a full batch is what splits them. That belongs wherever the receiver profile question lands, not in this rule.

## What this leaves alone

The receiver tests in `prometheus/compliance` only cover exemplars sent alongside a sample. Covering a `TimeSeries` that carries only exemplars is a separate change. The canonical proto comments are in prometheus/prometheus#19530, which carries the source version bump to rc.5 as well.

## On versioning

Retitled with the version, the way rc.4 was done in #2762, so the title is the record of what went into the release. #3080 still carries the single bump and #3081 is the other change in this one.

Related to prometheus/prometheus#17857 and prometheus/prometheus#16944.


