### PR TITLE
Add AlertINT to Alertmanager webhook receiver integrations

### DIFF
--- a/docs/operating/integrations.md
+++ b/docs/operating/integrations.md
@@ -84,6 +84,7 @@ data volumes.
 For notification mechanisms not natively supported by the Alertmanager, the
 [webhook receiver](/docs/alerting/configuration/#webhook_config) allows for integration.
 
+  * [AlertINT](https://github.com/alertint/alertint-agent): correlates alerts into incidents and runs LLM triage before notifying
   * [alertmanager-webhook-logger](https://github.com/tomtom-international/alertmanager-webhook-logger): logs alerts
   * [Alertsnitch](https://gitlab.com/yakshaving.art/alertsnitch): saves alerts to a MySQL database
   * [All Quiet](https://allquiet.app/integrations/inbound/prometheus): on-call & incident management


### PR DESCRIPTION
- Adds [AlertINT](https://github.com/alertint/alertint-agent) to the Alertmanager webhook receiver list
- Open-source (Go) agent that receives Alertmanager webhooks, correlates alerts into incidents, and runs LLM triage before notifying
- Alertmanager setup docs: https://github.com/alertint/alertint-agent/blob/main/docs/integrations/prometheus.md