### PR TITLE
fix: correct grafana dashboard URL in documentation

### DIFF
--- a/docs/visualization/grafana.md
+++ b/docs/visualization/grafana.md
@@ -65,7 +65,7 @@ for use in the `rate`and `increase` functions.
 
 ### Importing pre-built dashboards from Grafana.com
 
-Grafana.com maintains [a collection of shared dashboards](https://grafana.com/dashboards)
+Grafana.com maintains [a collection of shared dashboards](https://grafana.com/grafana/dashboards/)
 which can be downloaded and used with standalone instances of Grafana. Use
 the Grafana.com "Filter" option to browse dashboards for the "Prometheus"
 data source only.


### PR DESCRIPTION
<!--
    Please sign CNCF's Developer Certificate of Origin and sign-off your commits by adding the -s / --sign-off flag to `git commit`

    More information on both of those can be found at https://github.com/apps/dco

    If you are proposing a new integration, exporter, or client library, please include representative sample output.
 -->
