### PR TITLE
docs(security): stop presenting CORS as an XSS defence

### DIFF
--- a/docs/operating/security.md
+++ b/docs/operating/security.md
@@ -166,19 +166,21 @@ Prometheus, and most exporters, support TLS. Including authentication of clients
 via TLS client certificates. Details on configuring Prometheus are [`here`](https://prometheus.io/docs/guides/tls-encryption/).
 
 The Go projects share the same TLS library, based on the
-Go [crypto/tls](https://golang.org/pkg/crypto/tls) library.
+Go [crypto/tls](https://pkg.go.dev/crypto/tls) library.
 We default to TLS 1.2 as minimum version. Our policy regarding this is based on
 [Qualys SSL Labs](https://www.ssllabs.com/) recommendations, where we strive to
 achieve a grade 'A' with a default configuration and correctly provided
 certificates, while sticking as closely as possible to the upstream Go defaults.
 Achieving that grade provides a balance between perfect security and usability.
 
-TLS will be added to Java exporters in the future.
+Java components such as the
+[JMX exporter](https://github.com/prometheus/jmx_exporter) also support TLS
+(including mutual TLS) on their HTTP endpoints.
 
 If you have special TLS needs, like a different cipher suite or older TLS
 version, you can tune the minimum TLS version and the ciphers, as long as the
-cipher is not [marked as insecure](https://golang.org/pkg/crypto/tls/#InsecureCipherSuites)
-in the [crypto/tls](https://golang.org/pkg/crypto/tls) library. If that still
+cipher is not [marked as insecure](https://pkg.go.dev/crypto/tls#InsecureCipherSuites)
+in the [crypto/tls](https://pkg.go.dev/crypto/tls) library. If that still
 does not suit you, the current TLS settings enable you to build a secure tunnel
 between the servers and reverse proxies with more special requirements.
 
@@ -206,8 +208,10 @@ may wish to block such paths to prevent CSRF.
 
 For non-mutating endpoints, you may wish to set [CORS
 headers](https://fetch.spec.whatwg.org/#http-cors-protocol) such as
-`Access-Control-Allow-Origin` in your reverse proxy to prevent
-[XSS](https://en.wikipedia.org/wiki/Cross-site_scripting).
+`Access-Control-Allow-Origin` in your reverse proxy if a browser
+application on another origin should be allowed to read those
+responses. CORS relaxes the Same-Origin Policy; it is not a defence
+against [XSS](https://en.wikipedia.org/wiki/Cross-site_scripting).
 
 If you are composing PromQL queries that include input from untrusted users
 (e.g. URL parameters to console templates, or something you built yourself) who


### PR DESCRIPTION
## Problem

`docs/operating/security.md` currently tells operators to set CORS headers such as `Access-Control-Allow-Origin` **to prevent XSS**. That is incorrect: CORS relaxes the Same-Origin Policy so a browser on another origin can read responses; it is not an XSS defence.

Reported in #2449. Confirmed still present on current `main`.

The same page has two sibling stale claims in the TLS section:

- "TLS will be added to Java exporters in the future." The [JMX exporter](https://github.com/prometheus/jmx_exporter) already supports TLS, including mutual TLS (see its `http/ssl` integration tests).
- `crypto/tls` is linked via the retired `golang.org/pkg/crypto/tls` URLs (they redirect, but the canonical docs are on `pkg.go.dev`).

## Triage / Root cause

The CORS sentence is in the **API Security** section and presents CORS as an XSS control. Maintainers already agreed in #2449 that CORS should not be mentioned as a defence against XSS.

## Fix

- Reword the CORS sentence: set CORS if a browser app on another origin should be allowed to read non-mutating responses; CORS is not an XSS defence.
- Replace the Java TLS "in the future" sentence with the current JMX exporter TLS support.
- Point the three `crypto/tls` links at `https://pkg.go.dev/crypto/tls`.

## Issue Number

Fixes #2449

## Verification

- Read `docs/operating/security.md` on `upstream/main` @ `8ea3853e` — the "to prevent XSS" wording, the Java "in the future" sentence, and the `golang.org/pkg/crypto/tls` links were all still present.
- Confirmed `https://golang.org/pkg/crypto/tls` redirects to `https://pkg.go.dev/crypto/tls`.
- Confirmed jmx_exporter ships `MutualTLSWithAuthTest` / `MutualTLSWithCustomCiphersTest`.

## Notes / Risks

- Docs-only. No Prometheus server behaviour change.
- CORS is still documented, just not as an XSS control — operators who actually need cross-origin browser access still have the guidance.
- @RichiH as docs maintainer for the non-web-design surface (see MAINTAINERS.md).
