### PR TITLE
Add hint to regarding CORS headers of Alertmanager

### DIFF
--- a/docs/operating/security.md
+++ b/docs/operating/security.md
@@ -111,6 +111,11 @@ Any user with access to the Alertmanager HTTP endpoint has access to its data.
 They can create and resolve alerts. They can create, modify and delete
 silences.
 
+Operators who do not configure any form of authentication must exercise
+caution: Alertmanager serves `/api/v2` with `Access-Control-Allow-Origin: *`.
+This grants API access to any website visited by a browser capable of reaching
+the service.
+
 Where notifications are sent to is determined by the configuration file. With
 certain templating setups it is possible for notifications to end up at an
 alert-defined destination. For example if notifications use an alert label as


### PR DESCRIPTION
The current documentation specifies that only trusted users should have access to the http endpoints of Alertmanager. However, the browsers default Single Origin Policy pertains more to network access.

Thus, documenting the `Access-Control-Allow-Origin: *` headers is a good idea. The `API Security` section already hints at the configuration, but mentioning it in a Alertmanager specific location shouldn't hurt.

