### PR TITLE
clarify LTS commitment

### DIFF
--- a/docs/introduction/release-cycle.md
+++ b/docs/introduction/release-cycle.md
@@ -3,11 +3,11 @@ title: Long-term support
 sort_rank: 10
 ---
 
-Prometheus LTS are selected releases of Prometheus that receive bugfixes for an
-extended period of time.
+Prometheus LTS are selected releases of Prometheus that receive selected bug
+fixes for an extended period of one year.
 
 Every 6 weeks, a new Prometheus minor release cycle begins. After those 6
-weeks, minor releases generally no longer receive bugfixes. If a user is
+weeks, minor releases generally no longer receive bug fixes. If a user is
 impacted by a bug in a minor release, they often need to upgrade to the
 latest Prometheus release.
 
@@ -16,9 +16,14 @@ guarantees][stab]. However,
 there is a risk that new features and enhancements could also bring regressions,
 requiring another upgrade.
 
-Prometheus LTS only receive bug, security, and documentation fixes, but over a
-time window of one year. The build toolchain will also be kept up-to-date. This
-allows companies that rely on Prometheus to limit the upgrade risks while still
+Prometheus LTS version will only receive fixes for selected issues with high
+severity, i.e. a CVSS rating of 7.0 or higher. Additional changes for bug fixes
+or documentation fixes might be added. The build toolchain will also be kept
+up-to-date. This is a best effort commitment by the community, contributions are
+welcome.
+Support periods of two subsequent LTS version should overlap by at least one
+month.
+This allows users that rely on Prometheus to limit the upgrade risks while still
 having a Prometheus server maintained by the community.
 
 ## List of LTS releases
@@ -28,7 +33,7 @@ having a Prometheus server maintained by the community.
 | Prometheus 2.37     | 2022-07-14     | 2023-07-31     | End of life   |
 | Prometheus 2.45     | 2023-06-23     | 2024-07-31     | End of life   |
 | Prometheus 2.53     | 2024-06-16     | 2025-07-31     | End of life   |
-| **Prometheus 3.5**  | **2025-07-14** | **2026-07-31** | **Supported** |
+| Prometheus 3.5      | 2025-07-14     | 2026-07-31     | End of life   |
 | **Prometheus 3.13** | **2026-07-01** | **2027-07-31** | **Supported** |
 | TBD                 | 2027-06        | 2028-07-31     | Upcoming      |
 
@@ -36,7 +41,7 @@ having a Prometheus server maintained by the community.
 
 Some features are excluded from LTS support:
 
-- Things listed as unstable in our [API stability guarantees][stab].
+- Unstable features as listed in our [API stability guarantees][stab].
 - [Experimental features][fflag].
 - OpenBSD support.
 

--- a/docs/introduction/release-cycle.md
+++ b/docs/introduction/release-cycle.md
@@ -19,7 +19,7 @@ requiring another upgrade.
 Prometheus LTS version will only receive fixes for selected issues with high
 severity, i.e. a CVSS rating of 7.0 or higher. Additional changes for bug fixes
 or documentation fixes might be added. The build toolchain will also be kept
-up-to-date. This is a best effort commitment by the community, contributions are
+up-to-date. This is **a best effort commitment by the community**, contributions are
 welcome.
 Support periods of two subsequent LTS version should overlap by at least one
 month.


### PR DESCRIPTION
Mostly this adds some clarity which fixes qualify to get into an LTS version and what SLO (or lack thereof) users can expect. Mark Prometheus 3.5 as end of life.

As discussed on the latest [developer summit](https://docs.google.com/document/d/1uurQCi5iVufhYHGlBZ8mJMK_freDFKPG0iYBQqJ9fvA/edit?tab=t.0#heading=h.n9o76ns88jo4) meeting.

<!--
    Please sign CNCF's Developer Certificate of Origin and sign-off your commits by adding the -s / --sign-off flag to `git commit`

    More information on both of those can be found at https://github.com/apps/dco

    If you are proposing a new integration, exporter, or client library, please include representative sample output.
 -->
