### PR TITLE
Mark Prometheus 3.5 as end of life

### DIFF
--- a/docs-config.ts
+++ b/docs-config.ts
@@ -57,7 +57,7 @@ export default {
 
   // Long-term support versions configuration.
   ltsVersions: {
-    prometheus: ["3.5", "3.13"],
+    prometheus: ["3.13"],
   },
 
   // Repositories for the downloads page. The order in this file is the

--- a/docs/introduction/release-cycle.md
+++ b/docs/introduction/release-cycle.md
@@ -28,7 +28,7 @@ having a Prometheus server maintained by the community.
 | Prometheus 2.37     | 2022-07-14     | 2023-07-31     | End of life   |
 | Prometheus 2.45     | 2023-06-23     | 2024-07-31     | End of life   |
 | Prometheus 2.53     | 2024-06-16     | 2025-07-31     | End of life   |
-| **Prometheus 3.5**  | **2025-07-14** | **2026-07-31** | **Supported** |
+| Prometheus 3.5      | 2025-07-14     | 2026-07-31     | End of life   |
 | **Prometheus 3.13** | **2026-07-01** | **2027-07-31** | **Supported** |
 | TBD                 | 2027-06        | 2028-07-31     | Upcoming      |
 


### PR DESCRIPTION
Support for 3.5 ended on 2026-07-31, 3.13 is the only supported LTS.

<!--
    Please sign CNCF's Developer Certificate of Origin and sign-off your commits by adding the -s / --sign-off flag to `git commit`

    More information on both of those can be found at https://github.com/apps/dco

    If you are proposing a new integration, exporter, or client library, please include representative sample output.
 -->
